### PR TITLE
apt: fips, cis and esm now use aptURL instead of serviceURL directive

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import platform
 import shutil
 
 from uaclient import util
@@ -57,7 +56,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
     @raises: InvalidAPTCredentialsError when the token provided can't access
         the repo PPA.
     """
-    series = platform.dist()[2]
+    series = util.get_platform_info('series')
     if not valid_apt_credentials(repo_url, series, credentials):
         raise InvalidAPTCredentialsError(
             'Invalid APT credentials provided for %s' % repo_url)
@@ -116,7 +115,7 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
 
 def add_ppa_pinning(apt_preference_file, repo_url, priority):
     """Add an apt preferences file and pin for a PPA."""
-    series = platform.dist()[2]
+    series = util.get_platform_info('series')
     _protocol, repo_path = repo_url.split('://')
     origin = repo_path.replace('private-ppa.launchpad.net/', 'LP-PPA-')
     origin = origin.replace('/', '-')

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -30,7 +30,7 @@ class CISEntitlement(repo.RepoEntitlement):
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -31,7 +31,7 @@ class ESMEntitlement(repo.RepoEntitlement):
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -38,7 +38,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 'No legacy entitlement token present. Using machine token'
                 ' as %s credentials', self.title)
             token = self.cfg.machine_token['machineSecret']
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         try:
@@ -85,7 +85,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
             access_directives = self.cfg.read_cache(
                 'machine-access-%s' % self.name).get('directives', {})
-            repo_url = access_directives.get('serviceURL', self.repo_url)
+            repo_url = access_directives.get('aptURL', self.repo_url)
             if not repo_url:
                 repo_url = self.repo_url
             apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import os
-import platform
 
 from uaclient import apt
 from uaclient.entitlements import base
@@ -27,7 +26,7 @@ class RepoEntitlement(base.UAEntitlement):
         """
         if not self.can_enable():
             return False
-        series = platform.dist()[2]
+        series = util.get_platform_info('series')
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         resource_cfg = self.cfg.entitlements.get(self.name)
@@ -81,7 +80,6 @@ class RepoEntitlement(base.UAEntitlement):
         passed_affordances, details = self.check_affordances()
         if not passed_affordances:
             return status.INAPPLICABLE, details
-        apt_policy, _err = util.subp(['apt-cache', 'policy'])
         entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
             return status.INACTIVE, '%s PPA is not configured' % self.title

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -1,0 +1,87 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+import mock
+from io import StringIO
+
+from uaclient import config
+from uaclient.entitlements.cis import CISEntitlement
+from uaclient.testing.helpers import TestCase
+
+
+CIS_MACHINE_TOKEN = {
+    'machineSecret': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'cis-audit'}]}}}
+
+
+CIS_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'cis-audit',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://CIS',
+            'aptKey': 'APTKEY'
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+
+class TestCISEntitlementCanEnable(TestCase):
+
+    @mock.patch('os.getuid', return_value=0)
+    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+        """When operational status is INACTIVE, can_enable returns True."""
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cis-audit', CIS_RESOURCE_ENTITLED)
+        entitlement = CISEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            self.assertTrue(entitlement.can_enable())
+        self.assertEqual('', m_stdout.getvalue())
+
+
+class TestCISEntitlementEnable(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_enable_configures_apt_sources_and_auth_files(
+            self, m_getuid, m_platform_info, m_subp):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cis-audit', CIS_RESOURCE_ENTITLED)
+        entitlement = CISEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+
+        with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+            with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
+                self.assertTrue(entitlement.enable())
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list',
+                      'http://CIS', 'TOKEN', None, 'APTKEY')]
+
+        subp_apt_cmds = [
+            mock.call(['apt-get', 'update'], capture=True),
+            mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'])]
+
+        assert add_apt_calls == m_add_apt.call_args_list
+        # No apt pinning for cis-audit
+        assert [] == m_add_pinning.call_args_list
+        assert subp_apt_cmds == m_subp.call_args_list

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1,0 +1,83 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+import mock
+from io import StringIO
+
+from uaclient import config
+from uaclient.entitlements.fips import FIPSEntitlement
+from uaclient.testing.helpers import TestCase
+
+
+FIPS_MACHINE_TOKEN = {
+    'machineSecret': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'fips'}]}}}
+
+
+FIPS_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'fips',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://FIPS',
+            'aptKey': 'APTKEY'
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+
+class TestFIPSEntitlementCanEnable(TestCase):
+
+    @mock.patch('os.getuid', return_value=0)
+    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+        """When operational status is INACTIVE, can_enable returns True."""
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            self.assertTrue(entitlement.can_enable())
+        self.assertEqual('', m_stdout.getvalue())
+
+
+class TestFIPSEntitlementEnable(TestCase):
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_enable_configures_apt_sources_and_auth_files(
+            self, m_getuid, m_platform_info):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+
+        with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+            with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
+                self.assertTrue(entitlement.enable())
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
+                      'http://FIPS', 'TOKEN', None, 'APTKEY')]
+        apt_pinning_calls = [
+            mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial',
+                      'http://FIPS', 1001)]
+
+        assert add_apt_calls == m_add_apt.call_args_list
+        assert apt_pinning_calls == m_add_pinning.call_args_list


### PR DESCRIPTION
ua-contracts surfaces an aptURL directive to specify the entitlement's production/staging URL.
Fix the remaining cases where serviceURL was still being used in esm, fips and cis entitlements.

Fixes #215