### PR TITLE
util: add caveat_id to sensitive keys

### DIFF
--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -12,7 +12,7 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
                    ['running-in-container'],
                    ['lxc-is-container'])
 
-SENSITIVE_KEYS = ['password']
+SENSITIVE_KEYS = ['caveat_id', 'password']
 
 ETC_MACHINE_ID = '/etc/machine-id'
 DBUS_MACHINE_ID = '/var/lib/dbus/machine-id'


### PR DESCRIPTION
The value for the 'caveat_id' key can contain sensitive information like
a secret, therefore this adds it to the list of sensitive keys that are
filtered out.

Fixes #286