### PR TITLE
tox: use nose2, speed up run, and add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dev/entitlement-creds.json.*
 __pycache__
 .tox
 .pybuild
+.coverage
+*.egg-info/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# Pypi requirements for uaclient
 pymacaroons
 pyyaml
 six

--- a/setup.py
+++ b/setup.py
@@ -1,55 +1,56 @@
+# Copyright (C) 2019 Canonical Ltd.
+# This file is part of ubuntu-advantage-client.  See LICENSE file for license.
+
 import glob
 import setuptools
-import subprocess
-import os
 
 from uaclient import config
 from uaclient.util import subp
 
 NAME = 'ubuntu-advantage-tools'
 
+raw_requirements, _err = subp(['./dev/read-dependencies'])
+INSTALL_REQUIRES = raw_requirements.rstrip('\n').split('\n')
 
-def get_version():
+raw_test_requirements, _err = subp([
+    './dev/read-dependencies', '-r', 'test-requirements.txt']
+)
+TEST_REQUIRES = raw_test_requirements.rstrip('\n').split('\n')
+
+
+def _get_version():
     parts = config.get_version().split('-')
     if len(parts) == 1:
-       return parts[0]
+        return parts[0]
     major_minor, _subrev, _commitish = parts
     return major_minor
 
 
-_dir = os.path.dirname(os.path.realpath(__name__))
-
-
-requirements, _err = subp(['./dev/read-dependencies'])
-INSTALL_REQUIRES =requirements.rstrip('\n').split('\n')
-
-TEST_REQUIRES = [
-    'coverage',
-    'flake8',
-    'nose',
-    'pylint',
-    'testtools',
-]
-
 setuptools.setup(
     name=NAME,
-    version=get_version(),
-    packages=setuptools.find_packages(exclude=['*.testing', 'tests.*', '*.tests', 'tests']),
-    data_files=[('/etc/ubuntu-advantage', ['uaclient.conf']),
-                ('/etc/apt/apt.conf.d', glob.glob('apt.conf.d/*')),
-                ('/etc/update-motd.d', glob.glob('update-motd.d/*')),
-                ('/usr/lib/ubuntu-advantage', glob.glob('lib/*')),
-                ('/usr/share/keyrings', glob.glob('keyrings/*')),
-                (config.CONFIG_DEFAULTS['data_dir'], [])],
+    version=_get_version(),
+    packages=setuptools.find_packages(
+        exclude=['*.testing', 'tests.*', '*.tests', 'tests']
+    ),
+    data_files=[
+        ('/etc/ubuntu-advantage', ['uaclient.conf']),
+        ('/etc/apt/apt.conf.d', glob.glob('apt.conf.d/*')),
+        ('/etc/update-motd.d', glob.glob('update-motd.d/*')),
+        ('/usr/lib/ubuntu-advantage', glob.glob('lib/*')),
+        ('/usr/share/keyrings', glob.glob('keyrings/*')),
+        (config.CONFIG_DEFAULTS['data_dir'], [])
+    ],
     install_requires=INSTALL_REQUIRES,
     extras_require=dict(test=TEST_REQUIRES),
     author='Ubuntu Server Team',
     author_email='ubuntu-server@lists.ubuntu.com',
-    description=('Manage Ubuntu Advantage support entitlements: esm, fips'
-                 ' and livepatch'),
+    description=('Manage Ubuntu Advantage support entitlements'),
     license='GPLv3',
-    url='https://ubuntu.com/advantage',
-    entry_points={'console_scripts': ['ubuntu-advantage=uaclient.cli:main',
-                                      'ua=uaclient.cli:main']}
+    url='https://ubuntu.com/support',
+    entry_points={
+        'console_scripts': [
+            'ubuntu-advantage=uaclient.cli:main',
+            'ua=uaclient.cli:main'
+        ]
+    }
 )
-

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-# Pip requirements for uaclint unittests
 coverage
-mock
-nose
-unittest2
 flake8
+mock
+nose2
+pycodestyle
+unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,17 @@
 [tox]
-envlist = py2, py3, lint, pycodestyle
+envlist = py3, flake8, pycodestyle
 skipsdist = True
 
 [testenv]
-commands = {envpython} -m unittest discover uaclient
+envdir = {toxinidir}/.tox
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
+commands = nose2 --with-coverage --coverage uaclient/ uaclient
+
+[testenv:flake8]
+commands = flake8 uaclient setup.py
 
 [testenv:pycodestyle]
-basepython = python3
-deps =
-    pycodestyle==2.4.0
-commands = {envpython} -m pycodestyle {posargs:uaclient/}
+commands = pycodestyle {posargs:uaclient setup.py}
 
-
-[testenv:lint]
-commands = {envpython} -m flake8 uaclient
-deps = flake8


### PR DESCRIPTION
This utilizes nose2 so we can also turn on coverage for the python
files. By setting the envdir the tests also run considerably faster.
The file was cleaned up to make it easier to read.

The setup.py was added to tox and corrections made to clean up lint errors.

The *requirements.txt files were alphabetized and cleaned up.