### PR TITLE
esm: only remove the apt auth entry on disable

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -131,15 +131,8 @@ def add_apt_auth_conf_entry(repo_url, login, password):
     util.write_file(apt_auth_file, '\n'.join(new_lines), mode=0o600)
 
 
-def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
-                         fingerprint=None):
-    """Remove an authenticated apt repo and credentials to the system"""
-    logging.info('Removing authenticated apt repo: %s', repo_url)
-    util.del_file(repo_filename)
-    if keyring_file:
-        util.del_file(keyring_file)
-    elif fingerprint:
-        util.subp(['apt-key', 'del', fingerprint], capture=True)
+def remove_repo_from_apt_auth_file(repo_url):
+    """Remove a repo from the shared apt auth file"""
     _protocol, repo_path = repo_url.split('://')
     if repo_path.endswith('/'):  # strip trailing slash
         repo_path = repo_path[:-1]
@@ -154,6 +147,18 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
             os.unlink(apt_auth_file)
         else:
             util.write_file(apt_auth_file, content, mode=0o600)
+
+
+def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
+                         fingerprint=None):
+    """Remove an authenticated apt repo and credentials to the system"""
+    logging.info('Removing authenticated apt repo: %s', repo_url)
+    util.del_file(repo_filename)
+    if keyring_file:
+        util.del_file(keyring_file)
+    elif fingerprint:
+        util.subp(['apt-key', 'del', fingerprint], capture=True)
+    remove_repo_from_apt_auth_file(repo_url)
 
 
 def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -25,16 +25,16 @@ class ESMEntitlement(repo.RepoEntitlement):
         if not self.can_disable(silent, force):
             return False
         series = util.get_platform_info('series')
-        repo_filename = self.repo_list_file_tmpl.format(
-            name=self.name, series=series)
-        keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
         repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
-        apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
+        # We only remove the repo from the apt auth file, because ESM is a
+        # special-case: we want to be able to report on the available ESM
+        # updates even when it's disabled
+        apt.remove_repo_from_apt_auth_file(repo_url)
         if self.repo_pin_priority:
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -1,0 +1,96 @@
+import itertools
+import os.path
+from unittest import mock
+
+import pytest
+
+from uaclient import config
+from uaclient.entitlements.esm import ESMEntitlement
+
+
+ESM_MACHINE_TOKEN = {
+    'machineToken': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'esm'}]}}}
+
+
+ESM_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'esm',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://ESM',
+            'aptKey': 'APTKEY',
+            'suites': ['xenial']
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+M_PATH = 'uaclient.entitlements.esm.ESMEntitlement.'
+M_REPOPATH = 'uaclient.entitlements.repo.'
+M_GETPLATFORM = M_REPOPATH + 'util.get_platform_info'
+
+
+@pytest.fixture
+def entitlement(tmpdir):
+    """
+    A pytest fixture to create a ESMEntitlement with some default config
+
+    (Uses the tmpdir fixture for the underlying config cache.)
+    """
+    cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+    cfg.write_cache('machine-token', dict(ESM_MACHINE_TOKEN))
+    cfg.write_cache('machine-access-esm', dict(ESM_RESOURCE_ENTITLED))
+    return ESMEntitlement(cfg)
+
+
+class TestESMEntitlementDisable:
+
+    # Paramterize True/False for silent and force
+    @pytest.mark.parametrize(
+        'silent,force', itertools.product([False, True], repeat=2))
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_disable', return_value=False)
+    def test_disable_returns_false_on_can_disable_false_and_does_nothing(
+            self, m_can_disable, m_platform_info, silent, force):
+        """When can_disable is false disable returns false and noops."""
+        entitlement = ESMEntitlement({})
+
+        with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
+            assert False is entitlement.disable(silent, force)
+        assert [mock.call(silent, force)] == m_can_disable.call_args_list
+        assert 0 == m_remove_apt.call_count
+
+    @mock.patch('uaclient.apt.remove_auth_apt_repo')
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch(M_PATH + 'can_disable', return_value=True)
+    def test_disable_removes_apt_config(
+            self, m_can_disable, m_platform_info, m_rm_auth,
+            entitlement, tmpdir, caplog_text):
+        """When can_disable, disable removes apt configuration when force."""
+
+        original_exists = os.path.exists
+
+        def fake_exists(path):
+            if path == '/etc/apt/preferences.d/ubuntu-esm-xenial':
+                return True
+            return original_exists(path)
+
+        with mock.patch('os.path.exists', side_effect=fake_exists):
+            with mock.patch('uaclient.apt.os.unlink'):
+                with mock.patch('uaclient.util.subp'):
+                    assert entitlement.disable(True, True)
+        assert [mock.call(True, True)] == m_can_disable.call_args_list
+        auth_call = mock.call(
+            '/etc/apt/sources.list.d/ubuntu-esm-xenial.list',
+            'http://ESM', '/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg')
+        assert [auth_call] == m_rm_auth.call_args_list


### PR DESCRIPTION
We only remove the repo from the apt auth file, because ESM is a
special-case: we want to be able to report on the available ESM updates
even when it's disabled.

Fixes #351