### PR TITLE
Bug/gh 234: fips install packages. Fix invalid apt install/remove command flags

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -161,8 +161,8 @@ def find_apt_list_files(repo_url, series):
         lists_dir = out.split("'")[1]
 
     aptlist_filename = repo_path.replace('/', '_')
-    return glob.glob(
-        os.path.join(lists_dir, aptlist_filename + '_dists_%s*' % series))
+    return sorted(glob.glob(
+        os.path.join(lists_dir, aptlist_filename + '_dists_%s*' % series)))
 
 
 def remove_apt_list_files(repo_url, series):

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -43,8 +43,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
         apt.remove_apt_list_files(repo_url, series)
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
-            util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                       '--assume-yes'] + self.packages)
+            util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
         return True

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -37,8 +37,7 @@ class CISEntitlement(repo.RepoEntitlement):
         apt.remove_apt_list_files(repo_url, series)
         print('Removing packages: %s' % ', '.join(self.packages))
         try:
-            util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                       '--assume-yes'] + self.packages)
+            util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
         return True

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -9,7 +9,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
     packages = ['openssh-client-hmac', 'openssh-server-hmac',
-                'libssl1.0.0-hmac', 'linux-fips strongswan-hmac',
+                'libssl1.0.0-hmac', 'linux-fips', 'strongswan-hmac',
                 'openssh-client', 'openssh-server', 'openssl', 'libssl1.0.0',
                 'fips-initramfs', 'strongswan']
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -35,8 +35,8 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     os.unlink(repo_pref_file)
             apt.remove_apt_list_files(repo_url, series)
             try:
-                util.subp(['apt-get', 'remove', '--frontend=noninteractive',
-                           '--assume-yes'] + self.packages)
+                util.subp(
+                    ['apt-get', 'remove', '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
         if not silent:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -64,18 +64,19 @@ class RepoEntitlement(base.UAEntitlement):
             apt.add_ppa_pinning(
                 repo_pref_file, repo_url, self.origin, self.repo_pin_priority)
 
-        prerequisite_packages = []
+        prerequisite_pkgs = []
         if not os.path.exists(apt.APT_METHOD_HTTPS_FILE):
-            prerequisite_packages.append('apt-transport-https')
+            prerequisite_pkgs.append('apt-transport-https')
         if not os.path.exists(apt.CA_CERTIFICATES_FILE):
-            prerequisite_packages.append('ca-certificates')
+            prerequisite_pkgs.append('ca-certificates')
 
-        if prerequisite_packages:
+        if prerequisite_pkgs:
             print('Installing prerequisites: {}'.format(
-                ', '.join(prerequisite_packages)))
+                ', '.join(prerequisite_pkgs)))
             try:
-                util.subp(['apt-get', 'install'] + prerequisite_packages,
-                          capture=True)
+                util.subp(
+                    ['apt-get', 'install', '--assume-yes'] + prerequisite_pkgs,
+                    capture=True)
             except util.ProcessExecutionError as e:
                 logging.error(str(e))
                 return False
@@ -91,7 +92,9 @@ class RepoEntitlement(base.UAEntitlement):
                 util.subp(['apt-get', 'update'], capture=True)
                 print(
                     'Installing {title} packages ...'.format(title=self.title))
-                util.subp(['apt-get', 'install'] + self.packages, capture=True)
+                util.subp(
+                    ['apt-get', 'install', '--assume-yes'] + self.packages,
+                    capture=True)
             except util.ProcessExecutionError:
                 self.disable(silent=True, force=True)
                 logging.error(

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -106,26 +106,28 @@ class TestCommonCriteriaEntitlementEnable:
 
         subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
 
-        prerequisite_packages = []
+        prerequisite_pkgs = []
         if apt_transport_https:
-            prerequisite_packages.append('apt-transport-https')
+            prerequisite_pkgs.append('apt-transport-https')
         if ca_certificates:
-            prerequisite_packages.append('ca-certificates')
+            prerequisite_pkgs.append('ca-certificates')
 
-        if prerequisite_packages:
+        if prerequisite_pkgs:
             expected_stdout = (
                 'Installing prerequisites: %s\n' % ', '.join(
-                    prerequisite_packages))
+                    prerequisite_pkgs))
             subp_apt_cmds.append(
-                mock.call(['apt-get', 'install'] + prerequisite_packages,
-                          capture=True))
+                mock.call(
+                    ['apt-get', 'install', '--assume-yes'] + prerequisite_pkgs,
+                    capture=True))
         else:
             expected_stdout = ''
 
         subp_apt_cmds.extend([
             mock.call(['apt-get', 'update'], capture=True),
-            mock.call(['apt-get', 'install', 'ubuntu-commoncriteria'],
-                      capture=True)])
+            mock.call(
+                ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
+                capture=True)])
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -106,14 +106,21 @@ class TestCommonCriteriaEntitlementEnable:
 
         subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
 
