### PR TITLE
Enable Trusty build, remove python-six, fix flake8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,9 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), dh-python,
-               flake8 | python3-flake8, python3-mock,
-               python3 (>= 3.4), python3-nose, python3-unittest2
+Build-Depends: debhelper (>=9), dh-python, python3 (>= 3.4),
+               python3-flake8, python3-mock, python3-nose,
+               python3-setuptools, python3-yaml
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,19 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
 DEB_VERSION := $(shell dpkg-parsechangelog --show-field=Version)
+FLAKE8 := $(shell flake8 --version 2> /dev/null)
+
 %:
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_test:
 	python3 -m unittest discover uaclient
+ifdef FLAKE8
+	# required for Trusty
+	flake8 --ignore=E901 uaclient
+else
 	python3 -m flake8 uaclient
+endif
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools

--- a/dev/bddeb
+++ b/dev/bddeb
@@ -61,31 +61,23 @@ def run_helper(helper, args=None, strip=True):
     return stdout
 
 
-def write_debian_folder(root, templ_data, is_python2=False):
+def write_debian_folder(root, templ_data):
     """Create a debian package directory with all rendered template files."""
     print("Creating a debian/ folder in %r" % (root))
-    if is_python2:
-        pyver = "2"
-        python = "python"
-    else:
-        pyver = "3"
-        python = "python3"
-
-
 
     # Write out the control file template
     reqs_output = run_helper(
-        'read-dependencies', args=['--python-version', pyver, '--system-pkg-names'])
+        'read-dependencies', args=['--python-version', '3', '--system-pkg-names'])
     reqs = reqs_output.splitlines()
     test_reqs = run_helper(
         'read-dependencies',
         ['--requirements-file', 'test-requirements.txt',
-         '--system-pkg-names', '--python-version', pyver]).splitlines()
+         '--system-pkg-names', '--python-version', '3']).splitlines()
 
     requires = []
     # We consolidate all deps as Build-Depends as our package build runs all
     # tests so we need all runtime dependencies anyway.
-    requires.extend([python] + reqs + test_reqs)
+    requires.extend(['python3'] + reqs + test_reqs)
     templ_data['%BUILD_DEPS%'] = ','.join(requires)
 
     # Iterate over any .in template files and rendir into deb_dir
@@ -112,10 +104,6 @@ def get_parser():
                               " (default: %(default)s)"),
                         default=False,
                         action='store_true')
