### PR TITLE
Pkg fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
          python3-pkg-resources
-XB-Python-Version: ${python:Versions}
 Description: management tools for Ubuntu Advantage
  Ubuntu Advantage is the professional package of tooling, technology
  and expertise from Canonical, helping organisations around the world

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
-DEB_VERSION := $(shell dpkg-parsechangelog --show-field=Version)
+
+include /usr/share/dpkg/pkg-info.mk
 FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 %:


### PR DESCRIPTION
Some minor packaging fixes.

According to https://www.debian.org/doc/packaging-manuals/python-policy/module_packages.html#specifying_versions, `XB-Python-Version` is deprecated. I checked and the trusty build works without it, and there are no lintian errors.

`d/rules ` using `dpkg-parsechangelog` was already a lintian flag (debian-rules-parses-dpkg-parsechangelog), and I used the recommended solution since trusty's `dpkg` is new enough.
```
I: ubuntu-advantage-tools source: debian-rules-parses-dpkg-parsechangelog (line 3)
N: 
N:    The rules file appears to be parsing the output of dpkg-parsechangelog
N:    to determine the current package version name, version, or timestamp,
N:    etc.
N:    
N:    Since dpkg 1.16.1, this could be replaced by including the
N:    /usr/share/dpkg/pkg-info.mk Makefile library and using the
N:    DEB_{SOURCE,VERSION} or SOURCE_DATE_EPOCH variables.
N:    
N:    Using this library is not only cleaner and more efficient, it handles
N:    many corner-cases such as binNMUs, epoch versions, etc.
```