### PR TITLE
Set staging and production ua-contracts service URLS in config files

### DIFF
--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -1,6 +1,6 @@
 # Development UA Client config file. YAML
 sso_auth_url: 'https://login.ubuntu.com'
-contract_url: 'http://localhost:8080'
+contract_url: 'https://contracts.staging.canonical.com'
 data_dir: /tmp/uaclient
 log_level: error
 log_file: ubuntu-advantage-devel.log

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -1,6 +1,6 @@
 # Ubuntu-Advantage client config file.
 sso_auth_url: 'https://login.ubuntu.com'
-contract_url: 'https://contracts.ubuntu-advantage.com'
+contract_url: 'https://contracts.canonical.com'
 data_dir: /var/lib/ubuntu-advantage
 log_level: info
 log_file: /var/log/ubuntu-advantage.log

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -27,7 +27,7 @@ from uaclient import status as ua_status
 from uaclient import util
 from uaclient import version
 
-NAME = 'ubuntu-advantage-client'
+NAME = 'ubuntu-advantage'
 
 USAGE_TMPL = '{name} {command} [flags]'
 EPILOG_TMPL = (
@@ -39,6 +39,8 @@ Subscription: {subscription}
 Valid until: {contract_expiry}
 Technical support: {tech_support_level}
 """
+UA_DASHBOARD_URL = 'https://contracts.canonical.com'
+UA_STAGING_DASHBOARD_URL = 'https://contracts.staging.canonical.com'
 
 DEFAULT_LOG_FORMAT = (
     '%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s')
@@ -59,7 +61,8 @@ def attach_parser(parser=None):
     parser._optionals.title = 'Flags'
     parser.add_argument(
         'token', nargs='?',
-        help='Optional token obtained from Ubuntu Advantage dashboard')
+        help=('Optional token obtained from Ubuntu Advantage dashboard: %s' %
+              UA_DASHBOARD_URL))
     parser.add_argument(
         '--email', action='store',
         help='Optional email address for Ubuntu SSO login')


### PR DESCRIPTION
Add production and staging contracts urls to uaclient.conf and uaclient-devel.conf files.
Also reference production contracts URL from ua attach --help/usage.
Add minimal unit tests for attach argument parser.

Fixes #193