-
-    parser.add_argument("--python2", dest="python2",
-                        help=("build debs for python2 rather than python3"),
-                        default=False, action='store_true')
 
     parser.add_argument("--init-system", dest="init_system",
                         help=("build deb with INIT_SYSTEM=xxx"

--- a/dev/bddeb
+++ b/dev/bddeb
@@ -61,7 +61,7 @@ def run_helper(helper, args=None, strip=True):
     return stdout
 
 
-def write_debian_folder(root, templ_data, is_python2):
+def write_debian_folder(root, templ_data, is_python2=False):
     """Create a debian package directory with all rendered template files."""
     print("Creating a debian/ folder in %r" % (root))
     if is_python2:
@@ -189,8 +189,7 @@ def main():
 
     xdir = os.path.join(tdir, "ubuntu-advantage-tools-%s" % ver)
 
-    is_python2 = bool(args.series == 'trusty')
-    write_debian_folder(xdir, templ_data, is_python2=is_python2)
+    write_debian_folder(xdir, templ_data)
 
     print("Running 'debuild %s' in %r" % (' '.join(args.debuild_args),
                                           xdir))

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -2,7 +2,6 @@ import copy
 import json
 import logging
 import os
-import six
 from subprocess import check_output
 import yaml
 
@@ -37,23 +36,24 @@ class ConfigAbsentError(RuntimeError):
 
 class UAConfig(object):
 
-    data_paths = {'bound-macaroon': 'bound-macaroon',
-                  'accounts': 'accounts.json',
-                  'account-contracts': 'account-contracts.json',
-                  'account-users': 'account-users.json',
-                  'contract-token': 'contract-token.json',
-                  'machine-contracts': 'machine-contracts.json',
-                  'machine-access-cis-audit': 'machine-access-cis-audit.json',
-                  'machine-access-esm': 'machine-access-esm.json',
-                  'machine-access-fips': 'machine-access-fips.json',
-                  'machine-access-fips-updates':
-                      'machine-access-fips-updates.json',
-                  'machine-access-livepatch': 'machine-access-livepatch.json',
-                  'machine-detach': 'machine-detach.json',
-                  'machine-token': 'machine-token.json',
-                  'macaroon': 'sso-macaroon.json',
-                  'root-macaroon': 'root-macaroon.json',
-                  'oauth': 'sso-oauth.json'}
+    data_paths = {
+        'bound-macaroon': 'bound-macaroon',
+        'accounts': 'accounts.json',
+        'account-contracts': 'account-contracts.json',
+        'account-users': 'account-users.json',
+        'contract-token': 'contract-token.json',
+        'machine-contracts': 'machine-contracts.json',
+        'machine-access-cis-audit': 'machine-access-cis-audit.json',
+        'machine-access-esm': 'machine-access-esm.json',
+        'machine-access-fips': 'machine-access-fips.json',
+        'machine-access-fips-updates': 'machine-access-fips-updates.json',
+        'machine-access-livepatch': 'machine-access-livepatch.json',
+        'machine-detach': 'machine-detach.json',
+        'machine-token': 'machine-token.json',
+        'macaroon': 'sso-macaroon.json',
+        'root-macaroon': 'root-macaroon.json',
+        'oauth': 'sso-oauth.json'
+    }
 
     _contracts = None  # caching to avoid repetitive file reads
     _entitlements = None  # caching to avoid repetitive file reads
@@ -168,7 +168,7 @@ class UAConfig(object):
         if not os.path.exists(self.data_dir):
             os.makedirs(self.data_dir)
         filepath = self.data_path(key)
-        if not isinstance(content, six.string_types):
+        if not isinstance(content, str):
             content = json.dumps(content)
         util.write_file(filepath, content)
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -1,7 +1,6 @@
 import abc
 from datetime import datetime
 import os
-import six
 
 from uaclient import config
 from uaclient import contract
@@ -9,8 +8,7 @@ from uaclient import status
 from uaclient import util
 
 
-@six.add_metaclass(abc.ABCMeta)
-class UAEntitlement(object):
+class UAEntitlement(object, metaclass=abc.ABCMeta):
 
     # The lowercase name of this entitlement
     name = None
@@ -63,7 +61,8 @@ class UAEntitlement(object):
             op_status, _status_details = self.operational_status()
             if op_status == status.INACTIVE:
                 message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
-                          title=self.title)
+                    title=self.title
+                )
                 retval = False
         if message and not silent:
             print(message)
@@ -113,7 +112,8 @@ class UAEntitlement(object):
             affordance_series = affordances.get('series')
             if affordance_series and series not in affordance_series:
                 return False, status.MESSAGE_INAPPLICABLE_SERIES_TMPL.format(
-                                  title=self.title, series=series)
+                    title=self.title, series=series
+                )
         for error_message, functor, expected_result in self.static_affordances:
             if functor() != expected_result:
                 return False, error_message

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -60,7 +60,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'install', 'ca-certificates'],
                       capture=True)
         print('Installing {title} packages (this may take a while)'.format(
-                  title=self.title))
+            title=self.title)
+        )
         try:
             util.subp(['apt-get', 'update'], capture=True)
             util.subp(['apt-get', 'install'] + self.packages)
@@ -100,7 +101,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 pass
         if not silent:
             print('Warning: no option to disable {title}'.format(
-                      title=self.title))
+                title=self.title)
+            )
         return False
 
 

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import six
 
 from uaclient.entitlements import base
 from uaclient import status
