### PR TITLE
refresh: add subcommand to refresh all contract details

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -316,9 +316,11 @@ def action_refresh(args, cfg):
         print(ua_status.MESSAGE_NONROOT_USER)
         return 1
     if contract.request_updated_contract(cfg):
-        print('Refreshed Ubuntu Advantage contracts.')
-        logging.debug('Refreshed Ubuntu Advantage contracts.')
+        print(ua_status.MESSAGE_REFRESH_SUCCESS)
+        logging.debug(ua_status.MESSAGE_REFRESH_SUCCESS)
         return 0
+    print(ua_status.MESSAGE_REFRESH_FAILURE)
+    logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
     return 1
 
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -315,10 +315,10 @@ def action_refresh(args, cfg):
     if not cfg.is_attached:
         print(ua_status.MESSAGE_UNATTACHED)
         return 1
-    contract_token = cfg.read_cache('contract-token')
-    if contract_token:
-        contract_token = contract_token['contractToken']
-    if contract.request_contract_updates(cfg, contract_token=contract_token):
+    if os.getuid() != 0:
+        print(ua_status.MESSAGE_NONROOT_USER)
+        return 1
+    if contract.request_contract_updates(cfg):
         print('Refreshed Ubuntu Advantage contracts.')
         logging.debug('Refreshed Ubuntu Advantage contracts.')
         return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -235,8 +235,7 @@ def action_attach(args, cfg):
         try:
             contract_client.request_accounts(macaroon_token=bound_macaroon)
             contract_token = contract.get_contract_token_for_account(
-                contract_client, cfg.accounts[0]['id'],
-                macaroon_token=bound_macaroon)
+                contract_client, bound_macaroon, cfg.accounts[0]['id'])
         except (sso.SSOAuthError, util.UrlError) as e:
             logging.error(str(e))
             print('Could not attach machine. Unable to obtain authenticated'

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -178,8 +178,9 @@ def action_enable(args, cfg):
     @return: 0 on success, 1 otherwise
     """
     if cfg.is_attached and os.getuid() == 0:
-        # Refresh contracts prior to enable
-        contract.request_updated_contracts(cfg)
+        logging.debug('Refreshing contracts prior to enable')
+        if not contract.request_updated_contract(cfg):
+            logging.debugt(ua_status.MESSAGE_REFRESH_FAILURE)
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     return 0 if entitlement.enable() else 1
@@ -234,7 +235,9 @@ def action_attach(args, cfg):
             return 1
     else:
         contract_token = args.token
-
+    if not contract_token:
+        print('No valid contract token available')
+        return 1
     if not contract.request_updated_contract(cfg, contract_token):
         print(
             "Could not attach machine. Error contacting server %s" %
@@ -319,8 +322,7 @@ def action_refresh(args, cfg):
         print(ua_status.MESSAGE_REFRESH_SUCCESS)
         logging.debug(ua_status.MESSAGE_REFRESH_SUCCESS)
         return 0
-    print(ua_status.MESSAGE_REFRESH_FAILURE)
-    logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
+    logging.error(ua_status.MESSAGE_REFRESH_FAILURE)
     return 1
 
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -179,7 +179,10 @@ def action_enable(args, cfg):
     """
     if cfg.is_attached and os.getuid() == 0:
         # Refresh contracts prior to enable
-        contract.request_contract_updates(cfg, contract_token=None)
+        contract_token = cfg.read_cache('contract-token')
+        if contract_token:
+            contract_token = contract_token['contractToken']
+        contract.request_contract_updates(cfg, contract_token=contract_token)
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     return 0 if entitlement.enable() else 1
@@ -312,7 +315,10 @@ def action_refresh(args, cfg):
     if not cfg.is_attached:
         print(ua_status.MESSAGE_UNATTACHED)
         return 1
-    if contract.request_contract_updates(cfg, contract_token=None):
+    contract_token = cfg.read_cache('contract-token')
+    if contract_token:
+        contract_token = contract_token['contractToken']
+    if contract.request_contract_updates(cfg, contract_token=contract_token):
         print('Refreshed Ubuntu Advantage contracts.')
         logging.debug('Refreshed Ubuntu Advantage contracts.')
         return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -179,10 +179,7 @@ def action_enable(args, cfg):
     """
     if cfg.is_attached and os.getuid() == 0:
         # Refresh contracts prior to enable
-        contract_token = cfg.read_cache('contract-token')
-        if contract_token:
-            contract_token = contract_token['contractToken']
-        contract.request_contract_updates(cfg, contract_token=contract_token)
+        contract.request_updated_contracts(cfg)
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     return 0 if entitlement.enable() else 1
@@ -238,7 +235,7 @@ def action_attach(args, cfg):
     else:
         contract_token = args.token
 
-    if not contract.request_contract_updates(cfg, contract_token):
+    if not contract.request_updated_contract(cfg, contract_token):
         print(
             "Could not attach machine. Error contacting server %s" %
             cfg.contract_url)
@@ -318,7 +315,7 @@ def action_refresh(args, cfg):
     if os.getuid() != 0:
         print(ua_status.MESSAGE_NONROOT_USER)
         return 1
-    if contract.request_contract_updates(cfg):
+    if contract.request_updated_contract(cfg):
         print('Refreshed Ubuntu Advantage contracts.')
         logging.debug('Refreshed Ubuntu Advantage contracts.')
         return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -191,10 +191,9 @@ def action_enable(args, cfg):
 
     @return: 0 on success, 1 otherwise
     """
-    if cfg.is_attached and os.getuid() == 0:
-        logging.debug(ua_status.MESSAGE_REFRESH_ENABLE)
-        if not contract.request_updated_contract(cfg):
-            logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
+    logging.debug(ua_status.MESSAGE_REFRESH_ENABLE)
+    if not contract.request_updated_contract(cfg):
+        logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     return 0 if entitlement.enable() else 1

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -180,9 +180,6 @@ class UAConfig(object):
 
     def delete_cache(self):
         """Remove configuration cached response files class attributes."""
-        self._contracts = None
-        self._entitlements = None
-        self._machine_token = None
         for path_key in self.data_paths.keys():
             self.delete_cache_key(path_key)
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -165,7 +165,8 @@ class UAConfig(object):
     def delete_cache_key(self, key):
         """Remove specific cache file."""
         if not key:
-            return
+            raise RuntimeError(
+                'Invalid or empty key provided to delete_cache_key')
         if key.startswith('machine-access'):
             self._entitlements = None
         elif key == 'account-contracts':
@@ -183,10 +184,7 @@ class UAConfig(object):
         self._entitlements = None
         self._machine_token = None
         for path_key in self.data_paths.keys():
-            for private in (True, False):
-                cache_path = self.data_path(path_key, private)
-                if os.path.exists(cache_path):
-                    os.unlink(cache_path)
+            self.delete_cache_key(path_key)
 
     def read_cache(self, key, quiet=False):
         cache_path = self.data_path(key)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -36,6 +36,7 @@ class UAConfig(object):
         'machine-access-support': 'machine-access-support.json',
         'machine-detach': 'machine-detach.json',
         'machine-token': 'machine-token.json',
+        'machine-token-refresh': 'machine-token-refresh.json',
         'macaroon': 'sso-macaroon.json',
         'root-macaroon': 'root-macaroon.json',
         'oauth': 'sso-oauth.json'
@@ -161,14 +162,18 @@ class UAConfig(object):
             return os.path.join(data_dir, self.data_paths[key])
         return os.path.join(data_dir, key)
 
-    def delete_cache(self):
-        """Remove all configuration cached response files class attributes."""
+    def delete_cache(self, key=None):
+        """Remove configuration cached response files class attributes."""
         self._contracts = None
         self._entitlements = None
         self._machine_token = None
-        for key in self.data_paths.keys():
+        if key:
+            data_path_keys = [key]
+        else:
+            data_path_keys = self.data_paths.keys()
+        for path_key in data_path_keys:
             for private in (True, False):
-                cache_path = self.data_path(key, private)
+                cache_path = self.data_path(path_key, private)
                 if os.path.exists(cache_path):
                     os.unlink(cache_path)
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -162,16 +162,27 @@ class UAConfig(object):
             return os.path.join(data_dir, self.data_paths[key])
         return os.path.join(data_dir, key)
 
-    def delete_cache(self, key=None):
+    def delete_cache_key(self, key):
+        """Remove specific cache file."""
+        if not key:
+            return
+        if key.startswith('machine-access'):
+            self._entitlements = None
+        elif key == 'account-contracts':
+            self._contracts = None
+        elif key == 'machine-token':
+            self._machine_token = None
+        for private in (True, False):
+            cache_path = self.data_path(key, private)
+            if os.path.exists(cache_path):
+                os.unlink(cache_path)
+
+    def delete_cache(self):
         """Remove configuration cached response files class attributes."""
         self._contracts = None
         self._entitlements = None
         self._machine_token = None
-        if key:
-            data_path_keys = [key]
-        else:
-            data_path_keys = self.data_paths.keys()
-        for path_key in data_path_keys:
+        for path_key in self.data_paths.keys():
             for private in (True, False):
                 cache_path = self.data_path(path_key, private)
                 if os.path.exists(cache_path):

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,3 +1,5 @@
+import logging
+
 from uaclient import serviceclient
 from uaclient import util
 
@@ -68,30 +70,41 @@ class UAContractClient(serviceclient.UAServiceClient):
         self.cfg.write_cache('root-macaroon', root_macaroon)
         return root_macaroon
 
-    def request_accounts(self, macaroon_token):
+    def request_accounts(self, macaroon_token=None, machine_token=None):
         """Request list of accounts this user has access to."""
         headers = self.headers()
-        headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        if macaroon_token:
+            headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        else:
+            headers.update({'Authorization': 'Bearer %s' % machine_token})
         accounts, _headers = self.request_url(
             API_V1_ACCOUNTS, headers=headers)
         self.cfg.write_cache('accounts', accounts)
         return accounts
 
-    def request_account_contracts(self, macaroon_token, account_id):
+    def request_account_contracts(
+            self, account_id, macaroon_token=None, machine_token=None):
         """Request a list of contracts authorized for account_id."""
         url = API_V1_TMPL_ACCOUNT_CONTRACTS.format(account=account_id)
         headers = self.headers()
-        headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        if macaroon_token:
+            headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        else:
+            headers.update({'Authorization': 'Bearer %s' % machine_token})
         account_contracts, _headers = self.request_url(url, headers=headers)
         self.cfg.write_cache('account-contracts', account_contracts)
         return account_contracts
 
-    def request_add_contract_token(self, macaroon_token, contract_id):
+    def request_add_contract_token(
+            self, contract_id, macaroon_token=None, machine_token=None):
         """Create a contract token for use when adding a machine to a contract
 
         """
         headers = self.headers()
-        headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        if macaroon_token:
+            headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
+        else:
+            headers.update({'Authorization': 'Bearer %s' % machine_token})
         url = API_V1_TMPL_ADD_CONTRACT_TOKEN.format(contract=contract_id)
         contract_token, _headers = self.request_url(
             url, headers=headers,
@@ -202,18 +215,21 @@ class UAContractClient(serviceclient.UAServiceClient):
         return resource_access
 
 
-def get_contract_token_for_account(contract_client, macaroon, account_id):
+def get_contract_token_for_account(
+        contract_client, account_id, macaroon_token=None, machine_token=None):
     """Obtain a contract token for the account_id using the contract_client.
 
     @raises: SSOAuthError on auth failure or util.UrlError on connection
              failure.
     """
-    contract_client.request_accounts(macaroon)
+    contract_client.request_accounts(
+        macaroon_token=macaroon_token, machine_token=machine_token)
     contracts = contract_client.request_account_contracts(
-        macaroon, account_id)
+        account_id, macaroon_token=macaroon_token, machine_token=machine_token)
     contract_id = contracts['contracts'][0]['contractInfo']['id']
     contract_token_response = contract_client.request_add_contract_token(
-        macaroon, contract_id)
+        contract_id, macaroon_token=macaroon_token,
+        machine_token=machine_token)
     return contract_token_response['contractToken']
 
 
