### PR TITLE
repo: persist a localEnabled flag in machine-acces for non-root status

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -157,7 +157,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         machine_token, _headers = self.request_url(
             API_V1_CONTEXT_MACHINE_TOKEN, data=data, headers=headers)
         self.cfg.write_cache('machine-token', machine_token)
-        redacted_content = redact_sensitive(machine_token)
+        redacted_content = util.redact_sensitive(machine_token)
         self.cfg.write_cache('machine-token', redacted_content, private=False)
         return machine_token
 
@@ -199,7 +199,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         if headers.get('expires'):
             resource_access['expires'] = headers['expires']
         self.cfg.write_cache('machine-access-%s' % resource, resource_access)
-        redacted_content = redact_sensitive(resource_access)
+        redacted_content = util.redact_sensitive(resource_access)
         self.cfg.write_cache(
             'machine-access-%s' % resource, redacted_content, private=False)
         return resource_access
@@ -226,7 +226,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         if headers.get('expires'):
             response['expires'] = headers['expires']
         self.cfg.write_cache('machine-token', response)
-        redacted_content = redact_sensitive(response)
+        redacted_content = util.redact_sensitive(response)
         self.cfg.write_cache('machine-token', redacted_content, private=False)
         return response
 
@@ -244,19 +244,6 @@ def get_contract_token_for_account(contract_client, macaroon, account_id):
     contract_token_response = contract_client.request_add_contract_token(
         macaroon, contract_id)
     return contract_token_response['contractToken']
