### PR TITLE
deb: prerm and postrm cleanup no need to remove esm list file in postrm

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -29,12 +29,6 @@ remove_esm(){
     if [ -f "$esm_apt_gpg_key" ]; then
         rm "$esm_apt_gpg_key"
     fi
-
-    esm_apt_source_file="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
-    if [ -f "$esm_apt_source_file" ]; then
-        rm "$esm_apt_source_file"
-    fi
-
 }
 
 case "$1" in

--- a/debian/prerm
+++ b/debian/prerm
@@ -13,7 +13,7 @@ migrate_apt_sources(clean=True)
 }
 
 case "$1" in
-    purge|remove)
+    remove)
         remove_apt_files
         ;;
 esac


### PR DESCRIPTION
Since prerm calles migrate_apt_sources(clean=True) all sources list
files are already removed in prerm.

Also prerm doesn't take a purge param