@@ -17,14 +16,16 @@ PATCH_STATE_UNKNOWN_TMPL = '''\
     - Please see /var/log/syslog for more information.'''
 
 PATCH_STATE_MSG_MAP = {
-  'unapplied': 'Patches are available and will be deployed shortly.',
-  'applied': 'All available patches applied.',
-  'applied-with-bug': ('Live patching failed, please run `ubuntu-bug linux` to'
-                       ' report a bug'),
-  'apply-failed': ('Live patching failed, please run `ubuntu-bug linux` to'
-                   ' report a bug'),
-  'nothing-to-apply': 'All available patches applied.',
-  'applying': 'Live patching currently in progress.'
+    'unapplied': 'Patches are available and will be deployed shortly.',
+    'applied': 'All available patches applied.',
+    'applied-with-bug': (
+        'Live patching failed, please run `ubuntu-bug linux` to report a bug'
+    ),
+    'apply-failed': (
+        'Live patching failed, please run `ubuntu-bug linux` to report a bug'
+    ),
+    'nothing-to-apply': 'All available patches applied.',
+    'applying': 'Live patching currently in progress.'
 }
 
 CHECK_STATE_UNKNOWN_TMPL = '''\
@@ -33,8 +34,10 @@ CHECK_STATE_UNKNOWN_TMPL = '''\
 
 CHECK_STATE_MSG_MAP = {
     'needs-check': 'Regular server check is pending.',
-    'check-failed': ('Livepatch server check failed.\n'
-                     '    Please see /var/log/syslog for more information.'),
+    'check-failed': (
+        'Livepatch server check failed.\n'
+        '    Please see /var/log/syslog for more information.'
+    ),
     'checked': PATCH_STATE_MSG_MAP
 }
 
@@ -163,7 +166,7 @@ def livepatch_status_to_motd(status_output):
             return motd_lines.append(CHECK_STATE_UNKNOWN_TMPL.format(
                 check_state=check_state))
         message_map = CHECK_STATE_MSG_MAP[check_state]
-        if isinstance(message_map, six.string_types):
+        if isinstance(message_map, str):
             motd_lines.append(message_map)
         else:
             prefix = '   - '

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1,7 +1,7 @@
 """Tests related to uaclient.entitlement.base module."""
 
 import mock
-from six import StringIO
+from io import StringIO
 
 from uaclient import config
 from uaclient.entitlements import base

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -1,5 +1,5 @@
 import json
-import six
+import urllib
 
 from uaclient import config
 from uaclient import util
@@ -38,7 +38,7 @@ class UAServiceClient(object):
         try:
             response, headers = util.readurl(
                 url=url, data=data, headers=headers, method=method)
-        except six.moves.urllib.error.URLError as e:
+        except urllib.error.URLError as e:
             code = e.errno
             if hasattr(e, 'read'):
                 error_details = util.maybe_parse_json(e.read())

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -1,5 +1,5 @@
 import json
-import urllib
+from urllib import error
 
 from uaclient import config
 from uaclient import util
@@ -38,7 +38,7 @@ class UAServiceClient(object):
         try:
             response, headers = util.readurl(
                 url=url, data=data, headers=headers, method=method)
-        except urllib.error.URLError as e:
+        except error.URLError as e:
             code = e.errno
             if hasattr(e, 'read'):
                 error_details = util.maybe_parse_json(e.read())

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -3,7 +3,7 @@ import getpass
 import json
 import logging
 import pymacaroons
-import urllib
+from urllib import parse
 
 from uaclient import serviceclient
 from uaclient import util
@@ -87,7 +87,7 @@ class UbuntuSSOClient(serviceclient.UAServiceClient):
 
     def request_user_keys(self, email):
         content, _headers = self.request_url(
-            API_PATH_USER_KEYS + urllib.parse.quote(email))
+            API_PATH_USER_KEYS + parse.quote(email))
         return content
 
     def request_oauth_token(self, email, password, token_name, otp=None):

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -3,7 +3,7 @@ import getpass
 import json
 import logging
 import pymacaroons
