### PR TITLE
logging: fix debug logging

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -367,8 +367,7 @@ def main(sys_argv=None):
         int(log_level)
     except TypeError:
         log_level = getattr(logging, '%s' % cfg.log_file.upper())
-    log_file = logging.DEBUG if args.debug else cfg.log_file
-    setup_logging(log_level, log_file)
+    setup_logging(log_level, cfg.log_file)
     return args.action(args, cfg)
 
 


### PR DESCRIPTION
Setting log_file to logging.DEBUG was copied from the earlier log_level one
just before the try block, but it doesn't make sense with log_file.

Fix #240