### PR TITLE
One Build-Depends per line, and add git to Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,9 +2,14 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), dh-python, python3 (>= 3.4),
-               python3-flake8, python3-mock, python3-nose,
-               python3-setuptools, python3-yaml
+Build-Depends: debhelper (>=9),
+               dh-python,
+               python3 (>= 3.4),
+               python3-flake8,
+               python3-mock,
+               python3-nose,
+               python3-setuptools,
+               python3-yaml
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper (>=9),
                dh-python,
+               git,
                python3 (>= 3.4),
                python3-flake8,
                python3-mock,


### PR DESCRIPTION
Recipe builds are currently failing because they don't have git installed, which our version determination requires; I don't know for sure that Build-Depends is honoured in recipe builds, but this seems like a good place to start.