-import six
+import urllib
 
 from uaclient import serviceclient
 from uaclient import util
@@ -87,7 +87,7 @@ class UbuntuSSOClient(serviceclient.UAServiceClient):
 
     def request_user_keys(self, email):
         content, _headers = self.request_url(
-            API_PATH_USER_KEYS + six.moves.urllib.parse.quote(email))
+            API_PATH_USER_KEYS + urllib.parse.quote(email))
         return content
 
     def request_oauth_token(self, email, password, token_name, otp=None):
@@ -206,7 +206,7 @@ def prompt_request_macaroon(cfg, caveat_id):
     if discharge_macaroon:
         # TODO(invalidate cached macaroon on root-macaroon or discharge expiry)
         return discharge_macaroon
-    email = six.moves.input('Email: ')
+    email = input('Email: ')
     password = getpass.getpass('Password: ')
     args = {'email': email, 'password': password, 'caveat_id': caveat_id}
     sso_client = UbuntuSSOClient(cfg)
@@ -218,7 +218,7 @@ def prompt_request_macaroon(cfg, caveat_id):
             if API_ERROR_2FA_REQUIRED not in e:
                 logging.error(str(e))
                 break
-            args['otp'] = six.moves.input('Second-factor auth: ')
+            args['otp'] = input('Second-factor auth: ')
         if content:
             return content
     return None
@@ -260,9 +260,9 @@ def prompt_oauth_token(cfg):
     if oauth_token:
         return oauth_token
     try:
-        email = six.moves.input('Email: ')
+        email = input('Email: ')
         password = getpass.getpass('Password: ')
-        token_name = six.moves.input('Unique OAuth token name: ')
+        token_name = input('Unique OAuth token name: ')
     except KeyboardInterrupt:
         return None
     try:
@@ -273,7 +273,7 @@ def prompt_oauth_token(cfg):
             logging.error(str(e))
             return None
         try:
