### PR TITLE
apt/deb: write esm apt sources on trusty. handle upgrade path to new series

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -9,7 +9,12 @@ migrate_apt_sources()
 '
 }
 
-configure_apt_sources()
+case "$1" in
+    configure)
+      configure_apt_sources()
+    ;;
+esac
+exit 0
 
 #DEBHELPER#
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -16,10 +16,7 @@ EOF
 
 case "$1" in
     configure)
-      grep -iq trusty /etc/os-release
-      if [ $? ]; then
-          configure_esm_source
-      fi
+      grep -iq trusty /etc/os-release && configure_esm_source
       ;;
 esac
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,20 +1,29 @@
 #!/bin/sh -e
 
-configure_apt_sources() {
-    python3 -c '
-    from uaclient.apt import configure_default_apt_sources, migrate_apt_sources
+ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
 
-configure_default_apt_sources()
-migrate_apt_sources()
-'
+configure_esm_source() {
+    if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
+        cat > $ESM_APT_SOURCE_FILE <<EOF
+# Written by ubuntu-advantage-tools during package postinst
+deb https://esm.ubuntu.com/ubuntu trusty security
+deb https://esm.ubuntu.com/ubuntu trusty updates
+# deb-src https://esm.staging.ubuntu.com/ubuntu security
+# deb-src https://esm.staging.ubuntu.com/ubuntu updates
+EOF
+    fi
 }
 
 case "$1" in
     configure)
-      configure_apt_sources()
-    ;;
+      grep -iq trusty /etc/os-release
+      if [ $? ]; then
+          configure_esm_source
+      fi
+      ;;
 esac
-exit 0
 
 #DEBHELPER#
+exit 0
+
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,14 +1,15 @@
 #!/bin/sh -e
 
-install_default_apt_sources() {
+configure_apt_sources() {
     python3 -c '
-from uaclient.apt import reconfigure_apt_sources
+    from uaclient.apt import configure_default_apt_sources, migrate_apt_sources
 
-reconfigure_apt_sources()
+configure_default_apt_sources()
+migrate_apt_sources()
 '
 }
 
-install_default_apt_sources()
+configure_apt_sources()
 
 #DEBHELPER#
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+install_default_apt_sources() {
+    python3 -c '
+from uaclient.apt import reconfigure_apt_sources
+
+reconfigure_apt_sources()
+'
+}
+
+install_default_apt_sources()
+
+#DEBHELPER#
+

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,10 +1,21 @@
 #!/bin/sh -e
 
-CACHE_FILE=/var/cache/ubuntu-advantage-tools/ubuntu-advantage-status.cache
 
-if [ "$1" = purge -a -f "$CACHE_FILE" ]; then
-    rm "$CACHE_FILE"
-fi
+remove_apt_files() {
+    python3 -c '
+    from uaclient.apt import migrate_apt_sources
+
+migrate_apt_sources(clean=True)
+'
+
+}
+
+case "$1" in
+    purge|remove)
+        remove_apt_files()
+    ;;
+esac
+exit 0
 
 #DEBHELPER#
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -3,7 +3,7 @@
 
 remove_apt_files() {
     python3 -c '
-    from uaclient.apt import migrate_apt_sources
+from uaclient.apt import migrate_apt_sources
 
 migrate_apt_sources(clean=True)
 '
@@ -12,10 +12,8 @@ migrate_apt_sources(clean=True)
 
 case "$1" in
     purge|remove)
-        remove_apt_files()
-    ;;
+        remove_apt_files
+        ;;
 esac
 exit 0
-
-#DEBHELPER#
 

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -191,7 +191,6 @@ def reconfigure_apt_sources(platform_info=None):
 
     cfg = config.UAConfig()
     for ent_cls in entitlements.ENTITLEMENT_CLASSES:
-        import pdb; pdb.set_trace()
         if not hasattr(ent_cls, 'repo_url'):
             continue
         repo_filename = ent_cls.repo_list_file_tmpl.format(

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -1,6 +1,7 @@
 import glob
 import logging
 import os
+import re
 import shutil
 
 from uaclient import util
@@ -170,3 +171,53 @@ def remove_apt_list_files(repo_url, series):
     for path in find_apt_list_files(repo_url, series):
         if os.path.exists(path):
             os.unlink(path)
+
+
+def reconfigure_apt_sources(platform_info=None):
+    """Reconfigure apt sources for the given series.
+
+    Automatically setup an unauthenticated apt source for esm
+    production if not already present.
+    For each configured and enabled entitlement, update the sources files to
+    the new series.
+
+    @param platform_info: dict of platform information for testing
+    """
+    from uaclient import config
+    from uaclient import entitlements
+
+    if not platform_info:  # for testing
+        platform_info = util.get_platform_info()
+
+    cfg = config.UAConfig()
+    for ent_cls in entitlements.ENTITLEMENT_CLASSES:
+        import pdb; pdb.set_trace()
+        if not hasattr(ent_cls, 'repo_url'):
+            continue
+        repo_filename = ent_cls.repo_list_file_tmpl.format(
+            name=ent_cls.name, series=platform_info['series'])
+        repo_list_glob = ent_cls.repo_list_file_tmpl.format(
+            name=ent_cls.name, series='*')
+        resource_cfg = cfg.entitlements.get(ent_cls.name, {})
+        directives = resource_cfg.get('entitlement', {}).get('directives', {})
+        repo_url = directives.get('aptURL')
+        if not repo_url:
+            repo_url = ent_cls.repo_url
+        out, _err = util.subp(['apt-cache', 'policy'])
+        enabled = bool(re.search(r'(?P<pin>(-)?\d+) %s' % repo_url, out))
+        if not os.path.exists(repo_filename):
+            if ent_cls.name == 'esm':
+                if platform_info['release'] == '14.04':
+                    logging.info(
+                        'Providing unauthenticated ESM apt source file: %s',
+                        repo_filename)
+                    add_auth_apt_repo(repo_filename, repo_url)
+            elif enabled:  # And not esm
+                logging.info('Upgrading existing "%s" apt source files: %s',
+                             ent_cls.title, repo_filename)
+
+                add_auth_apt_repo(repo_filename, repo_url)
+        for path in glob.glob(repo_list_glob):
+            if platform_info['series'] not in path:
+                logging.info('Removing old apt source file: %s', path)
+                os.unlink(path)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -51,8 +51,8 @@ def valid_apt_credentials(repo_url, series, credentials):
     return False
 
 
-def add_auth_apt_repo(repo_filename, repo_url, credentials=None,
-                      keyring_file=None, fingerprint=None, pockets=('main',)):
+def add_auth_apt_repo(repo_filename, repo_url, credentials, keyring_file=None,
+                      fingerprint=None, pockets=('main',)):
     """Add an authenticated apt repo and credentials to the system.
 
     @raises: InvalidAPTCredentialsError when the token provided can't access
@@ -61,10 +61,9 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials=None,
     series = util.get_platform_info('series')
     if repo_url.endswith('/'):
         repo_url = repo_url[:-1]
-    if credentials:
-        if not valid_apt_credentials(repo_url, series, credentials):
-            raise InvalidAPTCredentialsError(
-                'Invalid APT credentials provided for %s' % repo_url)
+    if not valid_apt_credentials(repo_url, series, credentials):
+        raise InvalidAPTCredentialsError(
+            'Invalid APT credentials provided for %s' % repo_url)
     logging.info('Enabling authenticated repo: %s', repo_url)
     content = ''
     for pocket in pockets:
@@ -72,8 +71,6 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials=None,
                     '# deb-src {url}/ubuntu {series} {pocket}\n'.format(
                         url=repo_url, series=series, pocket=pocket))
     util.write_file(repo_filename, content)
-    if not credentials:
-        return
     try:
         login, password = credentials.split(':')
     except ValueError:  # Then we have a bearer token

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -14,6 +14,7 @@ class ESMEntitlement(repo.RepoEntitlement):
     description = (
         'Ubuntu Extended Security Maintenance archive'
         ' (https://ubuntu.com/esm)')
+    repo_pockets = ('security', 'updates')
     repo_url = 'https://esm.ubuntu.com'
     repo_key_file = 'ubuntu-esm-keyring.gpg'
 

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -16,6 +16,7 @@ class RepoEntitlement(base.UAEntitlement):
     repo_pref_file_tmpl = '/etc/apt/preferences.d/ubuntu-{name}-{series}'
     origin = None   # The repo Origin value for setting pinning
 
+    repo_pockets = ('main', )  # Overriden in ESMEntitlement
     repo_url = 'UNSET'
     repo_key_file = 'UNSET'  # keyfile delivered by ubuntu-cloudimage-keyring
     repo_pin_priority = None      # Optional repo pin priority in subclass
@@ -82,7 +83,8 @@ class RepoEntitlement(base.UAEntitlement):
                 return False
         try:
             apt.add_auth_apt_repo(
-                repo_filename, repo_url, token, keyring_file, ppa_fingerprint)
+                repo_filename, repo_url, token, keyring_file, ppa_fingerprint,
+                pockets=self.repo_pockets)
         except apt.InvalidAPTCredentialsError as e:
             logging.error(str(e))
             return False

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -114,7 +114,7 @@ class TestCommonCriteriaEntitlementEnable:
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cc-xenial.list',
-                      'http://CC', 'TOKEN', None, 'APTKEY')]
+                      'http://CC', 'TOKEN', None, 'APTKEY', pockets=('main',))]
 
         subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
 

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -77,7 +77,8 @@ class TestCISEntitlementEnable(TestCase):
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list',
-                      'http://CIS', 'TOKEN', None, 'APTKEY')]
+                      'http://CIS', 'TOKEN', None, 'APTKEY', pockets=('main',))
+        ]
 
         subp_apt_cmds = [
             mock.call(['apt-cache', 'policy']),

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -97,7 +97,8 @@ class TestFIPSEntitlementEnable:
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-fips-xenial.list',
-                      'http://FIPS', 'TOKEN', None, 'APTKEY')]
+                      'http://FIPS', 'TOKEN', None, 'APTKEY',
+                      pockets=('main',))]
         apt_pinning_calls = [
             mock.call('/etc/apt/preferences.d/ubuntu-fips-xenial',
                       'http://FIPS', 'UbuntuFIPS', 1001)]

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -70,11 +70,8 @@ class TestLivepatchContractStatus:
         livepatch_unentitled['entitlement']['entitled'] = False
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', dict(LIVEPATCH_MACHINE_TOKEN))
-        cfg.write_cache('machine-access-livepatch',
-                        dict(LIVEPATCH_RESOURCE_ENTITLED))
+        cfg.write_cache('machine-access-livepatch', livepatch_unentitled)
         entitlement = LivepatchEntitlement(cfg)
-        entitlement.cfg.write_cache(
-            'machine-access-livepatch', livepatch_unentitled)
         assert status.NONE == entitlement.contract_status()
 
 


### PR DESCRIPTION
Package postinst hook will now perform two tasks:
   - call configure_default_apt_sources to write ESM unauthenticated apt source file
   - call migrate_apt_sources to upgrade existing enabled entitlements to a new series
Package postrm will;
  - clean any apt source files written by uaclient
    
Fixes: #213
