### PR TITLE
Bug/gh 214 no update update on disable

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -59,6 +59,8 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
         the repo PPA.
     """
     series = util.get_platform_info('series')
+    if repo_url.endswith('/'):
+        repo_url = repo_url[:-1]
     if not valid_apt_credentials(repo_url, series, credentials):
         raise InvalidAPTCredentialsError(
             'Invalid APT credentials provided for %s' % repo_url)
@@ -79,6 +81,8 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
     else:
         auth_content = APT_AUTH_HEADER
     _protocol, repo_path = repo_url.split('://')
+    if repo_path.endswith('/'):  # strip trailing slash
+        repo_path = repo_path[:-1]
     auth_content += (
         'machine {repo_path}/ubuntu/ login {login} password'
         ' {password}\n'.format(
@@ -104,6 +108,8 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
     elif fingerprint:
         util.subp(['apt-key', 'del', fingerprint], capture=True)
     _protocol, repo_path = repo_url.split('://')
+    if repo_path.endswith('/'):  # strip trailing slash
+        repo_path = repo_path[:-1]
     apt_auth_file = get_apt_auth_file_from_apt_config()
     if os.path.exists(apt_auth_file):
         apt_auth = util.load_file(apt_auth_file)
@@ -121,6 +127,8 @@ def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
     """Add an apt preferences file and pin for a PPA."""
     series = util.get_platform_info('series')
     _protocol, repo_path = repo_url.split('://')
+    if repo_path.endswith('/'):  # strip trailing slash
+        repo_path = repo_path[:-1]
     content = (
         'Package: *\n'
         'Pin: release o={origin}, n={series}\n'
@@ -144,13 +152,15 @@ def get_apt_auth_file_from_apt_config():
 def find_apt_list_files(repo_url, series):
     """List any apt files in APT_CONFIG_LISTS_DIR given repo_url and series."""
     _protocol, repo_path = repo_url.split('://')
+    if repo_path.endswith('/'):  # strip trailing slash
+        repo_path = repo_path[:-1]
     lists_dir = '/var/lib/apt/lists'
     out, _err = util.subp(
         ['apt-config', 'shell', 'key', APT_CONFIG_LISTS_DIR])
     if out:  # then lists dir is present in config
         lists_dir = out.split("'")[1]
 
-    aptlist_filename = repo_path.rstrip('/').replace('/', '_')
+    aptlist_filename = repo_path.replace('/', '_')
     return glob.glob(
         os.path.join(lists_dir, aptlist_filename + '_dists_%s*' % series))
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -20,7 +20,7 @@ APT_AUTH_HEADER = """
 
 
 class InvalidAPTCredentialsError(RuntimeError):
-    """Raised when invalid token is provided for APT PPA access"""
+    """Raised when invalid token is provided for APT access"""
     pass
 
 
@@ -64,7 +64,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
     if not valid_apt_credentials(repo_url, series, credentials):
         raise InvalidAPTCredentialsError(
             'Invalid APT credentials provided for %s' % repo_url)
-    logging.info('Enabling authenticated apt PPA: %s', repo_url)
+    logging.info('Enabling authenticated repo: %s', repo_url)
     content = (
         'deb {url}/ubuntu {series} main\n'
         '# deb-src {url}/ubuntu {series} main\n'.format(
@@ -92,7 +92,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
         logging.debug('Copying %s to %s', keyring_file, APT_KEYS_DIR)
         shutil.copy(keyring_file, APT_KEYS_DIR)
     elif fingerprint:
-        logging.debug('Importing APT PPA key %s', fingerprint)
+        logging.debug('Importing APT key %s', fingerprint)
         util.subp(
             ['apt-key', 'adv', '--keyserver', 'keyserver.ubuntu.com',
              '--recv-keys', fingerprint], capture=True)
@@ -101,7 +101,7 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
 def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
                          fingerprint=None):
     """Remove an authenticated apt repo and credentials to the system"""
-    logging.info('Removing authenticated apt PPA: %s', repo_url)
+    logging.info('Removing authenticated apt repo: %s', repo_url)
     util.del_file(repo_filename)
     if keyring_file:
         util.del_file(keyring_file)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -160,8 +160,6 @@ def action_disable(args, cfg):
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     if entitlement.disable():
-        if hasattr(entitlement, 'repo_url'):
-            util.subp(['apt-get', 'update'], capture=True)
         return 0
     else:
         return 1

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -43,7 +43,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
             util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                       '--assume-yes'] + self.packages, capture=True)
