### PR TITLE
Disco hotfix 1824523, part 2

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -178,11 +178,12 @@ int main(int argc, char *argv[])
    setlocale(LC_ALL, "");
    textdomain("ubuntu-advantage-tools");
    // Self testing
-   if (access("/proc/self/status", R_OK) == 0) {
-      std::string ppid;
-      strprintf(ppid, "%d", getppid());
-      assert(ppid == getppid_of("self"));
-   }
+   // Dropped: see #1824523
+   // if (access("/proc/self/status", R_OK) == 0) {
+   //    std::string ppid;
+   //    strprintf(ppid, "%d", getppid());
+   //    assert(ppid == getppid_of("self"));
+   // }
    assert(cmdline_eligible(make_cmdline("apt\0update\0")));
    assert(cmdline_eligible(make_cmdline("apt-get\0update\0")));
    assert(!cmdline_eligible(make_cmdline("apt-get\0install\0")));

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-advantage-tools (19.4) disco; urgency=medium
+
+  * Drop the self-test assert in the apt-hook, it's making the subiquity
+    server install fail (LP: #1824523)
+
+ -- Andreas Hasenack <andreas@canonical.com>  Fri, 12 Apr 2019 17:59:16 -0300
+
 ubuntu-advantage-tools (19.3) disco; urgency=medium
 
   * apt-hook: Do not crash/fail if we can't read /proc/self/status


### PR DESCRIPTION
Drop the self test

<juliank|away> andreas: powersj: Just drop the self-test for getppid_of