### PR TITLE
status: add --json cli formatting option

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -295,7 +295,7 @@ def get_parser():
 def action_status(args, cfg):
     if not cfg:
         cfg = config.UAConfig()
-    if args.format == 'json':
+    if args and args.format == 'json':
         status = cfg.status()
         if status['expires'] != ua_status.INAPPLICABLE:
             status['expires'] = str(status['expires'])

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -48,6 +48,9 @@ DEFAULT_LOG_FORMAT = (
     '%(asctime)s - %(filename)s:(%(lineno)d) [%(levelname)s]: %(message)s')
 
 
+STATUS_FORMATS = ['table', 'json']
+
+
 def attach_parser(parser=None):
     """Build or extend an arg parser for attach subcommand."""
     usage = USAGE_TMPL.format(name=NAME, command='attach [token]')
@@ -150,8 +153,10 @@ def status_parser(parser=None):
         parser.usage = usage
         parser.prog = 'status'
     parser.add_argument(
-        '--json', action='store_true', help='Format output as json',
-        default=False)
+        '--format', action='store', choices=STATUS_FORMATS,
+        default=STATUS_FORMATS[0],
+        help=('Output status in the request format. Default: %s' %
+              STATUS_FORMATS[0]))
     parser._optionals.title = 'Flags'
     return parser
 
@@ -292,7 +297,7 @@ def action_status(args, cfg):
     if not cfg:
         cfg = config.UAConfig()
     if not cfg.is_attached:
-        if args.json:
+        if args.format == 'json':
             print(json.dumps({'attached': False}))
         else:
             print(ua_status.MESSAGE_UNATTACHED)
@@ -313,8 +318,8 @@ def action_status(args, cfg):
     for ent_cls in entitlements.ENTITLEMENT_CLASSES:
         ent = ent_cls(cfg)
         entitlement_content.append(ua_status.format_entitlement_status(
-            ent, args.json))
-    if args.json:
+            ent, bool(args.format == 'json')))
+    if args.format == 'json':
         status_content = json.dumps({
             'attached': True, 'account': account['name'],
             'entitlements': entitlement_content,

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -63,25 +63,13 @@ This machine is not attached to a UA subscription.
 See `ua attach` or https://ubuntu.com/advantage
 """
 
-STATUS_TMPL = '{name: <14}{entitlement_level: <26}{service_status}'
-
-
-def format_entitlement_status(entitlement, as_dict=False):
-    """Format entitlement status for print or as a dictionary."""
-    contract_status = entitlement.contract_status()
-    operational_status, _details = entitlement.operational_status()
-    fmt_args = {
-        'name': entitlement.name,
-        'entitlement_level': STATUS_COLOR.get(
-            contract_status, contract_status),
-        'service_status': STATUS_COLOR.get(
-            operational_status, operational_status)}
-    if as_dict:
-        # Don't colorize json
-        fmt_args['entitlement_level'] = contract_status
-        fmt_args['service_status'] = operational_status
-        return fmt_args
-    return STATUS_TMPL.format(**fmt_args)
+STATUS_HEADER_TMPL = """\
+Account: {account}
+Subscription: {subscription}
+Valid until: {expires}
+Technical support level: {techSupportLevel}
+"""
+STATUS_TMPL = '{name: <14}{entitled: <26}{status}'
 
 
 def get_upgradeable_esm_package_count():
@@ -103,3 +91,25 @@ def get_upgradeable_esm_package_count():
                     upgrade_count += 1
                     break
     return upgrade_count
+
+
+def format_tabular(status):
+    """Format status dict for tabular output."""
+    if not status['attached']:
+        return MESSAGE_UNATTACHED
+    content = [STATUS_HEADER_TMPL.format(
+        account=status['account'],
+        subscription=status['subscription'],
+        expires=status['expires'],
+        techSupportLevel=status['techSupportLevel'])]
+
+    for service_status in status['services']:
+        entitled = service_status['entitled']
+        fmt_args = {
+            'name': service_status['name'],
+            'entitled': STATUS_COLOR.get(entitled, entitled),
+            'status': STATUS_COLOR.get(
+                service_status['status'], service_status['status'])}
+        content.append(STATUS_TMPL.format(**fmt_args))
+    content.append('\nEnable entitlements with `ua enable <service>`')
+    return '\n'.join(content)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -63,16 +63,24 @@ This machine is not attached to a UA subscription.
 See `ua attach` or https://ubuntu.com/advantage
 """
 
-STATUS_TMPL = '{name: <14}{contract_state: <26}{status}'
+STATUS_TMPL = '{name: <14}{entitlement_level: <26}{service_status}'
 
 
-def format_entitlement_status(entitlement):
+def format_entitlement_status(entitlement, as_dict=False):
+    """Format entitlement status for print or as a dictionary."""
     contract_status = entitlement.contract_status()
     operational_status, _details = entitlement.operational_status()
     fmt_args = {
         'name': entitlement.name,
-        'contract_state': STATUS_COLOR.get(contract_status, contract_status),
-        'status': STATUS_COLOR.get(operational_status, operational_status)}
+        'entitlement_level': STATUS_COLOR.get(
+            contract_status, contract_status),
+        'service_status': STATUS_COLOR.get(
+            operational_status, operational_status)}
+    if as_dict:
+        # Don't colorize json
+        fmt_args['entitlement_level'] = contract_status
+        fmt_args['service_status'] = operational_status
+        return fmt_args
     return STATUS_TMPL.format(**fmt_args)
 
 


### PR DESCRIPTION
Add the ability to specify --format json|tabular to status output.
Also address that ua-contracts can omit date related fields (such as contract expiry)

Fixes: #227 
Fixes: #384 