### PR TITLE
config: use yaml.safe_load

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -197,7 +197,7 @@ def parse_config(config_path=None):
         config_path = os.environ.get('UA_CONFIG_FILE')
     LOG.debug('Using UA client configuration file at %s', config_path)
     if os.path.exists(config_path):
-        cfg.update(yaml.load(util.load_file(config_path)))
+        cfg.update(yaml.safe_load(util.load_file(config_path)))
     env_keys = {}
     for key, value in os.environ.items():
         if key.startswith('UA_'):


### PR DESCRIPTION
This suppresses a warning from PyYAML (which fixes #181).  We only need
to construct simple Python objects (i.e. strings, in our case), so we
don't need to use the unsafe yaml.load function.