### PR TITLE
Disco changes, new 19.5

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -178,11 +178,12 @@ int main(int argc, char *argv[])
    setlocale(LC_ALL, "");
    textdomain("ubuntu-advantage-tools");
    // Self testing
-   if (access("/proc/self/status", R_OK) == 0) {
-      std::string ppid;
-      strprintf(ppid, "%d", getppid());
-      assert(ppid == getppid_of("self"));
-   }
+   // Dropped: see #1824523
+   // if (access("/proc/self/status", R_OK) == 0) {
+   //    std::string ppid;
+   //    strprintf(ppid, "%d", getppid());
+   //    assert(ppid == getppid_of("self"));
+   // }
    assert(cmdline_eligible(make_cmdline("apt\0update\0")));
    assert(cmdline_eligible(make_cmdline("apt-get\0update\0")));
    assert(!cmdline_eligible(make_cmdline("apt-get\0install\0")));

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,17 @@
-ubuntu-advantage-tools (19.4) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (19.5) UNRELEASED; urgency=medium
 
   * Ship unattended-upgrades configuration for ESM
   * Wait for snapd to initialise before using it
   * Test fixes
 
  -- Andreas Hasenack <andreas@canonical.com>  Fri, 12 Apr 2019 09:28:00 -0300
+
+ubuntu-advantage-tools (19.4) disco; urgency=medium
+
+  * Drop the self-test assert in the apt-hook, it's making the subiquity
+    server install fail (LP: #1824523)
+
+ -- Andreas Hasenack <andreas@canonical.com>  Fri, 12 Apr 2019 17:59:16 -0300
 
 ubuntu-advantage-tools (19.3) disco; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,7 +4,7 @@ ubuntu-advantage-tools (19.5) UNRELEASED; urgency=medium
   * Wait for snapd to initialise before using it
   * Test fixes
 
- -- Andreas Hasenack <andreas@canonical.com>  Fri, 12 Apr 2019 09:28:00 -0300
+ -- Andreas Hasenack <andreas@canonical.com>  Mon, 15 Apr 2019 10:38:35 -0300
 
 ubuntu-advantage-tools (19.4) disco; urgency=medium
 


### PR DESCRIPTION
This brings back the last hotfix update in disco, and bumps the changelog version.