+                       '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
         return True

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -39,6 +39,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
+        apt.remove_apt_list_files(repo_url, series)
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
             util.subp(['apt-get', 'remove', '--frontend=noninteractive',

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -34,6 +34,7 @@ class CISEntitlement(repo.RepoEntitlement):
         if not repo_url:
             repo_url = self.repo_url
         apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
+        apt.remove_apt_list_files(repo_url, series)
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
             util.subp(['apt-get', 'remove', '--frontend=noninteractive',

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -38,7 +38,7 @@ class CISEntitlement(repo.RepoEntitlement):
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
             util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                       '--assume-yes'] + self.packages, capture=True)
+                       '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
         return True

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -40,6 +40,7 @@ class ESMEntitlement(repo.RepoEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
+        apt.remove_apt_list_files(repo_url, series)
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -40,7 +40,6 @@ class ESMEntitlement(repo.RepoEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
-        apt.remove_apt_list_files(repo_url, series)
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -106,7 +106,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             apt.remove_apt_list_files(repo_url, series)
             try:
                 util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                           '--assume-yes'] + self.packages, capture=True)
+                           '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
         if not silent:

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -147,7 +147,9 @@ def process_directives(cfg):
     if not cfg:
         return
     directives = cfg.get('entitlement', {}).get('directives', {})
-    remote_server = directives.get('remoteServer')
+    remote_server = directives.get('remoteServer', '')
+    if remote_server.endswith('/'):
+        remote_server = remote_server[:-1]
     if remote_server:
         util.subp(['/snap/bin/canonical-livepatch', 'config',
                    'remote-server=%s' % remote_server], capture=True)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -73,6 +73,7 @@ class RepoEntitlement(base.UAEntitlement):
         if not os.path.exists(apt.CA_CERTIFICATES_FILE):
             util.subp(['apt-get', 'install', 'ca-certificates'], capture=True)
         try:
+            print('Updating package lists ...')
             util.subp(['apt-get', 'update'], capture=True)
             if self.packages:
                 print(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -1,11 +1,13 @@
-import glob
 import logging
 import os
+import re
 
 from uaclient import apt
 from uaclient.entitlements import base
 from uaclient import status
 from uaclient import util
+
+APT_DISABLED_PIN = '-32768'
 
 
 class RepoEntitlement(base.UAEntitlement):
@@ -96,13 +98,14 @@ class RepoEntitlement(base.UAEntitlement):
             return status.INAPPLICABLE, details
         entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
-            return status.INACTIVE, '%s PPA is not configured' % self.title
+            return status.INACTIVE, '%s is not configured' % self.title
         directives = entitlement_cfg['entitlement'].get('directives', {})
         repo_url = directives.get('aptURL')
         if not repo_url:
             repo_url = self.repo_url
         protocol, repo_path = repo_url.split('://')
-        apt_repo_file = repo_url.split('://')[1].replace('/', '_')
-        if glob.glob('/var/lib/apt/lists/%s*' % apt_repo_file):
-            return status.ACTIVE, '%s PPA is active' % self.title
-        return status.INACTIVE, '%s PPA is not configured' % self.title
+        out, _err = util.subp(['apt-cache', 'policy'])
+        match = re.search(r'(?P<pin>(-)?\d+) %s' % repo_url, out)
+        if match and match.group('pin') != APT_DISABLED_PIN:
+            return status.ACTIVE, '%s is active' % self.title
+        return status.INACTIVE, '%s is not configured' % self.title

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -125,6 +125,7 @@ class TestCommonCriteriaEntitlementEnable:
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout = (
+            'Updating package lists ...\n'
             'Installing Canonical Common Criteria EAL2 Provisioning'
             ' packages ...\nCanonical Common Criteria EAL2 Provisioning'
             ' enabled.\nPlease follow instructions in'

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -54,7 +54,7 @@ class TestCommonCriteriaEntitlementCanEnable:
         entitlement = CommonCriteriaEntitlement(cfg)
         op_status, op_status_details = entitlement.operational_status()
         assert status.INACTIVE == op_status
-        details = '%s PPA is not configured' % entitlement.title
+        details = '%s is not configured' % entitlement.title
         assert details == op_status_details
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert True is entitlement.can_enable()
@@ -73,7 +73,7 @@ class TestCommonCriteriaEntitlementEnable:
             self, m_getuid, m_platform_info, m_subp, tmpdir,
             apt_transport_https, ca_certificates):
         """When entitled, configure apt repo auth token, pinning and url."""
-
+        m_subp.return_value = ('fakeout', '')
         original_exists = os.path.exists
 
         def exists(path):
@@ -104,7 +104,7 @@ class TestCommonCriteriaEntitlementEnable:
             mock.call('/etc/apt/sources.list.d/ubuntu-cc-xenial.list',
                       'http://CC', 'TOKEN', None, 'APTKEY')]
 
-        subp_apt_cmds = []
+        subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
 
         if apt_transport_https:
             subp_apt_cmds.append(

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -88,6 +88,7 @@ class TestCISEntitlementEnable(TestCase):
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout = (
+            'Updating package lists ...\n'
             'Installing Canonical CIS Benchmark Audit Tool packages ...\n'
             'Canonical CIS Benchmark Audit Tool enabled.\n')
         assert expected_stdout == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -61,6 +61,7 @@ class TestCISEntitlementEnable(TestCase):
             self, m_getuid, m_platform_info, m_subp):
         """When entitled, configure apt repo auth token, pinning and url."""
         m_platform_info.return_value = 'xenial'
+        m_subp.return_value = ('fakeout', '')
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
         cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
@@ -79,6 +80,7 @@ class TestCISEntitlementEnable(TestCase):
                       'http://CIS', 'TOKEN', None, 'APTKEY')]
 
         subp_apt_cmds = [
+            mock.call(['apt-cache', 'policy']),
             mock.call(['apt-get', 'update'], capture=True),
             mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'],
                       capture=True)]

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -173,8 +173,7 @@ class TestFIPSEntitlementDisable:
         assert [mock.call('http://FIPS', 'xenial')] == m_rm_list.call_args_list
         apt_cmd = mock.call(
             ['apt-get', 'remove', '--frontend=noninteractive',
-             '--assume-yes'] + entitlement.packages,
-            capture=True)
+             '--assume-yes'] + entitlement.packages)
         assert [apt_cmd] == m_subp.call_args_list
 
     @mock.patch('uaclient.util.get_platform_info')

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -1,7 +1,11 @@
 """Tests related to uaclient.entitlement.base module."""
 
