### PR TITLE
apt-hook: Do not crash/fail if we can't read /proc/self/status

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -60,9 +60,6 @@ static std::string getppid_of(std::string pid)
       return line;
    }
 
-   if (stream.fail())
-      _error->Error("Could not parse proc status of %s", pid.c_str());
-
    return "";
 }
 
@@ -181,9 +178,11 @@ int main(int argc, char *argv[])
    setlocale(LC_ALL, "");
    textdomain("ubuntu-advantage-tools");
    // Self testing
-   std::string ppid;
-   strprintf(ppid, "%d", getppid());
-   assert(ppid == getppid_of("self"));
+   if (access("/proc/self/status", R_OK) == 0) {
+      std::string ppid;
+      strprintf(ppid, "%d", getppid());
+      assert(ppid == getppid_of("self"));
+   }
    assert(cmdline_eligible(make_cmdline("apt\0update\0")));
    assert(cmdline_eligible(make_cmdline("apt-get\0update\0")));
    assert(!cmdline_eligible(make_cmdline("apt-get\0install\0")));


### PR DESCRIPTION
Emergency hotfix, as disco image builds are broken:

Only run the self-test if we can access the file, and ignore any
errors from reading status files, so that things fail silently
where we can't read them for whatever reasons.

This broke live image building for server.