### PR TITLE
apt: handle apt resource token as macaroon from ua-contracts

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -66,9 +66,11 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
         '# deb-src {url}/ubuntu {series} main\n'.format(
             url=repo_url, series=series))
     util.write_file(repo_filename, content)
-    # TODO(Confirm that machine-token or entitlement token provides format)
-    # which is supported by /etc/apt/auth.conf
-    login, password = credentials.split(':')
+    try:
+        login, password = credentials.split(':')
+    except ValueError::  # Then we have a bearer token
+        login = 'bearer'
+        password = credentials
     apt_auth_file = get_apt_auth_file_from_apt_config()
     if os.path.exists(apt_auth_file):
         auth_content = util.load_file(apt_auth_file)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import platform
 import shutil
 
 from uaclient import util
@@ -57,7 +56,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
     @raises: InvalidAPTCredentialsError when the token provided can't access
         the repo PPA.
     """
-    series = platform.dist()[2]
+    series = util.get_platform_info('series')
     if not valid_apt_credentials(repo_url, series, credentials):
         raise InvalidAPTCredentialsError(
             'Invalid APT credentials provided for %s' % repo_url)
@@ -116,7 +115,7 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
 
 def add_ppa_pinning(apt_preference_file, repo_url, priority):
     """Add an apt preferences file and pin for a PPA."""
-    series = platform.dist()[2]
+    series = util.get_platform_info('series')
     _protocol, repo_path = repo_url.split('://')
     origin = repo_path.replace('private-ppa.launchpad.net/', 'LP-PPA-')
     origin = origin.replace('/', '-')

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -30,7 +30,7 @@ class CISEntitlement(repo.RepoEntitlement):
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -31,7 +31,7 @@ class ESMEntitlement(repo.RepoEntitlement):
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -38,7 +38,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 'No legacy entitlement token present. Using machine token'
                 ' as %s credentials', self.title)
             token = self.cfg.machine_token['machineSecret']
-        repo_url = access_directives.get('serviceURL', self.repo_url)
+        repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
         try:
@@ -85,7 +85,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
             access_directives = self.cfg.read_cache(
                 'machine-access-%s' % self.name).get('directives', {})
-            repo_url = access_directives.get('serviceURL', self.repo_url)
+            repo_url = access_directives.get('aptURL', self.repo_url)
             if not repo_url:
                 repo_url = self.repo_url
             apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import os
-import platform
 
 from uaclient import apt
 from uaclient.entitlements import base
@@ -27,7 +26,7 @@ class RepoEntitlement(base.UAEntitlement):
         """
         if not self.can_enable():
             return False
-        series = platform.dist()[2]
+        series = util.get_platform_info('series')
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         resource_cfg = self.cfg.entitlements.get(self.name)
@@ -81,7 +80,6 @@ class RepoEntitlement(base.UAEntitlement):
         passed_affordances, details = self.check_affordances()
         if not passed_affordances:
             return status.INAPPLICABLE, details