@@ -228,3 +244,41 @@ def redact_sensitive(contract_response):
         else:
             redacted[key] = value
     return redacted
+
+
+def request_contract_updates(cfg, contract_token):
+    """Request contract updates from ua-contracts service.
+
+    @param cfg: Instance of UAConfig for this machine.
+    @param contract_token: Token of the contract we are updating.
+
+    @return: True on success False otherwise.
+    """
+    contract_client = UAContractClient(cfg)
+    if not contract_token:  # Crawl the accounts contract routes to get details
+        machine_token = cfg.machine_token['machineToken']
+        try:
+            contract_client.request_accounts(machine_token=machine_token)
+            contract_token = get_contract_token_for_account(
+                contract_client, cfg.accounts[0]['id'],
+                machine_token=machine_token)
+        except util.UrlError as e:
+            logging.error(str(e))
+            print('Could not update contract info from %s' %
+                  cfg.contract_url)
+            return False
+    try:
+        token_response = contract_client.request_contract_machine_attach(
+            contract_token=contract_token)
+        contractInfo = token_response['machineTokenInfo']['contractInfo']
+        for entitlement in contractInfo['resourceEntitlements']:
+            if entitlement.get('entitled'):
+                # Obtain each entitlement's accessContext for this machine
+                entitlement_name = entitlement['type']
+                contract_client.request_resource_machine_access(
+                    cfg.machine_token['machineToken'], entitlement_name)
+    except util.UrlError as e:
+        logging.error(
+            'Could not obtain updated contract information. %s', str(e))
+        return False
+    return True

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -307,7 +307,7 @@ def request_updated_contract(cfg, contract_token=None):
                     logging.debug(
                         'Contract refreshed. Entitlement %s now unentitled.',
                         entitlement['type'])
