### PR TITLE
caplog: bionic caplog fixture defaults to debug-level messages

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -23,6 +23,11 @@ def caplog_text(request):
     """
     try:
         try:
+            # TODO pyest 3.4 is funky and logs debug level by default
+            # https://docs.pytest.org/en/features/logging.html#\
+            #            incompatible-changes-in-pytest-3-4
+            # write_cache debug logs are seen on Bionic in test_livepatch:
+            # test_enable_false_when_can_enable_false
             caplog = request.getfixturevalue('caplog')
         except AttributeError:
             # Older versions of pytest only have getfuncargvalue, which is now

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -259,7 +259,10 @@ class TestLivepatchEntitlementEnable:
         entitlement = LivepatchEntitlement(cfg)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert not entitlement.enable()
-        assert '' == caplog_text()  # No additional logs on can_enable == False
+        info_level_logs = [  # see uaclient/conftest.py
+            line for line in caplog_text().splitlines()
+            if 'DEBUG' not in line]
+        assert [] == info_level_logs
         assert '' == m_stdout.getvalue()  # No additional prints
         assert [mock.call()] == m_can_enable.call_args_list
 


### PR DESCRIPTION
This is a workaround for caplogs on bionic not defaulting to
INFO level or higher.

It also appears that pytest.ini config log_level and caplog.set_level
options have no affect on this setting.

Fixes: #269