### PR TITLE
apt: obtain supported suite directives for apt entitlements

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -7,11 +7,12 @@ ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
 configure_esm_source() {
     if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
         cat > $ESM_APT_SOURCE_FILE <<EOF
-# Written by ubuntu-advantage-tools during package postinst
-deb https://esm.ubuntu.com/ubuntu trusty security
-deb https://esm.ubuntu.com/ubuntu trusty updates
-# deb-src https://esm.ubuntu.com/ubuntu security
-# deb-src https://esm.ubuntu.com/ubuntu updates
+# Written by ubuntu-advantage-tools
+deb https://esm.ubuntu.com/ubuntu trusty-security main
+# deb-src https://esm.ubuntu.com/ubuntu trusty-security main
+
+deb https://esm.ubuntu.com/ubuntu trusty-updates main
+# deb-src https://esm.ubuntu.com/ubuntu trusty-updates main
 EOF
     fi
 }

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -76,7 +76,7 @@ class UAConfig(object):
 
     @property
     def contract_url(self):
-        return self.cfg['contract_url']
+        return self.cfg.get('contract_url', 'https://contracts.canonical.com')
 
     @property
     def data_dir(self):

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -14,7 +14,6 @@ class ESMEntitlement(repo.RepoEntitlement):
     description = (
         'Ubuntu Extended Security Maintenance archive'
         ' (https://ubuntu.com/esm)')
-    repo_pockets = ('security', 'updates')
     repo_url = 'https://esm.ubuntu.com'
     repo_key_file = 'ubuntu-esm-keyring.gpg'
 

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -16,7 +16,6 @@ class RepoEntitlement(base.UAEntitlement):
     repo_pref_file_tmpl = '/etc/apt/preferences.d/ubuntu-{name}-{series}'
     origin = None   # The repo Origin value for setting pinning
 
-    repo_pockets = ('main', )  # Overriden in ESMEntitlement
     repo_url = 'UNSET'
     repo_key_file = 'UNSET'  # keyfile delivered by ubuntu-cloudimage-keyring
     repo_pin_priority = None      # Optional repo pin priority in subclass
@@ -51,6 +50,12 @@ class RepoEntitlement(base.UAEntitlement):
         repo_url = directives.get('aptURL')
         if not repo_url:
             repo_url = self.repo_url
+        repo_suites = directives.get('suites')
+        if not repo_suites:
+            logging.error(
+                'Empty %s apt suites directive from %s',
+                self.name, self.cfg.contract_url)
+            return False
         if self.repo_pin_priority:
             if not self.origin:
                 logging.error(
@@ -83,8 +88,8 @@ class RepoEntitlement(base.UAEntitlement):
                 return False
         try:
             apt.add_auth_apt_repo(
-                repo_filename, repo_url, token, keyring_file, ppa_fingerprint,
-                pockets=self.repo_pockets)
+                repo_filename, repo_url, token, repo_suites,
+                keyring_file, ppa_fingerprint)
         except apt.InvalidAPTCredentialsError as e:
             logging.error(str(e))
             return False

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -32,7 +32,8 @@ CC_RESOURCE_ENTITLED = {
         'entitled': True,
         'directives': {
             'aptURL': 'http://CC',
-            'aptKey': 'APTKEY'
+            'aptKey': 'APTKEY',
+            'suites': ['xenial']
         },
         'affordances': {
             'architectures': ['x86_64', 'ppc64le', 's390x'],
@@ -114,7 +115,7 @@ class TestCommonCriteriaEntitlementEnable:
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cc-xenial.list',
-                      'http://CC', 'TOKEN', None, 'APTKEY', pockets=('main',))]
+                      'http://CC', 'TOKEN', ['xenial'], None, 'APTKEY')]
 
         subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
 

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -26,7 +26,8 @@ CIS_RESOURCE_ENTITLED = {
         'entitled': True,
         'directives': {
             'aptURL': 'http://CIS',
-            'aptKey': 'APTKEY'
+            'aptKey': 'APTKEY',
+            'suites': ['xenial']
         },
         'affordances': {
             'series': []   # Will match all series
@@ -77,8 +78,7 @@ class TestCISEntitlementEnable(TestCase):
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list',
-                      'http://CIS', 'TOKEN', None, 'APTKEY', pockets=('main',))
-        ]
+                      'http://CIS', 'TOKEN', ['xenial'], None, 'APTKEY')]
 
         subp_apt_cmds = [
             mock.call(['apt-cache', 'policy']),


### PR DESCRIPTION
ua-contracts service provides a 'suites' directive which can
be a list or None and describes the supported apt source suites
that can be enabled for a given entitlement.

Also adds default trusty-security and trusty-updates to package postinst.

Enable any supported suites that match the current running series

Fixes: #329
Fixes: #315 