-        apt_policy, _err = util.subp(['apt-cache', 'policy'])
         entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
             return status.INACTIVE, '%s PPA is not configured' % self.title

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -1,0 +1,87 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+import mock
+from io import StringIO
+
+from uaclient import config
+from uaclient.entitlements.cis import CISEntitlement
+from uaclient.testing.helpers import TestCase
+
+
+CIS_MACHINE_TOKEN = {
+    'machineSecret': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'cis-audit'}]}}}
+
+
+CIS_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'cis-audit',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://CIS',
+            'aptKey': 'APTKEY'
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+
+class TestCISEntitlementCanEnable(TestCase):
+
+    @mock.patch('os.getuid', return_value=0)
+    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+        """When operational status is INACTIVE, can_enable returns True."""
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cis-audit', CIS_RESOURCE_ENTITLED)
+        entitlement = CISEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            self.assertTrue(entitlement.can_enable())
+        self.assertEqual('', m_stdout.getvalue())
+
+
+class TestCISEntitlementEnable(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_enable_configures_apt_sources_and_auth_files(
+            self, m_getuid, m_platform_info, m_subp):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cis-audit', CIS_RESOURCE_ENTITLED)
+        entitlement = CISEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+
+        with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+            with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
+                self.assertTrue(entitlement.enable())
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list',
+                      'http://CIS', 'TOKEN', None, 'APTKEY')]
+
+        subp_apt_cmds = [
+            mock.call(['apt-get', 'update'], capture=True),
+            mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'])]
+
+        assert add_apt_calls == m_add_apt.call_args_list
+        # No apt pinning for cis-audit
+        assert [] == m_add_pinning.call_args_list
+        assert subp_apt_cmds == m_subp.call_args_list

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1,0 +1,83 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+import mock
+from io import StringIO
+
+from uaclient import config
+from uaclient.entitlements.fips import FIPSEntitlement
+from uaclient.testing.helpers import TestCase
+
+
+FIPS_MACHINE_TOKEN = {
+    'machineSecret': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'fips'}]}}}
+
+
+FIPS_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'fips',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://FIPS',
+            'aptKey': 'APTKEY'
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+
+class TestFIPSEntitlementCanEnable(TestCase):
+
+    @mock.patch('os.getuid', return_value=0)
+    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+        """When operational status is INACTIVE, can_enable returns True."""
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            self.assertTrue(entitlement.can_enable())
+        self.assertEqual('', m_stdout.getvalue())
+
+
+class TestFIPSEntitlementEnable(TestCase):
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_enable_configures_apt_sources_and_auth_files(
+            self, m_getuid, m_platform_info):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+        # Unset static affordance container check
+        entitlement.static_affordances = ()
+
+        with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+            with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
+                self.assertTrue(entitlement.enable())
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
+                      'http://FIPS', 'TOKEN', None, 'APTKEY')]
+        apt_pinning_calls = [
+            mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial',
+                      'http://FIPS', 1001)]
+
+        assert add_apt_calls == m_add_apt.call_args_list
+        assert apt_pinning_calls == m_add_pinning.call_args_list

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1,0 +1,109 @@
+"""Tests related to uaclient.apt module."""
+
+import mock
+
+from uaclient.testing.helpers import TestCase
+
+from uaclient.apt import add_auth_apt_repo, valid_apt_credentials
+from uaclient import util
+
+
+class TestValidAptCredentials(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('os.path.exists', return_value=False)
+    def test_valid_apt_credentials_true_when_missing_apt_helper(
+            self, m_exists, m_subp):
+        """When apt-helper tool is absent return True without validation."""
+        assert True is valid_apt_credentials(
+            repo_url='http://fakerepo', series='xenial', credentials='mycreds')
+        expected_calls = [mock.call('/usr/lib/apt/apt-helper')]
+        assert expected_calls== m_exists.call_args_list
+        assert 0 == m_subp.call_count
+
+
+class TestAddAuthAptRepo(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_adds_apt_fingerprint(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Call apt-key to add the specified fingerprint."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
+                          credentials='mycreds', fingerprint='APTKEY')
+
+        apt_cmds = [
+            mock.call(['apt-key', 'adv', '--keyserver', 'keyserver.ubuntu.com',
+                       '--recv-keys', 'APTKEY'], capture=True)]
+        assert apt_cmds == m_subp.call_args_list
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_sources_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write a properly configured sources file to repo_filename."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
+                          credentials='mycreds', fingerprint='APTKEY')
+
+        expected_content = (
+            'deb http://fakerepo/ubuntu xenial main\n'
+            '# deb-src http://fakerepo/ubuntu xenial main\n')
+        assert expected_content == util.load_file(repo_file)
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_username_password_to_auth_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write apt authentication file when credentials are user:pwd."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(
+            repo_filename=repo_file, repo_url='http://fakerepo',
+            credentials='user:password', fingerprint='APTKEY')
+
+        expected_content = (
+            '\n# This file is created by ubuntu-advantage-tools and will be'
+            ' updated\n# by subsequent calls to ua attach|detach [entitlement]'
+            '\nmachine fakerepo/ubuntu/ login user password password\n')
+        assert expected_content == util.load_file(auth_file)
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_bearer_resource_token_to_auth_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write apt authentication file when credentials are bearer token."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(
+            repo_filename=repo_file, repo_url='http://fakerepo',
+            credentials='SOMELONGTOKEN', fingerprint='APTKEY')
+
+        expected_content = (
+            '\n# This file is created by ubuntu-advantage-tools and will be'
+            ' updated\n# by subsequent calls to ua attach|detach [entitlement]'
+            '\nmachine fakerepo/ubuntu/ login bearer password SOMELONGTOKEN\n')
+        assert expected_content == util.load_file(auth_file)


### PR DESCRIPTION
ua-contracts service provides a macaroon for a resourceToken instead of generally PPA credentials of the format username:password.

When obtaining a single auth token from ua-contracts service, apt authentication will bearer:<token>.

Handle a ValueError if credentials are not of the format username:password and instead use bearer as the username and <token> as the password.

Prerequisite branch: https://github.com/CanonicalLtd/ubuntu-advantage-client/pull/216