### PR TITLE
Wait for snapd to initialise before using it

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -77,6 +77,8 @@ class LivepatchEntitlement(base.UAEntitlement):
                 print('Installing snapd...')
                 util.subp(['apt-get', 'install', '--assume-yes', 'snapd'],
                           capture=True)
+                util.subp(['snap', 'wait', 'system', 'seed.loaded'],
+                          capture=True)
             print('Installing canonical-livepatch snap...')
             try:
                 util.subp(['snap', 'install', 'canonical-livepatch'],

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -79,10 +79,13 @@ class TestCISEntitlementEnable(TestCase):
         # Unset static affordance container check
         entitlement.static_affordances = ()
 
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
-                with mock.patch('uaclient.apt.add_ppa_pinning') as m_add_pin:
-                    self.assertTrue(entitlement.enable())
+        with mock.patch('uaclient.entitlements.repo.os.path.exists',
+                        mock.Mock(return_value=True)):
+            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+                with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
+                    with mock.patch(
+                            'uaclient.apt.add_ppa_pinning') as m_add_pin:
+                        self.assertTrue(entitlement.enable())
 
         add_apt_calls = [
             mock.call('/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list',

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -260,6 +260,7 @@ class TestLivepatchEntitlementEnable:
     mocks_snapd_install = [
         mock.call(
             ['apt-get', 'install', '--assume-yes', 'snapd'], capture=True),
+        mock.call(['snap', 'wait', 'system', 'seed.loaded'], capture=True),
     ]
     mocks_livepatch_install = [
         mock.call(['snap', 'install', 'canonical-livepatch'], capture=True),


### PR DESCRIPTION
This also includes a fix for a trusty package build unit test failure, required so I could build a package to test with.