### PR TITLE
cc: add initial common criteria entitlement and unit tests

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -9,6 +9,7 @@ Available entitlements:
  - FIPS 140-2 with updates
  - Canonical Livepatch (https://ubuntu.com/server/livepatch)
  - Canonical CIS Benchmark Audit Tool
+ - Canonical Common Criteria EAL2 Provisioning
 
 """
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -24,6 +24,7 @@ class UAConfig(object):
         'account-users': 'account-users.json',
         'contract-token': 'contract-token.json',
         'machine-contracts': 'machine-contracts.json',
+        'machine-access-cc': 'machine-access-cc.json',
         'machine-access-cis-audit': 'machine-access-cis-audit.json',
         'machine-access-esm': 'machine-access-esm.json',
         'machine-access-fips': 'machine-access-fips.json',

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -1,11 +1,12 @@
 from uaclient.entitlements.cis import CISEntitlement
+from uaclient.entitlements.cc import CommonCriteriaEntitlement
 from uaclient.entitlements.esm import ESMEntitlement
 from uaclient.entitlements import fips
 from uaclient.entitlements.livepatch import LivepatchEntitlement
 
 ENTITLEMENT_CLASSES = [
-    CISEntitlement, ESMEntitlement, fips.FIPSEntitlement,
-    fips.FIPSUpdatesEntitlement, LivepatchEntitlement]
+    CISEntitlement, CommonCriteriaEntitlement, ESMEntitlement,
+    fips.FIPSEntitlement, fips.FIPSUpdatesEntitlement, LivepatchEntitlement]
 
 ENTITLEMENT_CLASS_BY_NAME = dict(
     (cls.name, cls) for cls in ENTITLEMENT_CLASSES)

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -1,0 +1,44 @@
+import os
+
+from uaclient import apt
+from uaclient.entitlements import repo
+from uaclient import util
+
+
+class CommonCriteriaEntitlement(repo.RepoEntitlement):
+
+    name = 'cc'
+    title = 'Canonical Common Criteria EAL2 Provisioning'
+    description = (
+        'Common Criteria for Information Technology Security Evaluation - EAL2'
+    )
+    repo_url = ('https://private-ppa.launchpad.net/ubuntu-advantage/'
+                'commoncriteria')
+    repo_key_file = 'ubuntu-cc-keyring.gpg'
+    packages = ['ubuntu-commoncriteria']
+
+    def disable(self, silent=False, force=False):
+        """Disable specific entitlement
+
+        @return: True on success, False otherwise.
+        """
+        if not self.can_disable(silent, force):
+            return False
+        series = util.get_platform_info('series')
+        repo_filename = self.repo_list_file_tmpl.format(
+            name=self.name, series=series)
+        keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
+        entitlement_cfg = self.cfg.read_cache(
+            'machine-access-%s' % self.name)['entitlement']
+        access_directives = entitlement_cfg.get('directives', {})
+        repo_url = access_directives.get('aptURL', self.repo_url)
+        if not repo_url:
+            repo_url = self.repo_url
+        apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
+        print('Removing packages: %s' % ', '.join(self.packages))
+        try:
+            util.subp(['apt-get', 'remove', '--frontend=noninteractive',
+                       '--assume-yes'] + self.packages, capture=True)
+        except util.ProcessExecutionError:
+            pass
+        return True

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -16,6 +16,10 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
                 'commoncriteria')
     repo_key_file = 'ubuntu-cc-keyring.gpg'
     packages = ['ubuntu-commoncriteria']
+    messaging = {
+        'post_enable': [
+            'Please follow instructions in /usr/lib/common-criteria/README'
+            ' to configure EAL2']}
 
     def disable(self, silent=False, force=False):
         """Disable specific entitlement

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -37,7 +37,7 @@ class CISEntitlement(repo.RepoEntitlement):
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
             util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                       '--assume-yes'] + self.packages)
