### PR TITLE
integrate apt esm hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 
 build:
-	@echo Nothing to be done for build
+	$(MAKE) -C apt-hook build
 
 deps:
 	./dev/read-dependencies -v 3 --system-pkg-names --test-distro

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,7 +1,7 @@
 APT::Update::Post-Invoke-Stats {
-	"[ ! -f /usr/lib/apt-esm-hook/hook ] || /usr/lib/apt-esm-hook/hook";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook";
 };
 
 APT::Install::Post-Invoke-Success {
-	"[ ! -f /usr/lib/apt-esm-hook/hook ] || /usr/lib/apt-esm-hook/hook";
+	"[ ! -f /usr/lib/ubuntu-advantage/apt-esm-hook ] || /usr/lib/ubuntu-advantage/apt-esm-hook";
 }; 

--- a/apt-hook/20apt-esm-hook.conf
+++ b/apt-hook/20apt-esm-hook.conf
@@ -1,0 +1,7 @@
+APT::Update::Post-Invoke-Stats {
+	"[ ! -f /usr/lib/apt-esm-hook/hook ] || /usr/lib/apt-esm-hook/hook";
+};
+
+APT::Install::Post-Invoke-Success {
+	"[ ! -f /usr/lib/apt-esm-hook/hook ] || /usr/lib/apt-esm-hook/hook";
+}; 

--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -3,5 +3,9 @@ all: hook
 hook: hook.cc
 	$(CXX) -Wall -Wextra -pedantic $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
 
+install: hook
+	install -D -m 644 20apt-esm-hook.conf $(DESTDIR)/etc/apt/apt.conf.d/20apt-esm-hook.conf
+	install -D -m 755 hook $(DESTDIR)/usr/lib/ubuntu-advantage/apt-esm-hook
+
 clean:
 	rm -f hook

--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -1,0 +1,7 @@
+all: hook
+
+hook: hook.cc
+	$(CXX) -Wall -Wextra -pedantic $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
+
+clean:
+	rm -f hook

--- a/apt-hook/Makefile
+++ b/apt-hook/Makefile
@@ -1,5 +1,7 @@
 all: hook
 
+build: hook
+
 hook: hook.cc
 	$(CXX) -Wall -Wextra -pedantic $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -g -o hook hook.cc -lapt-pkg $(LDLIBS)
 

