### PR TITLE
Re-enable tests at build time.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), lsb-release
+Build-Depends: debhelper (>=9), flake8 | python3-flake8, python3 (>= 3.4),
+ fakeroot, python3-fixtures, lsb-release
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), flake8 | python3-flake8, python3 (>= 3.4),
+Build-Depends: debhelper (>=9), python3-flake8, python3 (>= 3.4),
  fakeroot, python3-fixtures, lsb-release
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com

--- a/debian/rules
+++ b/debian/rules
@@ -3,4 +3,5 @@
 	dh $@
 
 override_dh_auto_test:
-	@echo "Skipping tests during package builds."
+	python3 -m unittest discover tests
+	flake8 tests


### PR DESCRIPTION
These were disabled in 10ubuntu0.14.04.2.

I located a failed build in launchpad of 10ubuntu0.14.04.1, when tests were last enabled: https://launchpad.net/ubuntu/+source/ubuntu-advantage-tools/10ubuntu0.14.04.1

Looks like the `flake8 | python3-flake8` build-dep didn't work. I tried in a PPA, and it worked just fine:
https://launchpad.net/~ahasenack/+archive/ubuntu/ua-tests-pkg-build-time/+build/16646028

We could just drop the `flake8 |` bit, which doesn't exist in trusty, and use `python3-flake8` directly. The `flake8` package was there because of precise I believe.

Fixes issue #391 