-            otp = six.moves.input('Second-factor auth: ')
+            otp = input('Second-factor auth: ')
         except KeyboardInterrupt:
             return None
         oauth_token = client.request_oauth_token(

--- a/uaclient/testing/helpers.py
+++ b/uaclient/testing/helpers.py
@@ -1,13 +1,13 @@
 import functools
+import io
 import logging
 import os
 import shutil
-import six
 import tempfile
-import unittest2
+import unittest
 
 
-class TestCase(unittest2.TestCase):
+class TestCase(unittest.TestCase):
 
     with_logs = False
 
@@ -16,7 +16,7 @@ class TestCase(unittest2.TestCase):
         if self.with_logs:
             # Create a log handler so unit tests can search expected logs.
             self.logger = logging.getLogger()
-            self._logs = six.StringIO()
+            self._logs = io.StringIO()
             formatter = logging.Formatter('%(levelname)s: %(message)s')
             handler = logging.StreamHandler(self._logs)
             handler.setFormatter(formatter)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -7,6 +7,10 @@ import os
 from uaclient.testing.helpers import TestCase
 from uaclient import util
 
+PRIVACY_POLICY_URL = (
+    "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+)
+
 OS_RELEASE_DISCO = """\
 NAME="Ubuntu"
 VERSION="19.04 (Disco Dingo)"
@@ -17,10 +21,10 @@ VERSION_ID="19.04"
 HOME_URL="https://www.ubuntu.com/"
 SUPPORT_URL="https://help.ubuntu.com/"
 BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+PRIVACY_POLICY_URL="%s"
 VERSION_CODENAME=disco
 UBUNTU_CODENAME=disco
-"""
+""" % (PRIVACY_POLICY_URL)
 
 OS_RELEASE_BIONIC = """\
 NAME="Ubuntu"
@@ -32,10 +36,10 @@ VERSION_ID="18.04"
 HOME_URL="https://www.ubuntu.com/"
 SUPPORT_URL="https://help.ubuntu.com/"
 BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+PRIVACY_POLICY_URL="%s"
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
-"""
+""" % (PRIVACY_POLICY_URL)
 
 OS_RELEASE_XENIAL = """\
 NAME="Ubuntu"

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import subprocess
-import urllib
+from urllib import request
 import uuid
 
 
@@ -114,7 +114,7 @@ def maybe_parse_json(content):
 def readurl(url, data=None, headers=None, method=None):
     if data and not method:
         method = 'POST'
-    req = urllib.request.Request(url, data=data, headers=headers)
+    req = request.Request(url, data=data, headers=headers)
     if method:
         req.get_method = lambda: method
     if data:
@@ -128,7 +128,7 @@ def readurl(url, data=None, headers=None, method=None):
     logging.debug(
         'URL [%s]: %s, headers: %s, data: %s',
         method or 'GET', url, headers, redacted_data)
-    resp = urllib.request.urlopen(req)
+    resp = request.urlopen(req)
     content = decode_binary(resp.read())
     if 'application/json' in resp.headers.get('Content-type', ''):
         content = json.loads(content)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os
 import re
-import six
 import subprocess
+import urllib
 import uuid
 
 
@@ -52,7 +52,7 @@ class ProcessExecutionError(IOError):
 
 def decode_binary(blob, encoding='utf-8'):
     """Convert a binary type into a text type using given encoding."""
-    if isinstance(blob, six.string_types):
+    if isinstance(blob, str):
         return blob
     return blob.decode(encoding)
 
@@ -67,7 +67,7 @@ def del_file(path):
 
 def encode_text(text, encoding='utf-8'):
     """Convert a text string into a binary type using given encoding."""
-    if isinstance(text, six.binary_type):
+    if isinstance(text, bytes):
         return text
     return text.encode(encoding)
 
@@ -114,7 +114,7 @@ def maybe_parse_json(content):
 def readurl(url, data=None, headers=None, method=None):
     if data and not method:
         method = 'POST'
-    req = six.moves.urllib.request.Request(url, data=data, headers=headers)
+    req = urllib.request.Request(url, data=data, headers=headers)
     if method:
         req.get_method = lambda: method
     if data:
@@ -128,7 +128,7 @@ def readurl(url, data=None, headers=None, method=None):
     logging.debug(
         'URL [%s]: %s, headers: %s, data: %s',
         method or 'GET', url, headers, redacted_data)
-    resp = six.moves.urllib.request.urlopen(req)
+    resp = urllib.request.urlopen(req)
     content = decode_binary(resp.read())
     if 'application/json' in resp.headers.get('Content-type', ''):
         content = json.loads(content)
@@ -149,7 +149,7 @@ def subp(args, rcs=None, capture=False):
     @return: Tuple of utf-8 decoded stdout, stderr
     @raises ProcessExecutionError on invalid command or returncode not in rcs.
     """
-    bytes_args = [x if isinstance(x, six.binary_type) else x.encode("utf-8")
+    bytes_args = [x if isinstance(x, bytes) else x.encode("utf-8")
                   for x in args]
     if rcs is None:
         rcs = [0]


### PR DESCRIPTION
Trusty is now buildable in an sbuild.

This removes dependencies on python-six, which was getting used
throughout. This is meant to be a Python 3 only application so there is
no need for python-six. Here is how various usage was updated:

python-six     --> python-3
string_types   --> str
binary_types   --> bytes
StringIO       --> io.StringIO
six.moves      --> import urllib or input()
@add_metaclass --> function signature

Due to differences in the way that flake8 can be installed across Trusty
to Bionic, this simplifies the dependency list and deals with the
different mechanisms for calling it. The trusty found flake8 errors are
fixed and one error is ignored.

Closes #169 #170 #172