### PR TITLE
OC: support auth.conf.d for ESM

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -27,6 +27,13 @@ case "$1" in
         # remove ESM keyring files created by enable-esm
         rm -f /etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg
         rm -f /etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg
+        # ESM sources.list.d snippet
+        series=$(grep ^DISTRIB_CODENAME= /etc/lsb-release | cut -d = -f 2)
+        if [ -n "${series}" ]; then
+            rm -f /etc/apt/sources.list.d/ubuntu-esm-${series}.list
+        fi
+        # ubuntu-advantage auth.conf.d snippet
+        rm -f /etc/apt/auth.conf.d/90ubuntu-advantage
     ;;    
 
     *)

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -12,8 +12,8 @@ class ESMTest(UbuntuAdvantageTest):
         """The enable-esm option enables the ESM repository on p."""
         self.SERIES = 'precise'
         expected_repo_list = (
-            'deb https://user:pass@esm.ubuntu.com/ubuntu precise main\n'
-            '# deb-src https://user:pass@esm.ubuntu.com/ubuntu precise main\n')
+            'deb https://esm.ubuntu.com/ubuntu precise main\n'
+            '# deb-src https://esm.ubuntu.com/ubuntu precise main\n')
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(0, process.returncode)
         self.assertIn('Ubuntu ESM repository enabled', process.stdout)
@@ -29,14 +29,14 @@ class ESMTest(UbuntuAdvantageTest):
         """The enable-esm option enables the ESM repository on t."""
         self.SERIES = 'trusty'
         expected_repo_list = (
-            'deb https://user:pass@esm.ubuntu.com/ubuntu '
+            'deb https://esm.ubuntu.com/ubuntu '
             'trusty-security main\n'
-            '# deb-src https://user:pass@esm.ubuntu.com/ubuntu '
+            '# deb-src https://esm.ubuntu.com/ubuntu '
             'trusty-security main\n'
             '\n'
-            'deb https://user:pass@esm.ubuntu.com/ubuntu '
+            'deb https://esm.ubuntu.com/ubuntu '
             'trusty-updates main\n'
-            '# deb-src https://user:pass@esm.ubuntu.com/ubuntu '
+            '# deb-src https://esm.ubuntu.com/ubuntu '
             'trusty-updates main\n')
         process = self.script('enable-esm', 'user:pass')
         self.assertEqual(0, process.returncode)

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -18,6 +18,10 @@ class ESMTest(UbuntuAdvantageTest):
         self.assertEqual(0, process.returncode)
         self.assertIn('Ubuntu ESM repository enabled', process.stdout)
         self.assertEqual(expected_repo_list, self.repo_list.read_text())
+        self.assertEqual(
+            self.apt_auth_file.read_text(),
+            'machine esm.ubuntu.com/ login user password pass\n')
+        self.assertEqual(self.apt_auth_file.stat().st_mode, 0o100600)
         keyring_file = self.trusted_gpg_dir / 'ubuntu-esm-keyring.gpg'
         self.assertEqual('GPG key', keyring_file.read_text())
         # the apt-transport-https dependency is already installed
@@ -43,6 +47,10 @@ class ESMTest(UbuntuAdvantageTest):
         self.assertIn('Ubuntu ESM repository enabled', process.stdout)
         self.assertEqual(expected_repo_list, self.repo_list.read_text())
         keyring_file = self.trusted_gpg_dir / 'ubuntu-esm-v2-keyring.gpg'
+        self.assertEqual(
+            self.apt_auth_file.read_text(),
+            'machine esm.ubuntu.com/ login user password pass\n')
+        self.assertEqual(self.apt_auth_file.stat().st_mode, 0o100600)
         self.assertEqual('GPG key trusty', keyring_file.read_text())
         # the apt-transport-https dependency is already installed
         self.assertNotIn(

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -57,6 +57,14 @@ class ESMTest(UbuntuAdvantageTest):
             'Installing missing dependency apt-transport-https',
             process.stdout)
 
