### PR TITLE
config: reset cached class attributes during config.delete_cache

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_test:
-	python3 -m unittest discover uaclient
+	python3 -m nose2
 ifdef FLAKE8
 	# required for Trusty
 	flake8 --ignore=E901 uaclient

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -50,7 +50,10 @@ class UAConfig(object):
     @property
     def accounts(self):
         """Return the list of accounts that apply to this authorized user."""
-        return self.read_cache('accounts')['accounts']
+        accounts = self.read_cache('accounts')
+        if not accounts:
+            return []
+        return accounts['accounts']
 
     @property
     def contract_url(self):
@@ -116,7 +119,7 @@ class UAConfig(object):
             self._machine_token = self.read_cache('machine-token')
         return self._machine_token
 
-    def data_path(self, key):
+    def data_path(self, key=None):
         """Return the file path in the data directory represented by the key"""
         if not key:
             return self.cfg['data_dir']

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -53,6 +53,20 @@ class UAConfig(object):
         accounts = self.read_cache('accounts')
         if not accounts:
             return []
+        warning_msg = None
+        if not isinstance(accounts, dict):
+            warning_msg = ('Unexpected type %s in cache %s' %
+                           (type(accounts), self.data_path('accounts')))
+        elif 'accounts' not in accounts:
+            warning_msg = ("Missing 'accounts' key in cache %s" %
+                           self.data_path('accounts'))
+        elif not isinstance(accounts['accounts'], list):
+            warning_msg = (
+                "Unexpected 'accounts' type %s in cache %s" %
+                (type(accounts['accounts']), self.data_path('accounts')))
+        if warning_msg:
+            LOG.warning(warning_msg)
+            return []
         return accounts['accounts']
 
     @property

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -91,11 +91,18 @@ class UAConfig(object):
 
     @property
     def entitlements(self):
-        """Return the machine-token if cached in the machine token response."""
+        """Return a dictionary of entitlements keyed by entitlement name.
+
+        Return an empty dict if no entitlements are present.
+        """
         if self._entitlements:
             return self._entitlements
+        machine_token = self.machine_token
+        if not machine_token:
+            return {}
+
         self._entitlements = {}
-        contractInfo = self.machine_token['machineTokenInfo']['contractInfo']
+        contractInfo = machine_token['machineTokenInfo']['contractInfo']
         ent_by_name = dict(
             (e['type'], e) for e in contractInfo['resourceEntitlements'])
         for entitlement_name, ent_value in ent_by_name.items():

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -124,13 +124,12 @@ class UAConfig(object):
             return os.path.join(self.cfg['data_dir'], self.data_paths[key])
         return os.path.join(self.cfg['data_dir'], key)
 
-    def delete_cache(self, key=None):
-        if key is None:
-            for key in self.data_paths.keys():
-                cache_path = self.data_path(key)
-                if os.path.exists(cache_path):
-                    os.unlink(cache_path)
-        else:
+    def delete_cache(self):
+        """Remove all configuration cached response files class attributes."""
+        self._contracts = None
+        self._entitlements = None
+        self._machine_token = None
+        for key in self.data_paths.keys():
             cache_path = self.data_path(key)
             if os.path.exists(cache_path):
                 os.unlink(cache_path)

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -18,6 +18,8 @@ KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
 
 class TestAccounts(TestCase):
 
+    with_logs = True
+
     def test_accounts_returns_empty_list_when_no_cached_account_value(self):
         """Config.accounts property returns an empty list when no cache."""
         tmp_dir = self.tmp_dir()
@@ -32,6 +34,42 @@ class TestAccounts(TestCase):
         cfg.write_cache('accounts', {'accounts': ['acct1', 'acct2']})
 
         assert ['acct1', 'acct2'] == cfg.accounts
