### PR TITLE
apt: handle macaroon resourceToken from ua-contract instead of username:passwd

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -66,9 +66,11 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
         '# deb-src {url}/ubuntu {series} main\n'.format(
             url=repo_url, series=series))
     util.write_file(repo_filename, content)
-    # TODO(Confirm that machine-token or entitlement token provides format)
-    # which is supported by /etc/apt/auth.conf
-    login, password = credentials.split(':')
+    try:
+        login, password = credentials.split(':')
+    except ValueError::  # Then we have a bearer token
+        login = 'bearer'
+        password = credentials
     apt_auth_file = get_apt_auth_file_from_apt_config()
     if os.path.exists(apt_auth_file):
         auth_content = util.load_file(apt_auth_file)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -68,7 +68,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
     util.write_file(repo_filename, content)
     try:
         login, password = credentials.split(':')
-    except ValueError::  # Then we have a bearer token
+    except ValueError:  # Then we have a bearer token
         login = 'bearer'
         password = credentials
     apt_auth_file = get_apt_auth_file_from_apt_config()

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1,0 +1,109 @@
+"""Tests related to uaclient.apt module."""
+
+import mock
+
+from uaclient.testing.helpers import TestCase
+
+from uaclient.apt import add_auth_apt_repo, valid_apt_credentials
+from uaclient import util
+
+
+class TestValidAptCredentials(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('os.path.exists', return_value=False)
+    def test_valid_apt_credentials_true_when_missing_apt_helper(
+            self, m_exists, m_subp):
+        """When apt-helper tool is absent return True without validation."""
+        assert True is valid_apt_credentials(
+            repo_url='http://fakerepo', series='xenial', credentials='mycreds')
+        expected_calls = [mock.call('/usr/lib/apt/apt-helper')]
+        assert expected_calls== m_exists.call_args_list
+        assert 0 == m_subp.call_count
+
+
+class TestAddAuthAptRepo(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_adds_apt_fingerprint(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Call apt-key to add the specified fingerprint."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
+                          credentials='mycreds', fingerprint='APTKEY')
+
+        apt_cmds = [
+            mock.call(['apt-key', 'adv', '--keyserver', 'keyserver.ubuntu.com',
+                       '--recv-keys', 'APTKEY'], capture=True)]
+        assert apt_cmds == m_subp.call_args_list
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_sources_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write a properly configured sources file to repo_filename."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
+                          credentials='mycreds', fingerprint='APTKEY')
+
+        expected_content = (
+            'deb http://fakerepo/ubuntu xenial main\n'
+            '# deb-src http://fakerepo/ubuntu xenial main\n')
+        assert expected_content == util.load_file(repo_file)
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_username_password_to_auth_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write apt authentication file when credentials are user:pwd."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(
+            repo_filename=repo_file, repo_url='http://fakerepo',
+            credentials='user:password', fingerprint='APTKEY')
+
+        expected_content = (
+            '\n# This file is created by ubuntu-advantage-tools and will be'
+            ' updated\n# by subsequent calls to ua attach|detach [entitlement]'
+            '\nmachine fakerepo/ubuntu/ login user password password\n')
+        assert expected_content == util.load_file(auth_file)
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
+    @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    def test_add_auth_apt_repo_writes_bearer_resource_token_to_auth_file(
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+        """Write apt authentication file when credentials are bearer token."""
+        tmp_dir = self.tmp_dir()
+        repo_file = self.tmp_path('repo.conf', tmp_dir)
+        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        m_get_apt_auth_file.return_value = auth_file
+
+        add_auth_apt_repo(
+            repo_filename=repo_file, repo_url='http://fakerepo',
+            credentials='SOMELONGTOKEN', fingerprint='APTKEY')
+
+        expected_content = (
+            '\n# This file is created by ubuntu-advantage-tools and will be'
+            ' updated\n# by subsequent calls to ua attach|detach [entitlement]'
+            '\nmachine fakerepo/ubuntu/ login bearer password SOMELONGTOKEN\n')
+        assert expected_content == util.load_file(auth_file)

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -18,7 +18,7 @@ class TestValidAptCredentials(TestCase):
         assert True is valid_apt_credentials(
             repo_url='http://fakerepo', series='xenial', credentials='mycreds')
         expected_calls = [mock.call('/usr/lib/apt/apt-helper')]
-        assert expected_calls== m_exists.call_args_list
+        assert expected_calls == m_exists.call_args_list
         assert 0 == m_subp.call_count
 
 


### PR DESCRIPTION
ua-contracts service provides a macaroon for a resourceToken instead of generally PPA credentials of the format username:password.

When obtaining a single auth token from ua-contracts service, apt authentication will bearer:.

Handle a ValueError if credentials are not of the format username:password and instead use bearer as the username and as the password.

This diff is only big while we await prerequisite #216.

Here is the incremental diff
http://paste.ubuntu.com/p/byvKGBg4c6/
