### PR TITLE
travis: enable additional python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,12 @@
 language: python
 python:
-  - 3.4
-  - 3.6
-dist: precise
-
-services:
-  - docker
-
+  - 3.4 # trusty
+  - 3.5 # xenial
+  - 3.6 # bionic
+  - 3.7 # disco+
 matrix:
   fast_finish: true
-
-stages:
-  - lint
-  - test
-
-jobs:
-  include:
-    - stage: lint
-      script: make lint/docker
-      python: 3.6
-      dist: trusty
-
-install: make testdep
-script: make test
+install:
+  - make testdep
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - 3.4 # trusty
   - 3.5 # xenial
   - 3.6 # bionic
-  - 3.7 # disco+
+  - 3.7-dev
+dist: trusty
 matrix:
   fast_finish: true
 install:


### PR DESCRIPTION
This adds coverage of all the required Python versions found in
Ubuntu Trusty, Xenial, Bionic, and the current development release.

This also only runs tox now as it does both unittests and linting.