-import mock
 from io import StringIO
+import itertools
+import mock
+import os
+
+import pytest
 
 from uaclient import config
 from uaclient.entitlements.fips import FIPSEntitlement
@@ -115,3 +119,74 @@ class TestFIPSEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         assert 0 == m_add_pinning.call_count
         assert 'ERROR    Cannot setup apt pin' in caplog_text()
+
+
+class TestFIPSEntitlementDisable:
+
+    # Paramterize True/False for silent and force
+    @pytest.mark.parametrize(
+        'silent,force', itertools.product([False, True], repeat=2))
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_disable', return_value=False)
+    def test_disable_returns_false_on_can_disable_false_and_does_nothing(
+            self, m_can_disable, m_platform_info, silent, force):
+        """When can_disable is false disable returns false and noops."""
+        entitlement = FIPSEntitlement({})
+
+        with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
+            assert False is entitlement.disable(silent, force)
+        assert [mock.call(silent, force)] == m_can_disable.call_args_list
+        assert 0 == m_remove_apt.call_count
+
+    @mock.patch('uaclient.apt.remove_apt_list_files')
+    @mock.patch('uaclient.apt.remove_auth_apt_repo')
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_disable', return_value=True)
+    def test_disable_returns_false_and_removes_apt_config_on_force(
+            self, m_can_disable, m_platform_info, m_rm_auth, m_rm_list,
+            tmpdir, caplog_text):
+        """When can_disable, disable removes apt configuration when force."""
+        m_platform_info.return_value = 'xenial'
+        cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+        cfg.write_cache('machine-token', FIPS_MACHINE_TOKEN)
+        cfg.write_cache('machine-access-fips', FIPS_RESOURCE_ENTITLED)
+        entitlement = FIPSEntitlement(cfg)
+
+        original_exists = os.path.exists
+
+        def fake_exists(path):
+            if path == '/etc/apt/preferences.d/ubuntu-fips-xenial':
+                return True
+            return original_exists(path)
+
+        with mock.patch('os.path.exists', side_effect=fake_exists):
+            with mock.patch('uaclient.apt.os.unlink') as m_unlink:
+                with mock.patch('uaclient.util.subp') as m_subp:
+                    assert False is entitlement.disable(True, True)
+        assert [mock.call(True, True)] == m_can_disable.call_args_list
+        calls = [mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial')]
+        assert calls == m_unlink.call_args_list
+        auth_call = mock.call(
+            '/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
+            'http://FIPS', '/etc/apt/trusted.gpg.d/ubuntu-fips-keyring.gpg')
+        assert [auth_call] == m_rm_auth.call_args_list
+        assert [mock.call('http://FIPS', 'xenial')] == m_rm_list.call_args_list
+        apt_cmd = mock.call(
+            ['apt-get', 'remove', '--frontend=noninteractive',
+             '--assume-yes'] + entitlement.packages,
+            capture=True)
+        assert [apt_cmd] == m_subp.call_args_list
+
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_disable', return_value=True)
+    def test_disable_returns_false_does_nothing_by_default(
+            self, m_can_disable, m_platform_info, caplog_text):
+        """When can_disable, disable does nothing without force param."""
+        entitlement = FIPSEntitlement({})
+
+        with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
+            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+                assert False is entitlement.disable()
+        assert [mock.call(False, False)] == m_can_disable.call_args_list
+        assert 0 == m_remove_apt.call_count
+        assert 'Warning: no option to disable FIPS\n' == m_stdout.getvalue()


### PR DESCRIPTION
No longer run apt-get update after ua disable <entitlement>.

Additional bug fixes:
   - scrub repo_url to remove optional trailing / in apt config functions to avoid double // in apt config files
   - call apt-cache policy to determine if an entitlement is enabled since we soon will seed /etc/apt/sources.list.d file for esm (though it won't be authenticated/enabled) which will produce /var/lib/apt/lists/* files for esm on trusty.
   - livepatch remoteServer url from ua-contracts comes with trailing / character that livepatch snap does not like https://github.com/CanonicalLtd/ua-contracts/issues/215


Add the following helper functions to uaclient.apt:
 - find_apt_list_files: list files related to a repo_url in /var/lib/apt/lists/*
 - remove_apt_list_files: remove said files above

From fips*, cc and cis-audit entitlements, call remove_apt_list_files to disable the entitlement

Fixes: #214 