+                       '--assume-yes'] + self.packages, capture=True)
         except util.ProcessExecutionError:
             pass
         return True

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -1,0 +1,97 @@
+"""Tests related to uaclient.entitlement.base module."""
+
+import mock
+from io import StringIO
+
+from uaclient import config
+from uaclient import status
+from uaclient.entitlements.cc import CommonCriteriaEntitlement
+from uaclient.testing.helpers import TestCase
+
+
+CC_MACHINE_TOKEN = {
+    'machineSecret': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'cc'}]}}}
+
+
+CC_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': False
+        },
+        'type': 'cc',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://CC',
+            'aptKey': 'APTKEY'
+        },
+        'affordances': {
+            'series': ['xenial']
+        }
+    }
+}
+
+
+class TestCommonCriteriaEntitlementCanEnable(TestCase):
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_can_enable_true_on_entitlement_inactive(
+            self, m_getuid, m_platform_info):
+        """When operational status is INACTIVE, can_enable returns True."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cc', CC_RESOURCE_ENTITLED)
+        entitlement = CommonCriteriaEntitlement(cfg)
+        op_status, op_status_details = entitlement.operational_status()
+        assert status.INACTIVE == op_status
+        details = '%s PPA is not configured' % entitlement.title
+        assert details == op_status_details
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            assert True is entitlement.can_enable()
+        assert '' == m_stdout.getvalue()
+
+
+class TestCommonCriteriaEntitlementEnable(TestCase):
+
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch('os.getuid', return_value=0)
+    def test_enable_configures_apt_sources_and_auth_files(
+            self, m_getuid, m_platform_info, m_subp):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        m_platform_info.return_value = 'xenial'
+        tmp_dir = self.tmp_dir()
+        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-cc', CC_RESOURCE_ENTITLED)
+        entitlement = CommonCriteriaEntitlement(cfg)
+
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+                with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pin:
+                    assert True is entitlement.enable()
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-cc-xenial.list',
+                      'http://CC', 'TOKEN', None, 'APTKEY')]
+
+        subp_apt_cmds = [
+            mock.call(['apt-get', 'update'], capture=True),
+            mock.call(['apt-get', 'install', 'ubuntu-commoncriteria'])]
+
+        assert add_apt_calls == m_add_apt.call_args_list
+        # No apt pinning for cc
+        assert [] == m_add_pin.call_args_list
+        assert subp_apt_cmds == m_subp.call_args_list
+        expected_stdout = (
+            'Installing Canonical Common Criteria EAL2 Provisioning packages'
+            ' (this may take a while)\nCanonical Common Criteria EAL2'
+            ' Provisioning enabled.\n')
+        assert expected_stdout == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -84,14 +84,16 @@ class TestCommonCriteriaEntitlementEnable(TestCase):
 
         subp_apt_cmds = [
             mock.call(['apt-get', 'update'], capture=True),
-            mock.call(['apt-get', 'install', 'ubuntu-commoncriteria'])]
+            mock.call(['apt-get', 'install', 'ubuntu-commoncriteria'],
+                      capture=True)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout = (
-            'Installing Canonical Common Criteria EAL2 Provisioning packages'
-            ' (this may take a while)\nCanonical Common Criteria EAL2'
-            ' Provisioning enabled.\n')
+            'Installing Canonical Common Criteria EAL2 Provisioning'
+            ' packages ...\nCanonical Common Criteria EAL2 Provisioning'
+            ' enabled.\nPlease follow instructions in'
+            ' /usr/lib/common-criteria/README to configure EAL2\n')
         assert expected_stdout == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -80,13 +80,14 @@ class TestCISEntitlementEnable(TestCase):
 
         subp_apt_cmds = [
             mock.call(['apt-get', 'update'], capture=True),
-            mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'])]
+            mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'],
+                      capture=True)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cis-audit
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout = (
-            'Installing Canonical CIS Benchmark Audit Tool packages (this may'
-            ' take a while)\nCanonical CIS Benchmark Audit Tool enabled.\n')
+            'Installing Canonical CIS Benchmark Audit Tool packages ...\n'
+            'Canonical CIS Benchmark Audit Tool enabled.\n')
         assert expected_stdout == m_stdout.getvalue()


### PR DESCRIPTION
Adding initiall Common Criteria entitlement which will rely on a 'cc' entitlement type surfaced
by the ua-contract backend service.

This is a PPA-based entitlement which should work like fips* or cis-audit entitlement types.
CC entitlement does the following:
- It sets up an authenticated PPA
 - installs a common-criteria package dependency
  - adds RepoEntitlement.messaging class attribute for emitting custom instructions post enable

Drive-by fixes:
- entitlements.repo: simplify apt package install message 
-  entitlements.cis : add capture=True on package changes to log them
- entitlements.tests.test_cis:  mock stdout to avoid leaking printed messages during unit tests as well as
   validate messages printed

Fixes #175 