### PR TITLE
Update travis for trusty esm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "3.5"
-dist: precise
+dist: trusty
 install: pip install tox
 script: make lint test
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ install: pip install tox
 script: make lint test
 addons:
   apt:
-    sources:
-      - debian-sid
     packages:
       - shellcheck


### PR DESCRIPTION
Minimal changes to get CI working again on this branch. Note that "ua-trusty-esm-old-client" is our target here, NOT master.