### PR TITLE
Depend on python3-pkg-resources

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,8 @@ Package: ubuntu-advantage-tools
 Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
-         ${shlibs:Depends}
+         ${shlibs:Depends},
+         python3-pkg-resources
 XB-Python-Version: ${python:Versions}
 Description: management tools for Ubuntu Advantage
  Ubuntu Advantage is the professional package of tooling, technology


### PR DESCRIPTION
pkg_resources is imported when the /usr/bin/ua script is run.

This fixes issue #271 