### PR TITLE
drop inheritance from object

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -18,7 +18,7 @@ class ConfigAbsentError(RuntimeError):
     pass
 
 
-class UAConfig(object):
+class UAConfig:
 
     data_paths = {
         'bound-macaroon': 'bound-macaroon',

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -13,7 +13,7 @@ RE_KERNEL_UNAME = (
     r'-(?P<flavor>[A-Za-z0-9_-]+)')
 
 
-class UAEntitlement(object, metaclass=abc.ABCMeta):
+class UAEntitlement(metaclass=abc.ABCMeta):
 
     # The lowercase name of this entitlement
     name = None

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -6,7 +6,7 @@ from uaclient import util
 from uaclient import version
 
 
-class UAServiceClient(object):
+class UAServiceClient:
 
     # Set in subclasses to the config key referenced by this client
     service_url_cfg_key = None

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,4 +1,4 @@
-class TxtColor(object):
+class TxtColor:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'


### PR DESCRIPTION
As we are Python 3-only, we don't need to inherit from object to get
"new-style" class behaviour.