### PR TITLE
OC: Install unattended-upgrades config

### DIFF
--- a/apt.conf.d/51ubuntu-advantage-esm
+++ b/apt.conf.d/51ubuntu-advantage-esm
@@ -1,0 +1,3 @@
+Unattended-Upgrade::Allowed-Origins {
+  "${distro_id}ESM:${distro_codename}-security";
+};

--- a/debian/install
+++ b/debian/install
@@ -1,3 +1,4 @@
 ubuntu-advantage usr/bin/
 keyrings/*.gpg usr/share/keyrings/
 update-motd.d etc/
+apt.conf.d etc/apt/


### PR DESCRIPTION
Install an unattended-upgrades config for the ESM -security pocket.

Fixes issue #390 