-                    cfg.delete_cache(data_key)
+                    cfg.delete_cache_key(data_key)
     except util.UrlError as e:
         logging.error(
             'Could not obtain updated contract information. %s', str(e))

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -1,7 +1,6 @@
 import abc
 from datetime import datetime
 import logging
-import os
 import re
 
 from uaclient import config
@@ -54,13 +53,7 @@ class UAEntitlement(object, metaclass=abc.ABCMeta):
         """
         message = ''
         retval = True
-        if os.getuid() != 0:   # Ignore 'force' here. We always need sudo check
-            message = status.MESSAGE_NONROOT_USER
-            retval = False
-        elif not any([self.cfg.is_attached, force]):
-            message = status.MESSAGE_UNATTACHED
-            retval = False
-        elif not any([self.contract_status() == status.ENTITLED, force]):
+        if not any([self.contract_status() == status.ENTITLED, force]):
             message = status.MESSAGE_UNENTITLED_TMPL.format(title=self.title)
             retval = False
         elif not force:
@@ -76,12 +69,6 @@ class UAEntitlement(object, metaclass=abc.ABCMeta):
 
     def can_enable(self):
         """Report whether or not enabling is possible for the entitlement."""
-        if os.getuid() != 0:
-            print(status.MESSAGE_NONROOT_USER)
-            return False
-        if not self.cfg.is_attached:
-            print(status.MESSAGE_UNATTACHED)
-            return False
         if self.is_access_expired():
             token = self.cfg.machine_token['machineToken']
             contract_client = contract.UAContractClient(self.cfg)

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -53,32 +53,7 @@ class TestUaEntitlement(TestCase):
         entitlement = ConcreteTestEntitlement(cfg)
         self.assertEqual('/some/path', entitlement.cfg.data_dir)
 
-    @mock.patch('os.getuid', return_value=100)
-    def test_can_disable_requires_root(self, m_getuid):
-        """Non-root users receive False from UAEntitlement.can_disable."""
-        cfg = config.UAConfig(cfg={})
-        entitlement = ConcreteTestEntitlement(cfg)
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            self.assertFalse(entitlement.can_disable())
-        self.assertEqual(
-            'This command must be run as root (try using sudo)\n',
-            m_stdout.getvalue())
-
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_disable_false_on_unattached_machine(self, m_getuid):
-        """An unattached machine will return False from can_disable."""
-        tmp_dir = self.tmp_dir()
-        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
-        entitlement = ConcreteTestEntitlement(cfg)
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            self.assertFalse(entitlement.can_disable())
-        self.assertEqual(
-            'This machine is not attached to a UA subscription.\n'
-            'See `ua attach` or https://ubuntu.com/advantage\n\n',
-            m_stdout.getvalue())
-
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_disable_false_on_unentitled(self, m_getuid):
+    def test_can_disable_false_on_unentitled(self):
         """When entitlement contract is not enabled, can_disable is False."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -101,8 +76,7 @@ class TestUaEntitlement(TestCase):
             'See `ua status` or https://ubuntu.com/advantage\n\n',
             m_stdout.getvalue())
 
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_disable_false_on_entitlement_inactive(self, m_getuid):
+    def test_can_disable_false_on_entitlement_inactive(self):
         """When operational status is INACTIVE, can_disable returns False."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -125,8 +99,7 @@ class TestUaEntitlement(TestCase):
             'See `ua status`\n',
             m_stdout.getvalue())
 
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_disable_true_on_entitlement_active(self, m_getuid):
+    def test_can_disable_true_on_entitlement_active(self):
         """When operational status is ACTIVE, can_disable returns True."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -145,32 +118,7 @@ class TestUaEntitlement(TestCase):
             self.assertTrue(entitlement.can_disable())
         self.assertEqual('', m_stdout.getvalue())
 
