### PR TITLE
Packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ clean:
 	rm -rf *.egg-info/ .tox/ .cache/
 	find . -type f -name '*.pyc' -delete
 	find . -type d -name '*__pycache__' -delete
+	$(MAKE) -C apt-hook clean
 
 deb:
 	@echo Building unsigned debian package

--- a/debian/rules
+++ b/debian/rules
@@ -24,9 +24,9 @@ endif
 endif
 
 override_dh_auto_install:
-	dh_auto_install --sourcedirectory=apt-hook --buildsystem=makefile
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
+	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/debian/rules
+++ b/debian/rules
@@ -27,3 +27,7 @@ override_dh_auto_install:
 	dh_auto_install --sourcedirectory=apt-hook --buildsystem=makefile
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
+
+override_dh_auto_clean:
+	dh_auto_clean
+	make clean

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,10 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild --with bash-completion
-	dh $@ --sourcedirectory=apt-hook --buildsystem=makefile
+
+override_dh_auto_build:
+	dh_auto_build
+	make -C apt-hook build
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ include /usr/share/dpkg/pkg-info.mk
 FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 %:
-	dh $@ --with python3 --buildsystem=pybuild --with bash-completion
+	dh $@ --with python3,bash-completion --buildsystem=pybuild
 
 override_dh_auto_build:
 	dh_auto_build


### PR DESCRIPTION
This started as an investigation of why the tarball was shipping an empty `__pycache__` directory, and that showed some packaging inconsistencies along the way. Basically two build systems shouldn't be used, and the clean target needed was affected.

Fixes issue #281 