### PR TITLE
apt: valid_apt_credentials needs to check pool

### DIFF
--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -84,10 +84,56 @@ class TestValidAptCredentials:
             self, m_exists, m_subp):
         """When apt-helper tool is absent return True without validation."""
         assert True is valid_apt_credentials(
-            repo_url='http://fakerepo', series='xenial', credentials='mycreds')
+            repo_url='http://fakerepo', username='user', password='pwd')
         expected_calls = [mock.call('/usr/lib/apt/apt-helper')]
         assert expected_calls == m_exists.call_args_list
         assert 0 == m_subp.call_count
+
+    @mock.patch('uaclient.apt.os.unlink', return_value=True)
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.os.path.exists', return_value=True)
+    def test_valid_apt_credentials_returns_true_on_valid_creds(
+            self, m_exists, m_subp, m_unlink):
+        """Return true when apt-helper succeeds in authentication to repo."""
+
+        # Success apt-helper response
+        m_subp.return_value = 'Get:1 https://fakerepo\nFetched 285 B in 1s', ''
+
+        assert True is valid_apt_credentials(
+            repo_url='http://fakerepo', username='user', password='pwd')
+        exists_calls = [mock.call('/usr/lib/apt/apt-helper'),
+                        mock.call('/tmp/uaclient-apt-test')]
+        assert exists_calls == m_exists.call_args_list
+        apt_helper_call = mock.call(
+            ['/usr/lib/apt/apt-helper', 'download-file',
+             'http://user:pwd@fakerepo/ubuntu/pool/',
+             '/tmp/uaclient-apt-test'], capture=False)
+        assert [apt_helper_call] == m_subp.call_args_list
+        assert [mock.call('/tmp/uaclient-apt-test')] == m_unlink.call_args_list
+
+    @mock.patch('uaclient.apt.os.unlink', return_value=True)
+    @mock.patch('uaclient.util.subp')
+    @mock.patch('uaclient.apt.os.path.exists', return_value=True)
+    def test_valid_apt_credentials_returns_false_on_invalid_creds(
+            self, m_exists, m_subp, m_unlink):
+        """Return false when apt-helper fails in authentication to repo."""
+
+        # Failure apt-helper response
+        m_subp.side_effect = util.ProcessExecutionError(
+            cmd='apt-helper died', exit_code=100, stdout='Err:1...',
+            stderr='E: Failed to fetch .... 401 Unauthorized')
+
+        assert False is valid_apt_credentials(
+            repo_url='http://fakerepo', username='user', password='pwd')
+        exists_calls = [mock.call('/usr/lib/apt/apt-helper'),
+                        mock.call('/tmp/uaclient-apt-test')]
+        assert exists_calls == m_exists.call_args_list
+        apt_helper_call = mock.call(
+            ['/usr/lib/apt/apt-helper', 'download-file',
+             'http://user:pwd@fakerepo/ubuntu/pool/',
+             '/tmp/uaclient-apt-test'], capture=False)
+        assert [apt_helper_call] == m_subp.call_args_list
+        assert [mock.call('/tmp/uaclient-apt-test')] == m_unlink.call_args_list
 
 
 class TestAddAuthAptRepo:


### PR DESCRIPTION
Since Release files for esm and other repos are not authenticated
uaclient now attempts to access the /pool subdirectory which results in
403 if credentials are invalid.

Fixes: #273