### PR TITLE
unittest.cfg: remove as no longer needed

### DIFF
--- a/unittest.cfg
+++ b/unittest.cfg
@@ -1,2 +1,0 @@
-[pretty-assert]
-always-on = True


### PR DESCRIPTION
It configures nose2, which we no longer use.