-    @mock.patch('os.getuid', return_value=100)
-    def test_can_enable_requires_root(self, m_getuid):
-        """Non-root users receive False from UAEntitlement.can_enable."""
-        cfg = config.UAConfig(cfg={})
-        entitlement = ConcreteTestEntitlement(cfg)
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            self.assertFalse(entitlement.can_enable())
-        self.assertEqual(
-            'This command must be run as root (try using sudo)\n',
-            m_stdout.getvalue())
-
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_enable_false_on_unattached_machine(self, m_getuid):
-        """An unattached machine will return False from can_enable."""
-        tmp_dir = self.tmp_dir()
-        cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
-        entitlement = ConcreteTestEntitlement(cfg)
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            self.assertFalse(entitlement.can_enable())
-        self.assertEqual(
-            'This machine is not attached to a UA subscription.\n'
-            'See `ua attach` or https://ubuntu.com/advantage\n\n',
-            m_stdout.getvalue())
-
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_enable_false_on_unentitled(self, m_getuid):
+    def test_can_enable_false_on_unentitled(self):
         """When entitlement contract is not enabled, can_enable is False."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -192,8 +140,7 @@ class TestUaEntitlement(TestCase):
             'See `ua status` or https://ubuntu.com/advantage\n\n',
             m_stdout.getvalue())
 
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_enable_false_on_entitlement_active(self, m_getuid):
+    def test_can_enable_false_on_entitlement_active(self):
         """When operational status is ACTIVE, can_enable returns False."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -214,8 +161,7 @@ class TestUaEntitlement(TestCase):
             'Test Concrete Entitlement is already enabled.\nSee `ua status`\n',
             m_stdout.getvalue())
 
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+    def test_can_enable_true_on_entitlement_inactive(self):
         """When operational status is INACTIVE, can_enable returns True."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -52,9 +52,8 @@ PLATFORM_INFO_SUPPORTED = MappingProxyType({
 class TestCommonCriteriaEntitlementCanEnable:
 
     @mock.patch('uaclient.util.get_platform_info')
-    @mock.patch('os.getuid', return_value=0)
     def test_can_enable_true_on_entitlement_inactive(
-            self, m_getuid, m_platform_info, tmpdir):
+            self, m_platform_info, tmpdir):
         """When operational status is INACTIVE, can_enable returns True."""
         m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
@@ -77,9 +76,8 @@ class TestCommonCriteriaEntitlementEnable:
                              itertools.product([False, True], repeat=2))
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.get_platform_info')
-    @mock.patch('os.getuid', return_value=0)
     def test_enable_configures_apt_sources_and_auth_files(
-            self, m_getuid, m_platform_info, m_subp, tmpdir,
+            self, m_platform_info, m_subp, tmpdir,
             apt_transport_https, ca_certificates):
         """When entitled, configure apt repo auth token, pinning and url."""
         m_subp.return_value = ('fakeout', '')

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -38,8 +38,7 @@ CIS_RESOURCE_ENTITLED = {
 
 class TestCISEntitlementCanEnable(TestCase):
 
-    @mock.patch('os.getuid', return_value=0)
-    def test_can_enable_true_on_entitlement_inactive(self, m_getuid):
+    def test_can_enable_true_on_entitlement_inactive(self):
         """When operational status is INACTIVE, can_enable returns True."""
         tmp_dir = self.tmp_dir()
         cfg = config.UAConfig(cfg={'data_dir': tmp_dir})
@@ -57,9 +56,8 @@ class TestCISEntitlementEnable(TestCase):
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.get_platform_info')
-    @mock.patch('os.getuid', return_value=0)
     def test_enable_configures_apt_sources_and_auth_files(
-            self, m_getuid, m_platform_info, m_subp):
+            self, m_platform_info, m_subp):
         """When entitled, configure apt repo auth token, pinning and url."""
 
         def fake_platform(key=None):

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -69,10 +69,8 @@ class TestFIPSEntitlementCanEnable:
         entitlement = FIPSEntitlement(cfg)
         # Unset static affordance container check
         entitlement.static_affordances = ()
-        with mock.patch('uaclient.entitlements.base.os.getuid') as m_getuid:
-            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                m_getuid.return_value = 0
-                assert True is entitlement.can_enable()
+        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            assert True is entitlement.can_enable()
         assert '' == m_stdout.getvalue()
 
 

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -49,7 +49,6 @@ PLATFORM_INFO_SUPPORTED = MappingProxyType({
 })
 
 M_PATH = 'uaclient.entitlements.livepatch.'  # mock path
-M_GETUID = 'os.getuid'
 
 
 class TestLivepatchContractStatus:
@@ -162,10 +161,9 @@ class TestLivepatchEntitlementCanEnable:
         with mock.patch('uaclient.util.get_platform_info') as m_platform:
             with mock.patch('sys.stderr', new_callable=StringIO) as m_stdout:
                 with mock.patch('uaclient.util.is_container') as m_container:
-                    with mock.patch(M_GETUID, return_value=0):
-                        m_platform.return_value = PLATFORM_INFO_SUPPORTED
-                        m_container.return_value = False
-                        assert entitlement.can_enable()
+                    m_platform.return_value = PLATFORM_INFO_SUPPORTED
+                    m_container.return_value = False
+                    assert entitlement.can_enable()
         assert '' == m_stdout.getvalue()
         assert [mock.call()] == m_container.call_args_list
 
@@ -202,11 +200,10 @@ class TestLivepatchEntitlementCanEnable:
         unsupported_kernel['kernel'] = '4.4.0-140-notgeneric'
         with mock.patch('uaclient.util.get_platform_info') as m_platform:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                with mock.patch(M_GETUID, return_value=0):
-                    m_platform.return_value = unsupported_kernel
-                    entitlement = LivepatchEntitlement(
-                        entitlement.cfg)
-                    assert not entitlement.can_enable()
+                m_platform.return_value = unsupported_kernel
+                entitlement = LivepatchEntitlement(
+                    entitlement.cfg)
+                assert not entitlement.can_enable()
         msg = ('Livepatch is not available for kernel 4.4.0-140-notgeneric.\n'
                'Supported flavors are: generic, lowlatency\n\n')
         assert msg == m_stdout.getvalue()
@@ -223,11 +220,10 @@ class TestLivepatchEntitlementCanEnable:
         unsupported_kernel['arch'] = 'ppc64le'
         with mock.patch('uaclient.util.get_platform_info') as m_platform:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                with mock.patch(M_GETUID, return_value=0):
-                    m_platform.return_value = unsupported_kernel
-                    entitlement = LivepatchEntitlement(
-                        entitlement.cfg)
-                    assert not entitlement.can_enable()
+                m_platform.return_value = unsupported_kernel
+                entitlement = LivepatchEntitlement(
+                    entitlement.cfg)
+                assert not entitlement.can_enable()
         msg = ('Livepatch is not available for platform ppc64le.\n'
                'Supported platforms are: x86_64\n\n')
         assert msg == m_stdout.getvalue()
@@ -243,12 +239,11 @@ class TestLivepatchEntitlementCanEnable:
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('uaclient.util.get_platform_info') as m_platform:
                 with mock.patch('uaclient.util.is_container') as m_container:
-                    with mock.patch(M_GETUID, return_value=0):
-                        m_platform.return_value = PLATFORM_INFO_SUPPORTED
-                        m_container.return_value = True
-                        entitlement = LivepatchEntitlement(
-                            entitlement.cfg)
-                        assert not entitlement.can_enable()
+                    m_platform.return_value = PLATFORM_INFO_SUPPORTED
+                    m_container.return_value = True
+                    entitlement = LivepatchEntitlement(
+                        entitlement.cfg)
+                    assert not entitlement.can_enable()
         msg = 'Cannot install Livepatch on a container\n'
         assert msg == m_stdout.getvalue()
 

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -179,11 +179,10 @@ class TestLivepatchEntitlementCanEnable:
         unsupported_min_kernel['kernel'] = '4.2.9-00-generic'
         with mock.patch('uaclient.util.get_platform_info') as m_platform:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                with mock.patch(M_GETUID, return_value=0):
-                    m_platform.return_value = unsupported_min_kernel
-                    entitlement = LivepatchEntitlement(
-                        entitlement.cfg)
-                    assert not entitlement.can_enable()
+                m_platform.return_value = unsupported_min_kernel
+                entitlement = LivepatchEntitlement(
+                    entitlement.cfg)
+                assert not entitlement.can_enable()
         msg = ('Livepatch is not available for kernel 4.2.9-00-generic.\n'
                'Minimum kernel version required: 4.3\n\n')
         assert msg == m_stdout.getvalue()

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -70,6 +70,18 @@ Valid until: {expires}
 Technical support level: {techSupportLevel}
 """
 STATUS_TMPL = '{name: <14}{entitled: <26}{status}'
