### PR TITLE
Ship unattended-upgrades configuration

### DIFF
--- a/apt.conf.d/51ubuntu-advantage-esm
+++ b/apt.conf.d/51ubuntu-advantage-esm
@@ -1,0 +1,3 @@
+Unattended-Upgrade::Allowed-Origins {
+  "${distro_id}ESM:${distro_codename}-security";
+};

--- a/debian/postrm
+++ b/debian/postrm
@@ -35,6 +35,10 @@ remove_esm(){
         rm "$esm_apt_source_file"
     fi
 
+    esm_unattended_upgrades_file="/etc/apt/apt.conf.d/51ubuntu-advantage-esm"
+    if [ -f "$esm_unattended_upgrades_file" ]; then
+        rm "$esm_unattended_upgrades_file"
+    fi
 }
 
 case "$1" in

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         exclude=['*.testing', 'tests.*', '*.tests', 'tests']
     ),
     data_files=[
+        ('/etc/apt/apt.conf.d', ['apt.conf.d/51ubuntu-advantage-esm']),
         ('/etc/ubuntu-advantage', ['uaclient.conf']),
         ('/usr/share/keyrings', glob.glob('keyrings/*')),
         (defaults.CONFIG_DEFAULTS['data_dir'], [])


### PR DESCRIPTION
Fixes #355 

With ESM enabled we can see it would upgrade ansible and some krb5 packages. Also note the allowed origins:
```
root@trusty-ua:~# unattended-upgrade -v --dry-run
Initial blacklisted packages: 
Starting unattended upgrades script
Allowed origins are: ['o=Ubuntu,a=trusty-security', 'o=UbuntuESM,a=trusty', 'o=UbuntuESM,a=trusty-security']
Option --dry-run given, *not* performing real actions
Packages that will be upgraded: ansible krb5-locales libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0
Writing dpkg log to '/var/log/unattended-upgrades/unattended-upgrades-dpkg_2019-04-11_19:58:49.428473.log'
/usr/bin/dpkg --status-fd 9 --unpack --auto-deconfigure /var/cache/apt/archives/libk5crypto3_1.12+dfsg-2ubuntu5.4+esm1_amd64.deb /var/cache/apt/archives/libgssapi-krb5-2_1.12+dfsg-2ubuntu5.4+esm1_amd64.deb /var/cache/apt/archives/libkrb5-3_1.12+dfsg-2ubuntu5.4+esm1_amd64.deb /var/cache/apt/archives/libkrb5support0_1.12+dfsg-2ubuntu5.4+esm1_amd64.deb /var/cache/apt/archives/krb5-locales_1.12+dfsg-2ubuntu5.4+esm1_all.deb /var/cache/apt/archives/ansible_1.5.4+dfsg-1ubuntu0.1~esm1_all.deb 
/usr/bin/dpkg --status-fd 11 --configure libkrb5support0:amd64 libk5crypto3:amd64 libkrb5-3:amd64 libgssapi-krb5-2:amd64 krb5-locales:all ansible:all 
All upgrades installed
```