### PR TITLE
d/control: fix build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,9 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), dh-python,
-               flake8 | python3-flake8, python3-mock,
-               python3 (>= 3.4), python3-nose, python3-unittest2
+Build-Depends: debhelper (>=9), dh-python, python3 (>= 3.4),
+               flake8 | python3-flake8, python3-mock, python3-nose,
+               python3-setuptools, python3-unittest2, python3-yaml
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git


### PR DESCRIPTION
This adds the missing python3-setuptools and python3-yaml depedencies
needed for building on Xenial and newer.

I also re-ordered the depends to be more alphabetical.

Closes #170 