+    def test_enable_esm_auth_with_other_entries(self):
+        """Existing auth.conf entries are preserved."""
+        auth = 'machine example.com login user password pass\n'
+        self.apt_auth_file.write_text(auth)
+        process = self.script('enable-esm', 'user:pass')
+        self.assertEqual(0, process.returncode)
+        self.assertIn(auth, self.apt_auth_file.read_text())
+
     def test_enable_esm_install_apt_transport_https(self):
         """enable-esm installs apt-transport-https if needed."""
         self.apt_method_https.unlink()

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -158,6 +158,8 @@ class ESMTest(UbuntuAdvantageTest):
 
     def test_disable_esm(self):
         """The disable-esm option disables the ESM repository."""
+        other_auth = 'machine example.com login user password pass\n'
+        self.apt_auth_file.write_text(other_auth)
         self.script('enable-esm', 'user:pass')
         process = self.script('disable-esm')
         self.assertEqual(0, process.returncode)
@@ -169,6 +171,8 @@ class ESMTest(UbuntuAdvantageTest):
             self.trusted_gpg_dir / 'ubuntu-esm-v2-keyring.gpg')
         self.assertFalse(keyring_file_precise.exists())
         self.assertFalse(keyring_file_trusty.exists())
+        # credentials are removed
+        self.assertEqual(self.apt_auth_file.read_text(), other_auth)
 
     def test_disable_esm_disabled(self):
         """If the ESM repo is not enabled, disable-esm is a no-op."""

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -53,6 +53,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.etc_dir = Path(self.tempdir.join('etc'))
         self.keyrings_dir = Path(self.tempdir.join('keyrings'))
         self.trusted_gpg_dir = Path(self.tempdir.join('trusted.gpg.d'))
+        self.apt_auth_file = Path(self.tempdir.join('auth.conf'))
         self.apt_method_https = self.bin_dir / 'apt-method-https'
         self.ca_certificates = self.bin_dir / 'update-ca-certificates'
         self.snapd = self.bin_dir / 'snapd'
@@ -99,6 +100,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'FIPS_BOOT_CFG_DIR': str(self.etc_dir),
             'FIPS_ENABLED_FILE': str(self.fips_enabled_file),
             'KEYRINGS_DIR': str(self.keyrings_dir),
+            'APT_AUTH_FILE': str(self.apt_auth_file),
             'APT_KEYS_DIR': str(self.trusted_gpg_dir),
             'APT_METHOD_HTTPS': str(self.apt_method_https),
             'CA_CERTIFICATES': str(self.ca_certificates),

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -53,7 +53,8 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.etc_dir = Path(self.tempdir.join('etc'))
         self.keyrings_dir = Path(self.tempdir.join('keyrings'))
         self.trusted_gpg_dir = Path(self.tempdir.join('trusted.gpg.d'))
-        self.apt_auth_file = Path(self.tempdir.join('auth.conf'))
+        self.apt_auth_dir = Path(self.tempdir.join('auth.conf.d'))
+        self.apt_auth_file = self.apt_auth_dir / 'auth.conf'
         self.apt_method_https = self.bin_dir / 'apt-method-https'
         self.ca_certificates = self.bin_dir / 'update-ca-certificates'
         self.snapd = self.bin_dir / 'snapd'
@@ -100,6 +101,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
             'FIPS_BOOT_CFG_DIR': str(self.etc_dir),
             'FIPS_ENABLED_FILE': str(self.fips_enabled_file),
             'KEYRINGS_DIR': str(self.keyrings_dir),