--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2018-2019 Canonical Ltd
+ * Author: Julian Andres Klode <juliank@ubuntu.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This package is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+*/
+
+#include <apt-pkg/cachefile.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/init.h>
+#include <apt-pkg/strutl.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <assert.h>
+#include <sys/stat.h>
+#include <libintl.h>
+#include <locale.h>
+
+struct result {
+   int enabled_esms;
+   int disabled_esms;
+};
+
+// Return parent pid of specified pid, using /proc (pid might be self)
+static std::string getppid_of(std::string pid)
+{
+   std::string status_path;
+   std::string line;
+
+   if (pid == "")
+      return "";
+
+   strprintf(status_path, "/proc/%s/status", pid.c_str());
+
+   std::ifstream stream(status_path.c_str(), std::ios::in);
+
+   while (not stream.fail()) {
+      getline(stream, line);
+
+      if (line.find("PPid:") != 0)
+	 continue;
+
+      // Erase everything before a number
+      line.erase(0, line.find_first_of("0123456789"));
+
+      return line;
+   }
+
+   if (stream.fail())
+      _error->Error("Could not parse proc status of %s", pid.c_str());
+
+   return "";
+}
+
+// Get cmdline of specified pid. Arguments terminated with 0
+static std::string getcmdline(std::string pid)
+{
+   std::string cmdline_path;
+
+   if (pid == "")
+      return "";
+
+   strprintf(cmdline_path, "/proc/%s/cmdline", pid.c_str());
+   std::ifstream stream(cmdline_path.c_str(), std::ios::in);
+   std::ostringstream cmdline;
+   char buf[4096];
+
+   do
+   {
+      stream.read(buf, sizeof(buf));
+      cmdline.write(buf, stream.gcount());
+   } while (stream.gcount() > 0);
+
+   return cmdline.str();
+}
+
+// Check if a cmdline is eligible for showing ESM updates. Only apt
+// update and the various upgrade commands are
+static std::string command_used;
+static bool cmdline_eligible(std::string const &cmdline)
+{
+   const std::string commands[] = {"update", "upgrade", "dist-upgrade", "full-upgrade", "safe-upgrade"};
+
+   for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); i++)
+   {
+      if (cmdline.find('\0' + commands[i] + '\0') != std::string::npos)
+      {
+         command_used = commands[i];
+         return true;
+      }
+   }
+
+   return false;
+}
+
+// Check if we have an ESM upgrade for the specified package
+static void check_esm_upgrade(pkgCache::PkgIterator pkg, pkgPolicy *policy, result &res)
+{
+   pkgCache::VerIterator cur = pkg.CurrentVer();
+
+   if (cur.end())
+      return;
+
+   // Search all versions >= cur (list in decreasing order)
+   for (pkgCache::VerIterator ver = pkg.VersionList(); !ver.end() && ver->ID != cur->ID; ver++)
+   {
+      for (pkgCache::VerFileIterator pf = ver.FileList(); !pf.end(); pf++)
+      {
+	 // TODO: Just look at the origin, not pinning.
+	 if (pf.File().Archive() != 0 && pf.File().Origin() == std::string("UbuntuESM"))
+	 {
+	    if (policy->GetPriority(pf.File()) == -32768)
+	       res.disabled_esms++;
+	    else
+	       res.enabled_esms++;
+
+	    return;
+	 }
+      }
+   }
+}
+
+// Calculate the update count
+static int get_update_count(result &res)
+{
+   int count = 0;
+   if (!pkgInitConfig(*_config))
+      return -1;
+
+   if (!pkgInitSystem(*_config, _system))
+      return -1;
+
+   pkgCacheFile cachefile;
+
+   pkgCache *cache = cachefile.GetPkgCache();
+   pkgPolicy *policy = cachefile.GetPolicy();
+
+   if (cache == NULL || policy == NULL)
+      return -1;
+
+   for (pkgCache::PkgIterator pkg = cache->PkgBegin(); !pkg.end(); pkg++)
+   {
+      check_esm_upgrade(pkg, policy, res);
+   }
+   return count;
+}
+
+// Preserves \0 bytes in a string literal
+template<std::size_t n>
+std::string make_cmdline(const char (&s)[n])
+{
+   return std::string(s, n);
+}
+
+bool has_arg(char **argv, const char *arg)
+{
+   for (; *argv; argv++) {
+      if (strcmp(*argv, arg) == 0)
+         return true;
+   }
+   return false;
+}
+
+int main(int argc, char *argv[])
+{
+   (void) argc;   // unused
+   setlocale(LC_ALL, "");
+   textdomain("ubuntu-advantage-tools");
+   // Self testing
+   std::string ppid;
+   strprintf(ppid, "%d", getppid());
+   assert(ppid == getppid_of("self"));
+   assert(cmdline_eligible(make_cmdline("apt\0update\0")));
+   assert(cmdline_eligible(make_cmdline("apt-get\0update\0")));
+   assert(!cmdline_eligible(make_cmdline("apt-get\0install\0")));
+   assert(!cmdline_eligible(make_cmdline("apt\0install\0")));
+   assert(!cmdline_eligible(make_cmdline("apt\0install\0")));
+   assert(cmdline_eligible(make_cmdline("aptitude\0upgrade\0")));
+   assert(cmdline_eligible(make_cmdline("aptitude\0update\0")));
+   command_used = "";
+
+   result res = {0, 0};
+
+   if (has_arg(argv, "test") || cmdline_eligible(getcmdline(getppid_of(getppid_of("self")))))
+      get_update_count(res);
+   if (_error->PendingError())
+   {
+      _error->DumpErrors();
+      return 1;
+   }
+
+   if (res.enabled_esms > 0 && (command_used == "update"))
+   {
+      ioprintf(std::cout,
+               ngettext("%d of the updates is from Extended Security Maintenance.",
+                        "%d of the updates are from Extended Security Maintenance.",
+                        res.enabled_esms),
+               res.enabled_esms);
+      ioprintf(std::cout, "\n");
+   }
+
+   if (res.disabled_esms > 0)
+   {
+      if (command_used != "update")
+         std::cout << std::endl;
+      ioprintf(std::cout,
+               ngettext("%d additional update is available with Extended Security Maintenance.",
+                        "%d additional updates are available with Extended Security Maintenance.",
+                        res.disabled_esms),
+               res.disabled_esms);
+
+      ioprintf(std::cout, "\n");
+      ioprintf(std::cout, gettext("See 'ua enable esm' or https://ubuntu.com/esm"));
+      ioprintf(std::cout, "\n");
+   }
+
+   return 0;
+}

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper (>=9),
                dh-python,
                git,
+               libapt-pkg-dev,
                python3 (>= 3.4),
                python3-flake8,
                python3-pymacaroons,
@@ -18,9 +19,10 @@ Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git
 Vcs-Browser: https://github.com/CanonicalLtd/ubuntu-advantage-script
 
 Package: ubuntu-advantage-tools
-Architecture: all
+Architecture: any
 Depends: ${misc:Depends},
-         ${python3:Depends}
+         ${python3:Depends},
+         ${shlibs:Depends}
 XB-Python-Version: ${python:Versions}
 Description: management tools for Ubuntu Advantage
  Ubuntu Advantage is the professional package of tooling, technology

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
+	dh $@ --sourcedirectory=apt-hook --buildsystem=makefile
 
 override_dh_auto_test:
 	python3 -m nose2
@@ -16,5 +17,6 @@ else
 endif
 
 override_dh_auto_install:
+	dh_auto_install --sourcedirectory=apt-hook --buildsystem=makefile
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}


### PR DESCRIPTION
This integrates the hook for apt into the package. What's missing is the whole gettext shenanigans, and maybe you want to do things slightly differently in places, but this feels like a good start.