### PR TITLE
apt: ignore *-updates suite if system not configured for series-updates

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -67,7 +67,9 @@ def add_auth_apt_repo(repo_filename, repo_url, credentials, suites,
         raise InvalidAPTCredentialsError(
             'Invalid APT credentials provided for %s' % repo_url)
 
-    updates_enabled = True   # TODO determine from apt-cache policy
+    # Does this system have updates suite enabled?
+    policy, _err = util.subp(['apt-cache', 'policy'])
+    updates_enabled = bool(' %s-updates/' % series in policy)
 
     logging.info('Enabling authenticated repo: %s', repo_url)
     content = ''


### PR DESCRIPTION
ua-contracts sends a 'suites' directive for each entitlement which is a
list of potential suites to enable. For esm, those suites are:
 suites: ['precise', 'trusty-security', 'trusty-updates']

The client will only enable any '*-updates' apt source, if the machine
has already opted into <series>-updates via an apt-cache policy check.

Fixes: #343