+            'APT_AUTH_DIR': str(self.apt_auth_dir),
             'APT_AUTH_FILE': str(self.apt_auth_file),
             'APT_KEYS_DIR': str(self.trusted_gpg_dir),
             'APT_METHOD_HTTPS': str(self.apt_method_https),

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -96,7 +96,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         env = {
             'PATH': path,
             'FSTAB': str(self.fstab),
-            'REPO_LIST': str(self.repo_list),
+            'ESM_REPO_LIST': str(self.repo_list),
             'FIPS_REPO_LIST': str(self.repo_list),
             'FIPS_BOOT_CFG': str(self.boot_cfg),
             'FIPS_BOOT_CFG_DIR': str(self.etc_dir),

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -63,6 +63,7 @@ class UbuntuAdvantageTest(TestWithFixtures):
         self.keyrings_dir.mkdir()
         self.etc_dir.mkdir()
         self.fstab.write_text('')
+        self.apt_auth_dir.mkdir()
         self.trusted_gpg_dir.mkdir()
         (self.keyrings_dir / 'ubuntu-esm-keyring.gpg').write_text('GPG key')
         (self.keyrings_dir / 'ubuntu-esm-v2-keyring.gpg').write_text(

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -14,9 +14,9 @@ ARCH=${ARCH:-$(uname -m)}
 FIPS_REPO_URL="private-ppa.launchpad.net/ubuntu-advantage/fips"
 FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"
 FIPS_REPO_LIST=${FIPS_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-fips-${SERIES}.list"}
-REPO_URL="esm.ubuntu.com"
-REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
-REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
+ESM_REPO_URL="esm.ubuntu.com"
+ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
+ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:-"/usr/lib/apt/methods/https"}
@@ -155,23 +155,23 @@ _apt_remove_auth() {
 
 write_esm_list_file() {
     if [ "${SERIES}" = "precise" ]; then
-        cat > "$REPO_LIST" <<EOF
-deb https://${1}@${REPO_URL}/ubuntu ${SERIES} main
-# deb-src https://${1}@${REPO_URL}/ubuntu ${SERIES} main
+        cat > "$ESM_REPO_LIST" <<EOF
+deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES} main
+# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES} main
 EOF
     else
-        cat > "$REPO_LIST" <<EOF
-deb https://${1}@${REPO_URL}/ubuntu ${SERIES}-security main
-# deb-src https://${1}@${REPO_URL}/ubuntu ${SERIES}-security main
+        cat > "$ESM_REPO_LIST" <<EOF
+deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-security main
+# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-security main
 
-deb https://${1}@${REPO_URL}/ubuntu ${SERIES}-updates main
-# deb-src https://${1}@${REPO_URL}/ubuntu ${SERIES}-updates main
+deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-updates main
+# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-updates main
 EOF
     fi
 }
 
 enable_esm() {
-    for f in ${REPO_KEY_FILES}; do
+    for f in ${ESM_REPO_KEY_FILES}; do
         cp "${KEYRINGS_DIR}/${f}" "$APT_KEYS_DIR"
     done
     write_esm_list_file "$1"
@@ -183,9 +183,9 @@ enable_esm() {
 }
 
 disable_esm() {
-    if [ -f "$REPO_LIST" ]; then
-        mv "$REPO_LIST" "${REPO_LIST}.save"
-        for f in ${REPO_KEY_FILES}; do
+    if [ -f "$ESM_REPO_LIST" ]; then
+        mv "$ESM_REPO_LIST" "${ESM_REPO_LIST}.save"
+        for f in ${ESM_REPO_KEY_FILES}; do
             rm -f "$APT_KEYS_DIR/$f"
         done
         echo -n 'Running apt-get update... '
@@ -299,7 +299,7 @@ is_fips_enabled() {
 }
 
 is_esm_enabled() {
-    apt-cache policy | grep -Fq "$REPO_URL"
+    apt-cache policy | grep -Fq "$ESM_REPO_URL"
 }
 
 is_livepatch_enabled() {

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -18,6 +18,10 @@ ESM_REPO_HOST="esm.ubuntu.com"
 ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
 ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
+# XXX precise doesn't support auth.conf.d:
+# apt-config shell key Dir::Etc::netrcparts/
+# just auth.conf:
+# apt-config shell key Dir::Etc::netrc/
 APT_AUTH_DIR=${APT_AUTH_DIR:-"/etc/apt/auth.conf.d"}
 APT_AUTH_FILE=${APT_AUTH_FILE:-"/etc/apt/auth.conf.d/90ubuntu-advantage"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -18,6 +18,7 @@ ESM_REPO_HOST="esm.ubuntu.com"
 ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
 ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
+APT_AUTH_FILE=${APT_AUTH_FILE:-"/etc/apt/auth.conf"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:-"/usr/lib/apt/methods/https"}
 CA_CERTIFICATES=${CA_CERTIFICATES:-"/usr/sbin/update-ca-certificates"}

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -134,6 +134,25 @@ disable_livepatch() {
     fi
 }
 
+_apt_add_auth() {
+    local repo_host="$1"
+    local credentials="$2"
+
+    local login password
+    login=$(echo "$credentials" | cut -d: -f1)
+    password=$(echo "$credentials" | cut -d: -f2)
+    [ -f "$APT_AUTH_FILE" ] || touch "$APT_AUTH_FILE"
+    chmod 600 "$APT_AUTH_FILE"
+    echo "machine ${repo_host}/ubuntu/ login ${login} password ${password}" \
+         >>"$APT_AUTH_FILE"
+}
+
+_apt_remove_auth() {
+    local repo_host="$1"
+
+    sed -i "/^machine ${repo_host}\/ubuntu\/ login/d" "$APT_AUTH_FILE"
+}
+
 write_esm_list_file() {
     if [ "${SERIES}" = "precise" ]; then
         cat > "$REPO_LIST" <<EOF

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -18,7 +18,8 @@ ESM_REPO_HOST="esm.ubuntu.com"
 ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
 ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
-APT_AUTH_FILE=${APT_AUTH_FILE:-"/etc/apt/auth.conf"}
+APT_AUTH_DIR=${APT_AUTH_DIR:-"/etc/apt/auth.conf.d"}
+APT_AUTH_FILE=${APT_AUTH_FILE:-"/etc/apt/auth.conf.d/90ubuntu-advantage"}
 APT_KEYS_DIR=${APT_KEYS_DIR:-"/etc/apt/trusted.gpg.d"}
 APT_METHOD_HTTPS=${APT_METHOD_HTTPS:-"/usr/lib/apt/methods/https"}
 CA_CERTIFICATES=${CA_CERTIFICATES:-"/usr/sbin/update-ca-certificates"}
@@ -142,6 +143,7 @@ _apt_add_auth() {
     local login password
     login=$(echo "$credentials" | cut -d: -f1)
     password=$(echo "$credentials" | cut -d: -f2)
+    [ -d "$APT_AUTH_DIR" ] || mkdir -p "$APT_AUTH_DIR"
     [ -f "$APT_AUTH_FILE" ] || touch "$APT_AUTH_FILE"
     chmod 600 "$APT_AUTH_FILE"
     echo "machine ${repo_host}/ login ${login} password ${password}" \

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -144,14 +144,14 @@ _apt_add_auth() {
     password=$(echo "$credentials" | cut -d: -f2)
     [ -f "$APT_AUTH_FILE" ] || touch "$APT_AUTH_FILE"
     chmod 600 "$APT_AUTH_FILE"
-    echo "machine ${repo_host}/ubuntu/ login ${login} password ${password}" \
+    echo "machine ${repo_host}/ login ${login} password ${password}" \
          >>"$APT_AUTH_FILE"
 }
 
 _apt_remove_auth() {
     local repo_host="$1"
 
-    sed -i "/^machine ${repo_host}\/ubuntu\/ login/d" "$APT_AUTH_FILE"
+    sed -i "/^machine ${repo_host}\/ login/d" "$APT_AUTH_FILE"
 }
 
 write_esm_list_file() {

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -16,7 +16,7 @@ FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"
 FIPS_REPO_LIST=${FIPS_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-fips-${SERIES}.list"}
 ESM_REPO_HOST="esm.ubuntu.com"
 ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
-ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
+ESM_REPO_LIST=${ESM_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
 # XXX precise doesn't support auth.conf.d:
 # apt-config shell key Dir::Etc::netrcparts/

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -14,7 +14,7 @@ ARCH=${ARCH:-$(uname -m)}
 FIPS_REPO_URL="private-ppa.launchpad.net/ubuntu-advantage/fips"
 FIPS_REPO_KEY_FILE="ubuntu-fips-keyring.gpg"
 FIPS_REPO_LIST=${FIPS_REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-fips-${SERIES}.list"}
-ESM_REPO_URL="esm.ubuntu.com"
+ESM_REPO_HOST="esm.ubuntu.com"
 ESM_REPO_KEY_FILES="ubuntu-esm-keyring.gpg ubuntu-esm-v2-keyring.gpg"
 ESM_REPO_LIST=${REPO_LIST:-"/etc/apt/sources.list.d/ubuntu-esm-${SERIES}.list"}
 KEYRINGS_DIR=${KEYRINGS_DIR:-"/usr/share/keyrings"}
@@ -156,25 +156,28 @@ _apt_remove_auth() {
 write_esm_list_file() {
     if [ "${SERIES}" = "precise" ]; then
         cat > "$ESM_REPO_LIST" <<EOF
-deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES} main
-# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES} main
+deb https://${ESM_REPO_HOST}/ubuntu ${SERIES} main
+# deb-src https://${ESM_REPO_HOST}/ubuntu ${SERIES} main
 EOF
     else
         cat > "$ESM_REPO_LIST" <<EOF
-deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-security main
-# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-security main
+deb https://${ESM_REPO_HOST}/ubuntu ${SERIES}-security main
+# deb-src https://${ESM_REPO_HOST}/ubuntu ${SERIES}-security main
 
-deb https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-updates main
-# deb-src https://${1}@${ESM_REPO_URL}/ubuntu ${SERIES}-updates main
+deb https://${ESM_REPO_HOST}/ubuntu ${SERIES}-updates main
+# deb-src https://${ESM_REPO_HOST}/ubuntu ${SERIES}-updates main
 EOF
     fi
 }
 
 enable_esm() {
+    local token="$1"
+
     for f in ${ESM_REPO_KEY_FILES}; do
         cp "${KEYRINGS_DIR}/${f}" "$APT_KEYS_DIR"
     done
-    write_esm_list_file "$1"
+    write_esm_list_file "${token}"
+    _apt_add_auth "${ESM_REPO_HOST}" "${token}"
     install_package_if_missing_file "$APT_METHOD_HTTPS" apt-transport-https
     install_package_if_missing_file "$CA_CERTIFICATES" ca-certificates
     echo -n 'Running apt-get update... '
@@ -188,6 +191,7 @@ disable_esm() {
         for f in ${ESM_REPO_KEY_FILES}; do
             rm -f "$APT_KEYS_DIR/$f"
         done
+        _apt_remove_auth "${ESM_REPO_HOST}"
         echo -n 'Running apt-get update... '
         check_result apt_get update
         echo 'Ubuntu ESM repository disabled.'
@@ -299,7 +303,7 @@ is_fips_enabled() {
 }
 
 is_esm_enabled() {
-    apt-cache policy | grep -Fq "$ESM_REPO_URL"
+    apt-cache policy | grep -Fq "$ESM_REPO_HOST"
 }
 
 is_livepatch_enabled() {


### PR DESCRIPTION
This is not changing FIPS to use auth.conf.d, because FIPS does not exist in trusty. If we want to do that work, to keep things consistent, then that is a matter for another branch.