### PR TITLE
deb: add python3-nose2 as a package build-dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>=9),
                python3-flake8,
                python3-pymacaroons,
                python3-mock,
-               python3-nose,
+               python3-nose2,
                python3-setuptools,
                python3-yaml
 Standards-Version: 3.9.6

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_test:
-	python3 -m unittest discover uaclient
+	python3 -m nose2
 ifdef FLAKE8
 	# required for Trusty
 	flake8 --ignore=E901 uaclient

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@ flake8
 mock
 nose2
 pycodestyle
-unittest2


### PR DESCRIPTION
We are already using nose2 in our tox environments. This change set add an official package build-dependency on python3-nose2.

Also drop unittest2 from tox environment because I *think* we don't have any test dependencies or imports using that package. python3-unittest2 is also not available in trusty.


This branch should address missing dependency build failures on our daily build recipe page 
https://code.launchpad.net/~canonical-server/+recipe/ua-client-daily

"ModuleNotFoundError: No module named 'nose2'"
per https://launchpadlibrarian.net/416606184/buildlog_ubuntu-disco-amd64.ubuntu-advantage-tools_19.1-0ubuntu1~339~git.ee1a615~ubuntu19.04.1_BUILDING.txt.gz