-
-
-def redact_sensitive(contract_response):
-    """Redact security-sensitive content from contract_response dict."""
-    redacted = {}
-    for key, value in contract_response.items():
-        if key in util.SENSITIVE_KEYS:
-            redacted[key] = '<REDACTED>'
-        elif isinstance(value, dict):
-            redacted[key] = redact_sensitive(value)
-        else:
-            redacted[key] = value
-    return redacted
 
 
 def request_updated_contract(cfg, contract_token=None):

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -46,4 +46,9 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = False
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)
         return True

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -46,9 +46,5 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
-        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
-        public_cache['localEnabled'] = False
-        redacted_cache = util.redact_sensitive(public_cache)
-        self.cfg.write_cache(
-            'machine-access-%s' % self.name, redacted_cache, private=False)
+        self._set_local_enabled(False)
         return True

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -40,4 +40,9 @@ class CISEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = False
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)
         return True

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -40,9 +40,5 @@ class CISEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
-        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
-        public_cache['localEnabled'] = False
-        redacted_cache = util.redact_sensitive(public_cache)
-        self.cfg.write_cache(
-            'machine-access-%s' % self.name, redacted_cache, private=False)
+        self._set_local_enabled(False)
         return True

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -40,6 +40,11 @@ class ESMEntitlement(repo.RepoEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = False
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -40,11 +40,7 @@ class ESMEntitlement(repo.RepoEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
-        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
-        public_cache['localEnabled'] = False
-        redacted_cache = util.redact_sensitive(public_cache)
-        self.cfg.write_cache(
-            'machine-access-%s' % self.name, redacted_cache, private=False)
+        self._set_local_enabled(False)
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -39,11 +39,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     ['apt-get', 'remove', '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
-            public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
-            public_cache['localEnabled'] = False
-            redacted_cache = util.redact_sensitive(public_cache)
-            self.cfg.write_cache(
-                'machine-access-%s' % self.name, redacted_cache, private=False)
+            self._set_local_enabled(False)
         if not silent:
             print('Warning: no option to disable {title}'.format(
                 title=self.title)

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -39,6 +39,11 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     ['apt-get', 'remove', '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
+            public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+            public_cache['localEnabled'] = False
+            redacted_cache = util.redact_sensitive(public_cache)
+            self.cfg.write_cache(
+                'machine-access-%s' % self.name, redacted_cache, private=False)
         if not silent:
             print('Warning: no option to disable {title}'.format(
                 title=self.title)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -108,11 +108,7 @@ class RepoEntitlement(base.UAEntitlement):
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title))
                 return False
-        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
-        public_cache['localEnabled'] = True
-        redacted_cache = util.redact_sensitive(public_cache)
-        self.cfg.write_cache(
-            'machine-access-%s' % self.name, redacted_cache, private=False)
+        self._set_local_enabled(True)
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         for msg in self.messaging.get('post_enable', []):
             print(msg)
@@ -140,3 +136,11 @@ class RepoEntitlement(base.UAEntitlement):
             # policy will show APT_DISABLED_PIN for authenticated sources
             return status.ACTIVE, '%s is active' % self.title
         return status.INACTIVE, '%s is not configured' % self.title
+
+    def _set_local_enabled(self, value):
+        """Set local enabled flag true or false."""
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = value
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -108,6 +108,11 @@ class RepoEntitlement(base.UAEntitlement):
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title))
                 return False
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = True
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         for msg in self.messaging.get('post_enable', []):
             print(msg)
@@ -129,5 +134,9 @@ class RepoEntitlement(base.UAEntitlement):
         out, _err = util.subp(['apt-cache', 'policy'])
         match = re.search(r'(?P<pin>(-)?\d+) %s' % repo_url, out)
         if match and match.group('pin') != APT_DISABLED_PIN:
+            return status.ACTIVE, '%s is active' % self.title
+        if os.getuid() != 0 and entitlement_cfg.get('localEnabled', False):
+            # Use our cached enabled key for non-root users because apt
+            # policy will show APT_DISABLED_PIN for authenticated sources
             return status.ACTIVE, '%s is active' % self.title
         return status.INACTIVE, '%s is not configured' % self.title

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -73,7 +73,7 @@ class TestUaEntitlement(TestCase):
             self.assertFalse(entitlement.can_disable())
         self.assertEqual(
             'This subscription is not entitled to Test Concrete Entitlement.\n'
-            'See `ua status` or https://ubuntu.com/advantage\n\n',
+            'See `ua status` or https://ubuntu.com/advantage\n',
             m_stdout.getvalue())
 
     def test_can_disable_false_on_entitlement_inactive(self):
@@ -137,7 +137,7 @@ class TestUaEntitlement(TestCase):
             self.assertFalse(entitlement.can_enable())
         self.assertEqual(
             'This subscription is not entitled to Test Concrete Entitlement.\n'
-            'See `ua status` or https://ubuntu.com/advantage\n\n',
+            'See `ua status` or https://ubuntu.com/advantage\n',
             m_stdout.getvalue())
 
     def test_can_enable_false_on_entitlement_active(self):

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -56,7 +56,7 @@ class TestCommonCriteriaEntitlementOperationalStatus:
         'arch,series,details',
         (('arm64', 'xenial', 'Canonical Common Criteria EAL2 Provisioning is'
           ' not available for platform arm64.\nSupported platforms are:'
-          ' x86_64, ppc64le, s390x\n'),
+          ' x86_64, ppc64le, s390x'),
          ('s390x', 'trusty', 'Canonical Common Criteria EAL2 Provisioning'
           ' is not available for Ubuntu trusty.')))
     @mock.patch('uaclient.entitlements.repo.os.getuid', return_value=0)

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -184,7 +184,7 @@ class TestLivepatchEntitlementCanEnable:
                     entitlement.cfg)
                 assert not entitlement.can_enable()
         msg = ('Livepatch is not available for kernel 4.2.9-00-generic.\n'
-               'Minimum kernel version required: 4.3\n\n')
+               'Minimum kernel version required: 4.3\n')
         assert msg == m_stdout.getvalue()
 
     def test_can_enable_false_on_unsupported_kernel_flavor(self, tmpdir):
@@ -204,7 +204,7 @@ class TestLivepatchEntitlementCanEnable:
                     entitlement.cfg)
                 assert not entitlement.can_enable()
         msg = ('Livepatch is not available for kernel 4.4.0-140-notgeneric.\n'
-               'Supported flavors are: generic, lowlatency\n\n')
+               'Supported flavors are: generic, lowlatency\n')
         assert msg == m_stdout.getvalue()
 
     def test_can_enable_false_on_unsupported_architecture(self, tmpdir):
