### PR TITLE
apt: pinning to use hardcoded origin for each entitlement

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -115,12 +115,10 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
             util.write_file(apt_auth_file, content, mode=0o600)
 
 
-def add_ppa_pinning(apt_preference_file, repo_url, priority):
+def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
     """Add an apt preferences file and pin for a PPA."""
     series = util.get_platform_info('series')
     _protocol, repo_path = repo_url.split('://')
-    origin = repo_path.replace('private-ppa.launchpad.net/', 'LP-PPA-')
-    origin = origin.replace('/', '-')
     content = (
         'Package: *\n'
         'Pin: release o={origin}, n={series}\n'

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -10,12 +10,12 @@ class ESMEntitlement(repo.RepoEntitlement):
 
     name = 'esm'
     title = 'Extended Security Maintenance'
+    origin = 'UbuntuESM'
     description = (
         'Ubuntu Extended Security Maintenance archive'
         ' (https://ubuntu.com/esm)')
     repo_url = 'https://esm.ubuntu.com'
     repo_key_file = 'ubuntu-esm-keyring.gpg'
-    repo_pin_priority = -32768   # Allow seeing esm pkg counts but not install
 
     def disable(self, silent=False, force=False):
         """Disable specific entitlement

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -51,7 +51,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)
             apt.add_ppa_pinning(
-                repo_pref_file, repo_url, self.repo_pin_priority)
+                repo_pref_file, repo_url, self.origin, self.repo_pin_priority)
         return True
         if not os.path.exists(apt.APT_METHOD_HTTPS_FILE):
             util.subp(['apt-get', 'install', 'apt-transport-https'],
@@ -110,6 +110,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
 
     name = 'fips'
     title = 'FIPS'
+    origin = 'UbuntuFIPS'
     description = 'Canonical FIPS 140-2 Certified Modules'
     repo_url = 'https://private-ppa.launchpad.net/ubuntu-advantage/fips'
     repo_key_file = 'ubuntu-fips-keyring.gpg'
@@ -121,6 +122,7 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
 
     name = 'fips-updates'
     title = 'FIPS Updates'
+    origin = 'UbuntuFIPSUpdates'
     description = 'Canonical FIPS 140-2 Certified Modules with Updates'
     repo_url = (
         'https://private-ppa.launchpad.net/ubuntu-advantage/fips-updates')

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -48,6 +48,14 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             logging.error(str(e))
             return False
         if self.repo_pin_priority:
+            if not self.origin:
+                logging.error(
+                    "Cannot setup apt pin. Empty apt repo origin value '%s'." %
+                    self.origin)
+                logging.error(
+                    status.MESSAGE_ENABLED_FAILED_TMPL.format(
+                        title=self.title))
+                return False
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)
             apt.add_ppa_pinning(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -12,7 +12,7 @@ class RepoEntitlement(base.UAEntitlement):
 
     repo_list_file_tmpl = '/etc/apt/sources.list.d/ubuntu-{name}-{series}.list'
     repo_pref_file_tmpl = '/etc/apt/preferences.d/ubuntu-{name}-{series}'
-    origin = 'UNSET'   # The repo Origin value for setting pinning
+    origin = None   # The repo Origin value for setting pinning
 
     repo_url = 'UNSET'
     repo_key_file = 'UNSET'  # keyfile delivered by ubuntu-cloudimage-keyring
@@ -55,6 +55,14 @@ class RepoEntitlement(base.UAEntitlement):
             logging.error(str(e))
             return False
         if self.repo_pin_priority:
+            if not self.origin:
+                logging.error(
+                    "Cannot setup apt pin. Empty apt repo origin value '%s'." %
+                    self.origin)
+                logging.error(
+                    status.MESSAGE_ENABLED_FAILED_TMPL.format(
+                        title=self.title))
+                return False
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)
             apt.add_ppa_pinning(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -12,6 +12,7 @@ class RepoEntitlement(base.UAEntitlement):
 
     repo_list_file_tmpl = '/etc/apt/sources.list.d/ubuntu-{name}-{series}.list'
     repo_pref_file_tmpl = '/etc/apt/preferences.d/ubuntu-{name}-{series}'
+    origin = 'UNSET'   # The repo Origin value for setting pinning
 
     repo_url = 'UNSET'
     repo_key_file = 'UNSET'  # keyfile delivered by ubuntu-cloudimage-keyring
@@ -57,7 +58,7 @@ class RepoEntitlement(base.UAEntitlement):
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)
             apt.add_ppa_pinning(
-                repo_pref_file, repo_url, self.repo_pin_priority)
+                repo_pref_file, repo_url, self.origin, self.repo_pin_priority)
         if not os.path.exists(apt.APT_METHOD_HTTPS_FILE):
             util.subp(['apt-get', 'install', 'apt-transport-https'],
                       capture=True)

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -77,7 +77,7 @@ class TestFIPSEntitlementEnable(TestCase):
                       'http://FIPS', 'TOKEN', None, 'APTKEY')]
         apt_pinning_calls = [
             mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial',
-                      'http://FIPS', 1001)]
+                      'http://FIPS', 'UbuntuFIPS', 1001)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         assert apt_pinning_calls == m_add_pinning.call_args_list

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -34,6 +34,8 @@ FIPS_RESOURCE_ENTITLED = {
     }
 }
 
+M_PATH = 'uaclient.entitlements.fips.FIPSEntitlement.'
+
 
 class TestFIPSEntitlementCanEnable(TestCase):
 
@@ -52,16 +54,15 @@ class TestFIPSEntitlementCanEnable(TestCase):
         self.assertEqual('', m_stdout.getvalue())
 
 
-class TestFIPSEntitlementEnable(TestCase):
+class TestFIPSEntitlementEnable:
 
     @mock.patch('uaclient.util.get_platform_info')
     @mock.patch('os.getuid', return_value=0)
     def test_enable_configures_apt_sources_and_auth_files(
-            self, m_getuid, m_platform_info):
+            self, m_getuid, m_platform_info, tmpdir):
         """When entitled, configure apt repo auth token, pinning and url."""
         m_platform_info.return_value = 'xenial'
-        tmp_dir = self.tmp_dir()
-        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
+        cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
         cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
         entitlement = FIPSEntitlement(cfg)
@@ -70,7 +71,7 @@ class TestFIPSEntitlementEnable(TestCase):
 
         with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
             with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
-                self.assertTrue(entitlement.enable())
+                assert True is entitlement.enable()
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
@@ -81,3 +82,36 @@ class TestFIPSEntitlementEnable(TestCase):
 
         assert add_apt_calls == m_add_apt.call_args_list
         assert apt_pinning_calls == m_add_pinning.call_args_list
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_enable', return_value=False)
+    def test_enable_returns_false_on_can_enable_false(
+            self, m_can_enable, m_platform_info):
+        """When can_enable is false enable returns false and noops."""
+        entitlement = FIPSEntitlement({})
+
+        assert False is entitlement.enable()
+        assert 0 == m_platform_info.call_count
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_enable', return_value=True)
+    def test_enable_errors_on_repo_pin_but_invalid_origin(
+            self, m_can_enable, m_platform_info, caplog_text, tmpdir):
+        """When can_enable is false enable returns false and noops."""
+        m_platform_info.return_value = 'xenial'
+        cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+        entitlement.origin = None  # invalid value
+
+        with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+            with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pinning:
+                assert False is entitlement.enable()
+
+        add_apt_calls = [
+            mock.call('/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
+                      'http://FIPS', 'TOKEN', None, 'APTKEY')]
+        assert add_apt_calls == m_add_apt.call_args_list
+        assert 0 == m_add_pinning.call_count
+        assert 'ERROR    Cannot setup apt pin' in caplog_text()

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1,9 +1,28 @@
 """Tests related to uaclient.apt module."""
 
 import mock
+from textwrap import dedent
 
-from uaclient.apt import add_auth_apt_repo, valid_apt_credentials
+from uaclient.apt import (
+    add_auth_apt_repo, add_ppa_pinning, valid_apt_credentials)
 from uaclient import util
+
+
+class TestAddPPAPinning:
+
+    @mock.patch('uaclient.util.get_platform_info')
+    def test_write_apt_pin_file_to_apt_preferences(self, m_platform, tmpdir):
+        """Write proper apt pin file to specified apt_preference_file."""
+        m_platform.return_value = 'xenial'
+        pref_file = tmpdir.join('preffile').strpath
+        assert None is add_ppa_pinning(
+            pref_file, repo_url='http://fakerepo', origin='MYORIG',
+            priority=1003)
+        expected_pref = dedent('''\
+            Package: *
+            Pin: release o=MYORIG, n=xenial
+            Pin-Priority: 1003\n''')
+        assert expected_pref == util.load_file(pref_file)
 
 
 class TestValidAptCredentials:
@@ -30,8 +49,8 @@ class TestAddAuthAptRepo:
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
         """Call apt-key to add the specified fingerprint."""
-        repo_file = tmpdir.join('repo.conf')
-        auth_file = tmpdir.join('auth.conf')
+        repo_file = tmpdir.join('repo.conf').strpath
+        auth_file = tmpdir.join('auth.conf').strpath
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
@@ -50,8 +69,8 @@ class TestAddAuthAptRepo:
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
         """Write a properly configured sources file to repo_filename."""
-        repo_file = tmpdir.join('repo.conf')
-        auth_file = tmpdir.join('auth.conf')
+        repo_file = tmpdir.join('repo.conf').strpath
+        auth_file = tmpdir.join('auth.conf').strpath
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
@@ -70,8 +89,8 @@ class TestAddAuthAptRepo:
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
         """Write apt authentication file when credentials are user:pwd."""
-        repo_file = tmpdir.join('repo.conf')
-        auth_file = tmpdir.join('auth.conf')
+        repo_file = tmpdir.join('repo.conf').strpath
+        auth_file = tmpdir.join('auth.conf').strpath
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(
@@ -92,8 +111,8 @@ class TestAddAuthAptRepo:
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
         """Write apt authentication file when credentials are bearer token."""
-        repo_file = tmpdir.join('repo.conf')
-        auth_file = tmpdir.join('auth.conf')
+        repo_file = tmpdir.join('repo.conf').strpath
+        auth_file = tmpdir.join('auth.conf').strpath
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -2,13 +2,11 @@
 
 import mock
 
-from uaclient.testing.helpers import TestCase
-
 from uaclient.apt import add_auth_apt_repo, valid_apt_credentials
 from uaclient import util
 
 
-class TestValidAptCredentials(TestCase):
+class TestValidAptCredentials:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('os.path.exists', return_value=False)
@@ -22,18 +20,18 @@ class TestValidAptCredentials(TestCase):
         assert 0 == m_subp.call_count
 
 
-class TestAddAuthAptRepo(TestCase):
+class TestAddAuthAptRepo:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
     @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
     def test_add_auth_apt_repo_adds_apt_fingerprint(
-            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
+            tmpdir):
         """Call apt-key to add the specified fingerprint."""
-        tmp_dir = self.tmp_dir()
-        repo_file = self.tmp_path('repo.conf', tmp_dir)
-        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        repo_file = tmpdir.join('repo.conf')
+        auth_file = tmpdir.join('auth.conf')
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
@@ -49,11 +47,11 @@ class TestAddAuthAptRepo(TestCase):
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
     @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
     def test_add_auth_apt_repo_writes_sources_file(
-            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
+            tmpdir):
         """Write a properly configured sources file to repo_filename."""
-        tmp_dir = self.tmp_dir()
-        repo_file = self.tmp_path('repo.conf', tmp_dir)
-        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        repo_file = tmpdir.join('repo.conf')
+        auth_file = tmpdir.join('auth.conf')
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(repo_filename=repo_file, repo_url='http://fakerepo',
@@ -69,11 +67,11 @@ class TestAddAuthAptRepo(TestCase):
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
     @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
     def test_add_auth_apt_repo_writes_username_password_to_auth_file(
-            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
+            tmpdir):
         """Write apt authentication file when credentials are user:pwd."""
-        tmp_dir = self.tmp_dir()
-        repo_file = self.tmp_path('repo.conf', tmp_dir)
-        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        repo_file = tmpdir.join('repo.conf')
+        auth_file = tmpdir.join('auth.conf')
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(
@@ -91,11 +89,11 @@ class TestAddAuthAptRepo(TestCase):
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
     @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
     def test_add_auth_apt_repo_writes_bearer_resource_token_to_auth_file(
-            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp):
+            self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
+            tmpdir):
         """Write apt authentication file when credentials are bearer token."""
-        tmp_dir = self.tmp_dir()
-        repo_file = self.tmp_path('repo.conf', tmp_dir)
-        auth_file = self.tmp_path('auth.conf', tmp_dir)
+        repo_file = tmpdir.join('repo.conf')
+        auth_file = tmpdir.join('auth.conf')
         m_get_apt_auth_file.return_value = auth_file
 
         add_auth_apt_repo(


### PR DESCRIPTION
add_apt_pinning incorrectly assumed that FIPS repositories would live behind a private-ppa.launchpad.net/ url and would incorrectly calculate origin based on the expected LP_PPA origin line.

Staging and production FIPS/ESM/CC services now live behind a separate haproxy service that is not hosted as a Launchpad private-ppa. So, aptURLs related to those services live at something like esm.staging.canonical.com/fips instead of private-ppa.launchpad.net.

As a result, the entitlements should reference a expected PPA Origin which will be common across either production and staging services instead of calculating that origin.

Fixes #238 