### PR TITLE
esm: remove only the apt auth entry on disable

### DIFF
--- a/tools/constraints-bionic.txt
+++ b/tools/constraints-bionic.txt
@@ -1,4 +1,5 @@
 flake8==3.5.0
+py==1.5.2
 pycodestyle==2.3.1
 pytest==3.3.2
 pytest-cov==2.5.1

--- a/tools/constraints-trusty.txt
+++ b/tools/constraints-trusty.txt
@@ -1,6 +1,10 @@
 flake8==2.1.0
 pep8==1.4.6
 
+# The official version in Trusty is actually 1.4.20, however the version of
+# pytest below requires at least 1.4.24
+py==1.4.24
+
 # The official version in Trusty is actually 2.5.1, however this
 # version does not work with tox runs on Bionic and later. 2.6.2 is the
 # earliest version to properly function.

--- a/tools/constraints-xenial.txt
+++ b/tools/constraints-xenial.txt
@@ -1,4 +1,5 @@
 flake8==2.5.4
 pep8==1.7.0
+py==1.4.31
 pytest==2.8.7
 pytest-cov==2.2.1

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -131,15 +131,8 @@ def add_apt_auth_conf_entry(repo_url, login, password):
     util.write_file(apt_auth_file, '\n'.join(new_lines), mode=0o600)
 
 
-def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
-                         fingerprint=None):
-    """Remove an authenticated apt repo and credentials to the system"""
-    logging.info('Removing authenticated apt repo: %s', repo_url)
-    util.del_file(repo_filename)
-    if keyring_file:
-        util.del_file(keyring_file)
-    elif fingerprint:
-        util.subp(['apt-key', 'del', fingerprint], capture=True)
+def remove_repo_from_apt_auth_file(repo_url):
+    """Remove a repo from the shared apt auth file"""
     _protocol, repo_path = repo_url.split('://')
     if repo_path.endswith('/'):  # strip trailing slash
         repo_path = repo_path[:-1]
@@ -154,6 +147,18 @@ def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
             os.unlink(apt_auth_file)
         else:
             util.write_file(apt_auth_file, content, mode=0o600)
+
+
+def remove_auth_apt_repo(repo_filename, repo_url, keyring_file=None,
+                         fingerprint=None):
+    """Remove an authenticated apt repo and credentials to the system"""
+    logging.info('Removing authenticated apt repo: %s', repo_url)
+    util.del_file(repo_filename)
+    if keyring_file:
+        util.del_file(keyring_file)
+    elif fingerprint:
+        util.subp(['apt-key', 'del', fingerprint], capture=True)
+    remove_repo_from_apt_auth_file(repo_url)
 
 
 def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -25,16 +25,16 @@ class ESMEntitlement(repo.RepoEntitlement):
         if not self.can_disable(silent, force):
             return False
         series = util.get_platform_info('series')
-        repo_filename = self.repo_list_file_tmpl.format(
-            name=self.name, series=series)
-        keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
         entitlement_cfg = self.cfg.read_cache(
             'machine-access-%s' % self.name)['entitlement']
         access_directives = entitlement_cfg.get('directives', {})
         repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:
             repo_url = self.repo_url
-        apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
+        # We only remove the repo from the apt auth file, because ESM is a
+        # special-case: we want to be able to report on the available ESM
+        # updates even when it's disabled
+        apt.remove_repo_from_apt_auth_file(repo_url)
         if self.repo_pin_priority:
             repo_pref_file = self.repo_pref_file_tmpl.format(
                 name=self.name, series=series)

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -1,0 +1,96 @@
+import itertools
+import mock
+import os.path
+
+import pytest
+
+from uaclient import config
+from uaclient.entitlements.esm import ESMEntitlement
+
+
+ESM_MACHINE_TOKEN = {
+    'machineToken': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'esm'}]}}}
+
+
+ESM_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'esm',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://ESM',
+            'aptKey': 'APTKEY',
+            'suites': ['xenial']
+        },
+        'affordances': {
+            'series': []   # Will match all series
+        }
+    }
+}
+
+M_PATH = 'uaclient.entitlements.esm.ESMEntitlement.'
+M_REPOPATH = 'uaclient.entitlements.repo.'
+M_GETPLATFORM = M_REPOPATH + 'util.get_platform_info'
+
+
+@pytest.fixture
+def entitlement(tmpdir):
+    """
+    A pytest fixture to create a ESMEntitlement with some default config
+
+    (Uses the tmpdir fixture for the underlying config cache.)
+    """
+    cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+    cfg.write_cache('machine-token', dict(ESM_MACHINE_TOKEN))
+    cfg.write_cache('machine-access-esm', dict(ESM_RESOURCE_ENTITLED))
+    return ESMEntitlement(cfg)
+
+
+class TestESMEntitlementDisable:
+
+    # Paramterize True/False for silent and force
+    @pytest.mark.parametrize(
+        'silent,force', itertools.product([False, True], repeat=2))
+    @mock.patch('uaclient.util.get_platform_info')
+    @mock.patch(M_PATH + 'can_disable', return_value=False)
+    def test_disable_returns_false_on_can_disable_false_and_does_nothing(
+            self, m_can_disable, m_platform_info, silent, force):
+        """When can_disable is false disable returns false and noops."""
+        entitlement = ESMEntitlement({})
+
+        with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
+            assert False is entitlement.disable(silent, force)
+        assert [mock.call(silent, force)] == m_can_disable.call_args_list
+        assert 0 == m_remove_apt.call_count
+
+    @mock.patch('uaclient.apt.remove_auth_apt_repo')
+    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch(M_PATH + 'can_disable', return_value=True)
+    def test_disable_removes_apt_config(
+            self, m_can_disable, m_platform_info, m_rm_auth,
+            entitlement, tmpdir, caplog_text):
+        """When can_disable, disable removes apt configuration when force."""
+
+        original_exists = os.path.exists
+
+        def fake_exists(path):
+            if path == '/etc/apt/preferences.d/ubuntu-esm-xenial':
+                return True
+            return original_exists(path)
+
+        with mock.patch('os.path.exists', side_effect=fake_exists):
+            with mock.patch('uaclient.apt.os.unlink'):
+                with mock.patch('uaclient.util.subp'):
+                    assert entitlement.disable(True, True)
+        assert [mock.call(True, True)] == m_can_disable.call_args_list
+        auth_call = mock.call(
+            '/etc/apt/sources.list.d/ubuntu-esm-xenial.list',
+            'http://ESM', '/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg')
+        assert [auth_call] == m_rm_auth.call_args_list

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -558,7 +558,7 @@ class TestRemoveRepoFromAptAuthFile:
                           tmpdir, trailing_slash, repo_url, auth_file_content):
         """Check that auth file is rm'd if empty or contains just our line"""
         auth_file = tmpdir.join('auth_file')