+
+    def test_accounts_logs_warning_when_non_dictionary_cache_content(self):
+        """Config.accounts warns and returns empty list on non-dict cache."""
+        tmp_dir = self.tmp_dir()
+        cfg = UAConfig({'data_dir': tmp_dir})
+        cfg.write_cache('accounts', 'non-dict-value')
+
+        assert [] == cfg.accounts
+        expected_warning = (
+            "WARNING: Unexpected type <class 'str'> in cache %s" % (
+                self.tmp_path('accounts.json', tmp_dir)))
+        assert expected_warning in self.logs
+
+    def test_accounts_logs_warning_when_missing_accounts_key_in_cache(self):
+        """Config.accounts warns when missing 'accounts' key in cache"""
+        tmp_dir = self.tmp_dir()
+        cfg = UAConfig({'data_dir': tmp_dir})
+        cfg.write_cache('accounts', {'non-accounts': 'somethingelse'})
+
+        assert [] == cfg.accounts
+        expected_warning = (
+            "WARNING: Missing 'accounts' key in cache %s" %
+            self.tmp_path('accounts.json', tmp_dir))
+        assert expected_warning in self.logs
+
+    def test_accounts_logs_warning_when_non_list_accounts_cache_content(self):
+        """Config.accounts warns on non-list accounts key."""
+        tmp_dir = self.tmp_dir()
+        cfg = UAConfig({'data_dir': tmp_dir})
+        cfg.write_cache('accounts', {'accounts': 'non-list-value'})
+
+        assert [] == cfg.accounts
+        expected_warning = (
+            "WARNING: Unexpected 'accounts' type <class 'str'> in cache %s" % (
+                self.tmp_path('accounts.json', tmp_dir)))
+        assert expected_warning in self.logs
 
 
 class TestDataPath(TestCase):

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1,0 +1,72 @@
+import json
+import os
+
+from nose2.tools.params import params
+
+from uaclient.config import UAConfig
+from uaclient.testing.helpers import TestCase
+
+
+# These are in a variable rather than inline to work around
+# https://github.com/nose-devs/nose2/issues/433
+SIMPLE_PARAMS = (('machine_token', 'machine-token', None),
+                 ('contracts', 'account-contracts', []))
+
+KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
+                    ('accounts', 'accounts.json'))
+
+
+class TestDataPath(TestCase):
+
+    def test_data_path_returns_data_dir_path_without_key(self):
+        """The data_path method returns the data_dir when key is absent."""
+        cfg = UAConfig({'data_dir': '/my/dir'})
+        assert '/my/dir' == cfg.data_path()
+
+    @params(*KNOWN_DATA_PATHS)
+    def test_data_path_returns_file_path_with_defined_data_paths(
+            self, key, path_basename):
+        """When key is defined in Config.data_paths return data_path value."""
+        cfg = UAConfig({'data_dir': '/my/dir'})
+        assert '/my/dir/%s' % path_basename == cfg.data_path(key=key)
+
+    @params(('notHere', 'notHere'), ('anything', 'anything'))
+    def test_data_path_returns_file_path_with_undefined_data_paths(
+            self, key, path_basename):
+        """When key is not in Config.data_paths the key is used to data_dir"""
+        cfg = UAConfig({'data_dir': '/my/dir'})
+        assert '/my/dir/%s' % key == cfg.data_path(key=key)
+
+
+class TestReadCache(TestCase):
+
+    @params(*KNOWN_DATA_PATHS)
+    def test_read_cache_returns_none_when_data_path_absent(
+            self, key, path_basename):
+        """The data_path method returns the data_dir when key is absent."""
+        cfg = UAConfig({'data_dir': '/my/dir'})
+        assert None is cfg.read_cache(key)
+        assert False is os.path.exists(os.path.join('/my/dir', path_basename))
+
+    @params(*KNOWN_DATA_PATHS)
+    def test_read_cache_returns_content_when_data_path_present(
+            self, key, path_basename):
+        tmp_dir = self.tmp_dir()
+        cfg = UAConfig({'data_dir': tmp_dir})
+        data_path = self.tmp_path(path_basename, tmp_dir)
+        with open(data_path, 'w') as f:
+            f.write('content%s' % key)
+
+        assert 'content%s' % key == cfg.read_cache(key)
+
+    @params(*KNOWN_DATA_PATHS)
+    def test_read_cache_returns_stuctured_content_when_json_data_path_present(
+            self, key, path_basename):
+        tmp_dir = self.tmp_dir()
+        cfg = UAConfig({'data_dir': tmp_dir})
+        data_path = self.tmp_path(path_basename, tmp_dir)
+        expected = {key: 'content%s' % key}
+        with open(data_path, 'w') as f:
+            f.write(json.dumps(expected))
+
+        assert expected == cfg.read_cache(key)


### PR DESCRIPTION
Avoid tracebacks when referencing deleted configuration which
was incorrectly persisted in memory even after a `ua detach`
operation.

Since our only current caller is Config.delete_cache, drop the key-specific
parameter/logic from Config.delete_cache.

Fixes #196