### PR TITLE
travis: only run suite-specific tests on their corresponding Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: python
-python:
-  - 3.4 # trusty
-  - 3.5 # xenial
-  - 3.6 # bionic
-  - 3.7-dev
 dist: trusty
 matrix:
-  fast_finish: true
 install:
   # Required so `git describe` will definitely find a tag; see
   # https://github.com/travis-ci/travis-ci/issues/7422
@@ -14,3 +8,15 @@ install:
   - make testdeps
 script:
   - make test
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.4
+      env: TOXENV=py3-trusty,flake8-trusty
+    - python: 3.5
+      env: TOXENV=py3-xenial,flake8-xenial
+    - python: 3.6
+      env: TOXENV=py3-bionic,flake8-bionic
+    - python: 3.7-dev
+      env: TOXENV=py3,flake8

--- a/tools/constraints-trusty.txt
+++ b/tools/constraints-trusty.txt
@@ -1,14 +1,7 @@
 flake8==2.1.0
 pep8==1.4.6
-
-# The official version in Trusty is actually 1.4.20, however the version of
-# pytest below requires at least 1.4.24
-py==1.4.24
-
-# The official version in Trusty is actually 2.5.1, however this
-# version does not work with tox runs on Bionic and later. 2.6.2 is the
-# earliest version to properly function.
-pytest==2.6.2
+py==1.4.20
+pytest==2.5.1
 
 # pytest-cov isn't available in trusty; the package build tests don't require
 # it, but including it here allows us to keep a consistent test command in


### PR DESCRIPTION
This means that we aren't going to get false test failures if a combination we don't care about fails (i.e. we don't care if we break trusty's versions of packages when running on Python 3.6, because that's a combination that we will never encounter in the wild).

It also allows us to fix up the constraints used for trusty (as we no longer need versions that work on anything other than Python 3.4); this fixes #398.

(This will mean that more tox tests fail on developer machines, but those tests weren't actually testing the right combination of versions anyway; we should address that properly in #397.)