-        auth_file.write_binary(auth_file_content)
+        auth_file.write(auth_file_content, 'wb')
         m_get_apt_auth_file.return_value = auth_file.strpath
 
         remove_repo_from_apt_auth_file(
@@ -584,7 +584,7 @@ class TestRemoveRepoFromAptAuthFile:
                           trailing_slash):
         """Check that auth file is rewritten to only exclude our line"""
         auth_file = tmpdir.join('auth_file')
-        auth_file.write_binary(before_content)
+        auth_file.write(before_content, 'wb')
         m_get_apt_auth_file.return_value = auth_file.strpath
 
         remove_repo_from_apt_auth_file(
@@ -592,4 +592,4 @@ class TestRemoveRepoFromAptAuthFile:
 
         assert 0 == m_unlink.call_count
         assert 0o600 == stat.S_IMODE(os.lstat(auth_file.strpath).st_mode)
-        assert after_content == auth_file.read_binary()
+        assert after_content == auth_file.read('rb')

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -463,10 +463,11 @@ def remove_auth_apt_repo_kwargs(request):
 
 class TestRemoveAuthAptRepo:
 
-    @mock.patch('uaclient.apt.util.subp', mock.Mock())
-    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file', mock.Mock())
+    @mock.patch('uaclient.apt.util.subp')
+    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
     @mock.patch('uaclient.apt.util.del_file')
-    def test_repo_file_deleted(self, m_del_file, remove_auth_apt_repo_kwargs):
+    def test_repo_file_deleted(
+            self, m_del_file, _mock, __mock, remove_auth_apt_repo_kwargs):
         """Ensure that repo_filename is deleted, regardless of other params."""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
 
@@ -475,11 +476,11 @@ class TestRemoveAuthAptRepo:
 
         assert mock.call(repo_filename) in m_del_file.call_args_list
 
-    @mock.patch('uaclient.apt.util.subp', mock.Mock())
+    @mock.patch('uaclient.apt.util.subp')
+    @mock.patch('uaclient.apt.util.del_file')
     @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
-    @mock.patch('uaclient.apt.util.del_file', mock.Mock())
     def test_remove_from_auth_file_called(
-            self, m_remove_repo, remove_auth_apt_repo_kwargs):
+            self, m_remove_repo, _mock, __mock, remove_auth_apt_repo_kwargs):
         """Ensure that remove_repo_from_apt_auth_file is called."""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
 
@@ -488,11 +489,11 @@ class TestRemoveAuthAptRepo:
 
         assert mock.call(repo_url) in m_remove_repo.call_args_list
 
-    @mock.patch('uaclient.apt.util.subp', mock.Mock())
-    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file', mock.Mock())
+    @mock.patch('uaclient.apt.util.subp')
+    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
     @mock.patch('uaclient.apt.util.del_file')
     def test_keyring_file_deleted_if_given(
-            self, m_del_file, remove_auth_apt_repo_kwargs):
+            self, m_del_file, _mock, __mock, remove_auth_apt_repo_kwargs):
         """We should always delete the keyring file if it is given"""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
 
@@ -505,11 +506,11 @@ class TestRemoveAuthAptRepo:
         else:
             assert mock.call(keyring_file) not in m_del_file.call_args_list
 
+    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
+    @mock.patch('uaclient.apt.util.del_file')
     @mock.patch('uaclient.apt.util.subp')
-    @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file', mock.Mock())
-    @mock.patch('uaclient.apt.util.del_file', mock.Mock())
     def test_fingerprint_deleted_if_given_alone(
-            self, m_subp, remove_auth_apt_repo_kwargs):
+            self, m_subp, _mock, __mock, remove_auth_apt_repo_kwargs):
         """We should delete the fingerprint iff it is given without keyring"""
         repo_filename, repo_url = mock.sentinel.filename, mock.sentinel.url
 


### PR DESCRIPTION
We only remove the repo from the apt auth file, because ESM is a
special-case: we want to be able to report on the available ESM updates
even when it's disabled.

Fixes #351