@@ -224,7 +224,7 @@ class TestLivepatchEntitlementCanEnable:
                     entitlement.cfg)
                 assert not entitlement.can_enable()
         msg = ('Livepatch is not available for platform ppc64le.\n'
-               'Supported platforms are: x86_64\n\n')
+               'Supported platforms are: x86_64\n')
         assert msg == m_stdout.getvalue()
 
     def test_can_enable_false_on_containers(self, tmpdir):

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -35,33 +35,28 @@ STATUS_COLOR = {
 
 MESSAGE_DISABLED_TMPL = '{title} disabled.'
 MESSAGE_NONROOT_USER = 'This command must be run as root (try using sudo)'
-MESSAGE_ALREADY_DISABLED_TMPL = '\
-{title} is not currently enabled.\nSee `ua status`'
+MESSAGE_ALREADY_DISABLED_TMPL = """\
+{title} is not currently enabled.\nSee `ua status`"""
 MESSAGE_ENABLED_FAILED_TMPL = 'Could not enable {title}.'
 MESSAGE_ENABLED_TMPL = '{title} enabled.'
 MESSAGE_ALREADY_ENABLED_TMPL = '{title} is already enabled.\nSee `ua status`'
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\
 {title} is not available for platform {arch}.
-Supported platforms are: {supported_arches}
-"""
-MESSAGE_INAPPLICABLE_SERIES_TMPL = '\
-{title} is not available for Ubuntu {series}.'
+Supported platforms are: {supported_arches}"""
+MESSAGE_INAPPLICABLE_SERIES_TMPL = """\
+{title} is not available for Ubuntu {series}."""
 MESSAGE_INAPPLICABLE_KERNEL_TMPL = """\
 {title} is not available for kernel {kernel}.
-Supported flavors are: {supported_kernels}
-"""
+Supported flavors are: {supported_kernels}"""
 MESSAGE_INAPPLICABLE_KERNEL_VER_TMPL = """\
 {title} is not available for kernel {kernel}.
-Minimum kernel version required: {min_kernel}
-"""
+Minimum kernel version required: {min_kernel}"""
 MESSAGE_UNENTITLED_TMPL = """\
 This subscription is not entitled to {title}.
-See `ua status` or https://ubuntu.com/advantage
-"""
+See `ua status` or https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
-See `ua attach` or https://ubuntu.com/advantage
-"""
+See `ua attach` or https://ubuntu.com/advantage"""
 
 STATUS_HEADER_TMPL = """\
 Account: {account}

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -100,6 +100,21 @@ class TestIsContainer:
         calls = [mock.call(['systemd-detect-virt', '--quiet', '--container'])]
         assert calls == m_subp.call_args_list
 
+    @mock.patch('uaclient.util.subp')
+    def test_false_on_non_sytemd_detect_virt_and_no_runfiles(
+            self, m_subp, tmpdir):
+        """Return False when sytemd-detect-virt erros and no /run/* files."""
+        m_subp.side_effect = OSError('No systemd-detect-virt utility')
+
+        with mock.patch('uaclient.util.os.path.exists') as m_exists:
+            m_exists.return_value = False
+            assert False is util.is_container(run_path=tmpdir.strpath)
+        calls = [mock.call(['systemd-detect-virt', '--quiet', '--container'])]
+        assert calls == m_subp.call_args_list
+        exists_calls = [mock.call(tmpdir.join('container_type').strpath),
+                        mock.call(tmpdir.join('systemd/container').strpath)]
+        assert exists_calls == m_exists.call_args_list
+
 
 class TestParseOSRelease(TestCase):
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -82,9 +82,9 @@ class TestIsContainer:
     def test_true_on_run_container_type(self, m_subp, tmpdir):
         """Return True when /run/container_type exists."""
         m_subp.side_effect = OSError('No systemd-detect-virt utility')
-        util.write_file(tmpdir.join('container_type').strpath, '')  # touch
+        tmpdir.join('container_type').write('')
 
-        assert True is util.is_container(run_path=tmpdir)
+        assert True is util.is_container(run_path=tmpdir.strpath)
         calls = [mock.call(['systemd-detect-virt', '--quiet', '--container'])]
         assert calls == m_subp.call_args_list
 
@@ -92,11 +92,9 @@ class TestIsContainer:
     def test_true_on_run_systemd_container(self, m_subp, tmpdir):
         """Return True when /run/systemd/container exists."""
         m_subp.side_effect = OSError('No systemd-detect-virt utility')
-        path = tmpdir.join('systemd/container').strpath
-        os.makedirs(os.path.dirname(path))
-        util.write_file(tmpdir.join('systemd/container').strpath, '')  # touch
+        tmpdir.join('systemd/container').write('', ensure=True)
 
-        assert True is util.is_container(run_path=tmpdir)
+        assert True is util.is_container(run_path=tmpdir.strpath)
         calls = [mock.call(['systemd-detect-virt', '--quiet', '--container'])]
         assert calls == m_subp.call_args_list
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -8,10 +8,6 @@ from urllib import request
 import uuid
 
 
-CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
-                   ['running-in-container'],
-                   ['lxc-is-container'])
-
 SENSITIVE_KEYS = ['caveat_id', 'password', 'resourceToken', 'machineToken']
 
 ETC_MACHINE_ID = '/etc/machine-id'
@@ -65,16 +61,12 @@ def encode_text(text, encoding='utf-8'):
     return text.encode(encoding)
 
 
-def is_container():
+def is_container(run_path='/run'):
     """Checks to see if this code running in a container of some sort"""
-    for helper in CONTAINER_TESTS:
-        try:
-            # try to run a helper program. if it returns true/zero
-            # then we're inside a container. otherwise, no
-            subp(helper)
-            return True
-        except (IOError, OSError):
-            pass
+    for filename in ('container_type', 'systemd/container'):
+        path = os.path.join(run_path, filename)
+        if os.path.exists(path):
+            return bool(load_file(path).strip())
     return False
 
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -257,3 +257,16 @@ def get_machine_id(data_dir):
     machine_id = uuid.uuid4()
     write_file(fallback_machine_id_file, machine_id)
     return machine_id
+
+
+def redact_sensitive(content):
+    """Redact security-sensitive content from content dict."""
+    redacted = {}
+    for key, value in content.items():
+        if key in SENSITIVE_KEYS:
+            redacted[key] = '<REDACTED>'
+        elif isinstance(value, dict):
+            redacted[key] = redact_sensitive(value)
+        else:
+            redacted[key] = value
+    return redacted

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -63,10 +63,15 @@ def encode_text(text, encoding='utf-8'):
 
 def is_container(run_path='/run'):
     """Checks to see if this code running in a container of some sort"""
+    try:
+        subp(['systemd-detect-virt', '--quiet', '--container'])
+        return True
+    except (IOError, OSError):
+        pass
     for filename in ('container_type', 'systemd/container'):
         path = os.path.join(run_path, filename)
         if os.path.exists(path):
-            return bool(load_file(path).strip())
+            return True
     return False
 
 


### PR DESCRIPTION
Any repo-based entitlement can not check apt-cache policy to determine
if the entitlement is enabled because apt will automatically pin -32768
for a non-root user of an authenticated apt source because the non-root
user does not have permission on /etc/apt/auth.conf.d/<secureconffile>
due to mode 600 on those files.

As a result uaclient will fallback to our localEnabled flag in public
cache files which is set True after enable and False at disable.

Contained in this merge
- move redact_sensitive function out of contract and into util
- cis, fips*, esm, cis-audit will amend public redacted cache files with localEnabled True|False on enable|disable operations
- RepoEntitlement.operational_status  checks  to localEnabled == True value for non-root user if magic apt pin -32768 was found.
- Fixed  trusty util.is_container fails to report container for non-root user because running-in-container fails to report 'lxc'  (filed bug https://bugs.launchpad.net/upstart/+bug/1824270)
    - This is_container fix avoids an invalid 'inactive' setting reported to non-root users for entitlements that can't be installed on containers (livepatch/fips)

Fixes: #339