+MESSAGE_REFRESH_SUCCESS = 'Refreshed Ubuntu Advantage contracts.'
+MESSAGE_REFRESH_FAILURE = 'Failure to refresh Ubuntu Advantage contracts.'
+
+
+def format_entitlement_status(entitlement):
+    contract_status = entitlement.contract_status()
+    operational_status, _details = entitlement.operational_status()
+    fmt_args = {
+        'name': entitlement.name,
+        'contract_state': STATUS_COLOR.get(contract_status, contract_status),
+        'status': STATUS_COLOR.get(operational_status, operational_status)}
+    return STATUS_TMPL.format(**fmt_args)
 
 
 def get_upgradeable_esm_package_count():

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -70,6 +70,15 @@ Valid until: {expires}
 Technical support level: {techSupportLevel}
 """
 STATUS_TMPL = '{name: <14}{entitled: <26}{status}'
+
+MESSAGE_ATTACH_FAILURE_TMPL = """\
+Could not attach machine. Error contacting server {url}"""
+MESSAGE_ATTACH_SUCCESS_TMPL = """\
+This machine is now attached to '{contract_name}'.
+"""
+MESSAGE_DETACH_SUCCESS = 'This machine is now detached'
+
+MESSAGE_REFRESH_ENABLE = 'Refreshing contracts prior to enable'
 MESSAGE_REFRESH_SUCCESS = 'Refreshed Ubuntu Advantage contracts.'
 MESSAGE_REFRESH_FAILURE = 'Failure to refresh Ubuntu Advantage contracts.'
 

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,0 +1,65 @@
+from uaclient.config import UAConfig
+from uaclient.contract import UAContractClient
+
+try:
+    from typing import Any, Dict, Optional  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+
+class FakeContractClient(UAContractClient):
+
+    _requests = []
+    _responses = {}
+
+    def __init___(self, cfg, responses=None):
+        super().__init__(cfg)
+        if responses:
+            self._responses = responses
+
+    def request_url(self, path, data=None, headers=None, method=None):
+        request = {
+            'path': path, 'data': data, 'headers': headers, 'method': method}
+        self._requests.append(request)
+        # Return a response if we have one or empty
+        return self._responses.get(path, {}), {'header1': ''}
+
+
+class FakeConfig(UAConfig):
+
+    def __init__(self, cache_contents: 'Dict[str, Any]' = None) -> None:
+        self._cache_contents = (
+            cache_contents if cache_contents is not None else {})
+        super().__init__({})
+
+    def read_cache(self, key: str, quiet: bool = False) -> 'Optional[str]':
+        return self._cache_contents.get(key)
+
+    def write_cache(
+            self, key: str, content: 'Any', private: bool = True) -> None:
+        if private:
+            self._cache_contents[key] = content
+        else:
+            self._cache_contents['public-' + key] = content
+
+    @classmethod
+    def with_account(cls, account_name: str = 'test_account'):
+        return cls({
+            'accounts': {
+                'accounts': [{'name': account_name, 'id': account_name}]},
+        })
+
+    @classmethod
+    def for_attached_machine(
+            cls, account_name: str = 'test_account',
+            machine_token: 'Dict[str, Any]' = None):
+        value = {
+            'accounts': {'accounts': [{'name': account_name}]},
+            'machine-token': {
+                'machineToken': 'not-null',
+                'machineTokenInfo': {'contractInfo': {'id': 'cid'}}}
+        }
+        if machine_token:
+            value['machine-token'] = machine_token
+        return cls(value)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -4,17 +4,11 @@ import unittest
 from uaclient.testing.fakes import FakeConfig
 
 from io import StringIO
-try:
-    from typing import Any, Dict, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
 
 import pytest
 
 from uaclient import status
 from uaclient.cli import action_attach, attach_parser, UA_DASHBOARD_URL
-from uaclient.config import UAConfig
 
 M_PATH = 'uaclient.cli.'
 

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -1,6 +1,8 @@
 import mock
 import unittest
 
+from uaclient.testing.fakes import FakeConfig
+
 from io import StringIO
 try:
     from typing import Any, Dict, Optional  # noqa: F401
@@ -15,34 +17,6 @@ from uaclient.cli import action_attach, attach_parser, UA_DASHBOARD_URL
 from uaclient.config import UAConfig
 
 M_PATH = 'uaclient.cli.'
-
-
-class FakeConfig(UAConfig):
-
-    def __init__(self, cache_contents: 'Dict[str, Any]' = None) -> None:
-        self._cache_contents = (
-            cache_contents if cache_contents is not None else {})
-        super().__init__({})
-
-    def read_cache(self, key: str, quiet: bool = False) -> 'Optional[str]':
-        return self._cache_contents.get(key)
-
-    def write_cache(self, key: str, content: 'Any') -> None:
-        self._cache_contents[key] = content
-
-    @classmethod
-    def with_account(cls, account_name: str = 'test_account'):
-        return cls({
-            'accounts': {
-                'accounts': [{'name': account_name, 'id': account_name}]},
-        })
-
-    @classmethod
-    def for_attached_machine(cls, account_name: str = 'test_account'):
-        return cls({
-            'accounts': {'accounts': [{'name': account_name}]},
-            'machine-token': 'not-null',
-        })
 
 
 @mock.patch(M_PATH + 'os.getuid')

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -76,13 +76,13 @@ class TestActionAttach(unittest.TestCase):
             account_name)
         assert mock.call(expected_msg) in stdout.write.call_args_list
 
-    @mock.patch(M_PATH + 'contract.request_contract_updates')
+    @mock.patch(M_PATH + 'contract.request_updated_contract')
     @mock.patch(M_PATH + 'sso.discharge_root_macaroon')
     @mock.patch(M_PATH + 'contract.UAContractClient')
     @mock.patch(M_PATH + 'action_status')
     def test_happy_path_without_token_arg(
             self, action_status, contract_client, discharge_root_macaroon,
-            request_contract_updates):
+            request_updated_contract):
         """A mock-heavy test for the happy path without an argument"""
         # TODO: Improve this test with less general mocking and more
         # post-conditions
@@ -98,7 +98,7 @@ class TestActionAttach(unittest.TestCase):
             cfg.write_cache('machine-token', machine_token)
             return True
 
-        request_contract_updates.side_effect = fake_contract_updates
+        request_updated_contract.side_effect = fake_contract_updates
         ret = action_attach(args, cfg)
 
         assert 0 == ret

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -1,0 +1,71 @@
+import mock
+
+from uaclient.testing.fakes import FakeConfig
+
+try:
+    from typing import Any, Dict, Optional  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+from uaclient import status
+from uaclient.cli import action_refresh
+
+M_PATH = 'uaclient.cli.'
+
+
+@mock.patch(M_PATH + 'sys.stdout')
+@mock.patch(M_PATH + 'os.getuid', return_value=0)
+class TestActionRefresh:
+
+    def test_non_root_users_are_rejected(self, getuid, stdout):
+        """Check that a UID != 0 will receive a message and exit non-zero"""
+        getuid.return_value = 1
+
+        cfg = FakeConfig.for_attached_machine()
+        ret = action_refresh(mock.MagicMock(), cfg)
+
+        assert 1 == ret
+        assert (
+            mock.call(status.MESSAGE_NONROOT_USER) in
+            stdout.write.call_args_list)
+
+    def test_not_attached_errors(self, getuid, stdout):
+        """Check that an unattached machine emits message and exits 1"""
+        cfg = FakeConfig()
+
+        ret = action_refresh(mock.MagicMock(), cfg)
+
+        assert 1 == ret
+        expected_msg = status.MESSAGE_UNATTACHED
+        assert mock.call(expected_msg) in stdout.write.call_args_list
+
+    @mock.patch(M_PATH + 'logging.error')
+    @mock.patch(M_PATH + 'contract.request_updated_contract')
+    def test_refresh_contract_error_on_failure_to_update_contract(
+            self, request_updated_contract, logging_error, getuid, stdout):
+        """On failure in request_updates_contract emit an error."""
+        request_updated_contract.return_value = False  # failure to refresh
+
+        cfg = FakeConfig.for_attached_machine()
+        ret = action_refresh(mock.MagicMock(), cfg)
+
+        assert 1 == ret
+        assert (
+            mock.call(status.MESSAGE_REFRESH_FAILURE) in
+            logging_error.call_args_list)
+
+    @mock.patch(M_PATH + 'contract.request_updated_contract')
+    def test_refresh_contract_happy_path(
+            self, request_updated_contract, getuid, stdout):
+        """On success from request_updates_contract root user can refresh."""
+        request_updated_contract.return_value = True
+
+        cfg = FakeConfig.for_attached_machine()
+        ret = action_refresh(mock.MagicMock(), cfg)
+
+        assert 0 == ret
+        assert (
+            mock.call(status.MESSAGE_REFRESH_SUCCESS) in
+            stdout.write.call_args_list)
+        assert [mock.call(cfg)] == request_updated_contract.call_args_list

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1,0 +1,59 @@
+import mock
+import pytest
+
+from uaclient.contract import (
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH, request_updated_contract)
+
+from uaclient.testing.fakes import FakeConfig, FakeContractClient
+
+
+M_PATH = 'uaclient.contract.'
+
+
+class TestRequestUpdatedContract:
+
+    @mock.patch(M_PATH + 'UAContractClient')
+    def test_attached_config_and_contract_token_runtime_error(self, client):
+        """When attached, error if called with a contract_token."""
+
+        def fake_contract_client(cfg):
+            return FakeContractClient(cfg)
+
+        client.side_effect = fake_contract_client
+        cfg = FakeConfig.for_attached_machine()
+        with pytest.raises(RuntimeError) as exc:
+            request_updated_contract(cfg, contract_token='something')
+
+        expected_msg = (
+            'Got unexpected contract_token on an already attached machine')
+        assert expected_msg == str(exc.value)
+
+    @mock.patch('uaclient.util.get_machine_id', return_value='mid')
+    @mock.patch(M_PATH + 'UAContractClient')
+    def test_attached_config_refresh_machine_token_and_services(
+            self, client, get_machine_id):
+        """When attached, refresh machine token and all entitlements."""
+
+        refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH.format(
+            contract='cid', machine='mid')
+
+        machine_token = {
+            'machineToken': 'mToken',
+            'machineTokenInfo': {'contractInfo': {
+                'id': 'cid', 'resourceEntitlements': [
+                    {'entitled': True, 'type': 'ent1'},
+                    {'entitled': False, 'type': 'ent2'}]}}}
+
+        def fake_contract_client(cfg):
+            client = FakeContractClient(cfg)
+            client._responses = {refresh_route: machine_token}
+            return client
+
+        client.side_effect = fake_contract_client
+        cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
+        assert True is request_updated_contract(cfg)
+        assert machine_token == cfg.read_cache('machine-token')
+        # Redact public content
+        assert (
+            '<REDACTED>' == cfg.read_cache(
+                'public-machine-token')['machineToken'])

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -83,9 +83,8 @@ def is_exe(path):
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
 
-def load_file(filename):
-    """Read filename and return content."""
-    logging.debug('Reading file: %s', filename)
+def load_file(filename, decode=True):
+    """Read filename and decode content."""
     with open(filename, 'rb') as stream:
         content = stream.read()
     return content.decode('utf-8')

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -45,6 +45,10 @@ Activate and configure this machine's access to an Ubuntu Advantage
 services.
 
 .TP
+.B refresh
+Refresh contract and service details from Canonical.
+
+.TP
 .BR "status" " [--format=table|json]"
 Report current status of Ubuntu Advantage services on system.
 


### PR DESCRIPTION
- create separate function contract.request_updated_contract since this
logic is common to both attach, enable and refresh
- Add new UAContractClient.request_machine_token_refresh which use existing machine_token to request updated machine-token
 - call request_updated_contract prior to enable operation
 - call request_updated_contract in attach and refresh operations 

Fixes: #342