+        prerequisite_packages = []
         if apt_transport_https:
-            subp_apt_cmds.append(
-                mock.call(['apt-get', 'install', 'apt-transport-https'],
-                          capture=True))
+            prerequisite_packages.append('apt-transport-https')
         if ca_certificates:
+            prerequisite_packages.append('ca-certificates')
+
+        if prerequisite_packages:
+            expected_stdout = (
+                'Installing prerequisites: %s\n' % ', '.join(
+                    prerequisite_packages))
             subp_apt_cmds.append(
-                mock.call(['apt-get', 'install', 'ca-certificates'],
+                mock.call(['apt-get', 'install'] + prerequisite_packages,
                           capture=True))
+        else:
+            expected_stdout = ''
 
         subp_apt_cmds.extend([
             mock.call(['apt-get', 'update'], capture=True),
@@ -124,7 +131,7 @@ class TestCommonCriteriaEntitlementEnable:
         # No apt pinning for cc
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
-        expected_stdout = (
+        expected_stdout += (
             'Updating package lists ...\n'
             'Installing Canonical Common Criteria EAL2 Provisioning'
             ' packages ...\nCanonical Common Criteria EAL2 Provisioning'

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -82,8 +82,9 @@ class TestCISEntitlementEnable(TestCase):
         subp_apt_cmds = [
             mock.call(['apt-cache', 'policy']),
             mock.call(['apt-get', 'update'], capture=True),
-            mock.call(['apt-get', 'install', 'ubuntu-cisbenchmark-16.04'],
-                      capture=True)]
+            mock.call(
+                ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
+                capture=True)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cis-audit

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -90,10 +90,12 @@ class TestFIPSEntitlementEnable:
         apt_pinning_calls = [
             mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial',
                       'http://FIPS', 'UbuntuFIPS', 1001)]
+        install_cmd = mock.call(
+            ['apt-get', 'install', '--assume-yes'] + fips_entitlement.packages,
+            capture=True)
+
         subp_calls = [
-            mock.call(['apt-get', 'update'], capture=True),
-            mock.call(['apt-get', 'install'] + fips_entitlement.packages,
-                      capture=True)]
+            mock.call(['apt-get', 'update'], capture=True), install_cmd]
 
         assert [mock.call()] == m_can_enable.call_args_list
         assert add_apt_calls == m_add_apt.call_args_list

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -175,8 +175,7 @@ class TestFIPSEntitlementDisable:
         assert [auth_call] == m_rm_auth.call_args_list
         assert [mock.call('http://FIPS', 'xenial')] == m_rm_list.call_args_list
         apt_cmd = mock.call(
-            ['apt-get', 'remove', '--frontend=noninteractive',
-             '--assume-yes'] + fips_entitlement.packages)
+            ['apt-get', 'remove', '--assume-yes'] + fips_entitlement.packages)
         assert [apt_cmd] == m_subp.call_args_list
 
     @mock.patch('uaclient.util.get_platform_info')

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -36,11 +36,11 @@ class TestFindAptListFilesFromRepoSeries:
         repo_url = 'http://c.com/fips-updates/'
         _protocol, repo_path = repo_url.split('://')
         prefix = repo_path.rstrip('/').replace('/', '_')
-        paths = [
+        paths = sorted([
             tmpdir.join(prefix + '_dists_nomatch').strpath,
             tmpdir.join(prefix + '_dists_xenial_InRelease').strpath,
             tmpdir.join(
-                prefix + '_dists_xenial_main_binary-amd64_Packages').strpath]
+                prefix + '_dists_xenial_main_binary-amd64_Packages').strpath])
         for path in paths:
             util.write_file(path, '')
 


### PR DESCRIPTION
* apt: install prerequisites as single apt cmd
* apt: don't pass invalid --frontend to apt-get remove calls
* add auth cfg setup after prefilght check and prerequisite install
* fips: drop FIPSEntitlement.enable duplicate code. rely on Repo.enable
* apt: fix spurrious apt test by ordering glob.glob output for find_apt_list_files

Fixes: #234 
Fixes: #258 
