### PR TITLE
security: redact sensitive tokens from ua-contracts responses for public

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -9,6 +9,8 @@ from uaclient.defaults import CONFIG_DEFAULTS, DEFAULT_CONFIG_FILE
 
 LOG = logging.getLogger(__name__)
 
+PRIVATE_SUBDIR = 'private'
+
 
 class ConfigAbsentError(RuntimeError):
     """Raised when no valid config is discovered."""
@@ -30,6 +32,7 @@ class UAConfig(object):
         'machine-access-fips': 'machine-access-fips.json',
         'machine-access-fips-updates': 'machine-access-fips-updates.json',
         'machine-access-livepatch': 'machine-access-livepatch.json',
+        'machine-access-support': 'machine-access-support.json',
         'machine-detach': 'machine-detach.json',
         'machine-token': 'machine-token.json',
         'macaroon': 'sso-macaroon.json',
@@ -145,13 +148,17 @@ class UAConfig(object):
             self._machine_token = self.read_cache('machine-token')
         return self._machine_token
 
-    def data_path(self, key=None):
+    def data_path(self, key=None, private=True):
         """Return the file path in the data directory represented by the key"""
+        if private:
+            data_dir = os.path.join(self.cfg['data_dir'], 'private')
+        else:
+            data_dir = self.cfg['data_dir']
         if not key:
-            return self.cfg['data_dir']
+            return data_dir
         if key in self.data_paths:
-            return os.path.join(self.cfg['data_dir'], self.data_paths[key])
-        return os.path.join(self.cfg['data_dir'], key)
+            return os.path.join(data_dir, self.data_paths[key])
+        return os.path.join(data_dir, key)
 
     def delete_cache(self):
         """Remove all configuration cached response files class attributes."""
@@ -159,27 +166,37 @@ class UAConfig(object):
         self._entitlements = None
         self._machine_token = None
         for key in self.data_paths.keys():
-            cache_path = self.data_path(key)
-            if os.path.exists(cache_path):
-                os.unlink(cache_path)
+            for private in (True, False):
+                cache_path = self.data_path(key, private)
+                if os.path.exists(cache_path):
+                    os.unlink(cache_path)
 
     def read_cache(self, key, quiet=False):
         cache_path = self.data_path(key)
-        if not os.path.exists(cache_path):
-            if not quiet:
-                logging.debug('File does not exist: %s', cache_path)
-            return None
-        content = util.load_file(cache_path)
+        try:
+            content = util.load_file(cache_path)
+        except Exception:
+            public_cache_path = cache_path.replace('%s/' % PRIVATE_SUBDIR, '')
+            try:
+                content = util.load_file(public_cache_path)
+            except Exception:
+                if not os.path.exists(cache_path) and not quiet:
+                    logging.debug('File does not exist: %s', cache_path)
+                return None
         json_content = util.maybe_parse_json(content)
         return json_content if json_content else content
 
-    def write_cache(self, key, content):
-        if not os.path.exists(self.data_dir):
-            os.makedirs(self.data_dir)
-        filepath = self.data_path(key)
+    def write_cache(self, key, content, private=True):
+        filepath = self.data_path(key, private)
+        data_dir = os.path.dirname(filepath)
+        if not os.path.exists(data_dir):
+            os.makedirs(data_dir)
         if not isinstance(content, str):
             content = json.dumps(content)
-        util.write_file(filepath, content)
+        if private:
+            util.write_file(filepath, content, mode=0o600)
+        else:
+            util.write_file(filepath, content)
 
 
 def parse_config(config_path=None):

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -305,11 +305,8 @@ class TestMigrateAptSources:
                 platform_info={'series': 'xenial', 'release': '16.04'})
         assert [] == m_add_apt.call_args_list
         # Only exists checks for for cfg.is_attached and can_enable
-        exists_calls = [
-            mock.call(tmpdir.join('machine-token.json').strpath),
-            mock.call(tmpdir.join('machine-access-cc.json').strpath)]
         assert [] == m_unlink.call_args_list  # remove nothing
-        assert exists_calls == m_exists.call_args_list
+        assert [] == m_exists.call_args_list
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.get_platform_info')
@@ -355,13 +352,10 @@ class TestMigrateAptSources:
                 assert None is migrate_apt_sources(cfg=cfg)
         assert [] == m_add_apt.call_args_list
         # Only exists checks for for cfg.is_attached and can_enable
-        exists_calls = [
-            mock.call(tmpdir.join('machine-token.json').strpath),
-            mock.call(tmpdir.join('machine-access-cc.json').strpath)]
         unlink_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cc-trusty.list')]
         assert unlink_calls == m_unlink.call_args_list  # remove nothing
-        assert exists_calls == m_exists.call_args_list
+        assert [] == m_exists.call_args_list
 
     @mock.patch('uaclient.apt.os.unlink')
     @mock.patch('uaclient.apt.add_auth_apt_repo')

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -12,7 +12,7 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
                    ['running-in-container'],
                    ['lxc-is-container'])
 
-SENSITIVE_KEYS = ['caveat_id', 'password']
+SENSITIVE_KEYS = ['caveat_id', 'password', 'resourceToken', 'machineToken']
 
 ETC_MACHINE_ID = '/etc/machine-id'
 DBUS_MACHINE_ID = '/var/lib/dbus/machine-id'


### PR DESCRIPTION
Create private subdir for ua-contracts responses.
Config.read_cache and write_cache now handle perm errors and fallback
to public files if non-root runs ua status

Fixes: #254