### PR TITLE
honour enableByDefault obligations from contract server

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -185,6 +185,19 @@ def action_disable(args, cfg):
         return 1
 
 
+def _perform_enable(entitlement_name: str, cfg: config.UAConfig) -> bool:
+    """Perform the enable action on a named entitlement.
+
+    (This helper excludes any messaging, so that different enablement code
+    paths can message themselves.)
+
+    @return: True on success, False otherwise
+    """
+    ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
+    entitlement = ent_cls(cfg)
+    return entitlement.enable()
+
+
 @assert_attached_root
 def action_enable(args, cfg):
     """Perform the enable action on a named entitlement.
@@ -194,9 +207,7 @@ def action_enable(args, cfg):
     logging.debug(ua_status.MESSAGE_REFRESH_ENABLE)
     if not contract.request_updated_contract(cfg):
         logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
-    ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
-    entitlement = ent_cls(cfg)
-    return 0 if entitlement.enable() else 1
+    return 0 if _perform_enable(args.name, cfg) else 1
 
 
 @assert_attached_root

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -266,12 +266,14 @@ def action_attach(args, cfg):
         ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
             contract_name=contract_name))
 
-    for entitlement_name, ent_value in cfg.entitlements.items():
-        obligations = ent_value['entitlement'].get('obligations')
-        if not obligations:
-            continue
-        if obligations.get('enableByDefault'):
+    enable_by_default_entitlements = [
+        name for name, value in cfg.entitlements.items()
+        if value['entitlement'].get('obligations', {}).get('enableByDefault')]
+    if enable_by_default_entitlements:
+        print(ua_status.MESSAGE_ATTACH_ENABLING_DEFAULTS)
+        for entitlement_name in enable_by_default_entitlements:
             _perform_enable(entitlement_name, cfg)
+        print()  # Add a line before status output
 
     action_status(args=None, cfg=cfg)
     return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -265,6 +265,14 @@ def action_attach(args, cfg):
     print(
         ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
             contract_name=contract_name))
+
+    for entitlement_name, ent_value in cfg.entitlements.items():
+        obligations = ent_value['entitlement'].get('obligations')
+        if not obligations:
+            continue
+        if obligations.get('enableByDefault'):
+            _perform_enable(entitlement_name, cfg)
+
     action_status(args=None, cfg=cfg)
     return 0
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -266,9 +266,11 @@ def action_attach(args, cfg):
         ua_status.MESSAGE_ATTACH_SUCCESS_TMPL.format(
             contract_name=contract_name))
 
-    enable_by_default_entitlements = [
+    # sort the list, so that we get consistent attach behaviour regardless of
+    # dict ordering
+    enable_by_default_entitlements = sorted([
         name for name, value in cfg.entitlements.items()
-        if value['entitlement'].get('obligations', {}).get('enableByDefault')]
+        if value['entitlement'].get('obligations', {}).get('enableByDefault')])
     if enable_by_default_entitlements:
         print(ua_status.MESSAGE_ATTACH_ENABLING_DEFAULTS)
         for entitlement_name in enable_by_default_entitlements:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -71,6 +71,7 @@ Could not attach machine. Error contacting server {url}"""
 MESSAGE_ATTACH_SUCCESS_TMPL = """\
 This machine is now attached to '{contract_name}'.
 """
+MESSAGE_ATTACH_ENABLING_DEFAULTS = 'Enabling default entitlements...'
 MESSAGE_DETACH_SUCCESS = 'This machine is now detached'
 
 MESSAGE_REFRESH_ENABLE = 'Refreshing contracts prior to enable'

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -227,8 +227,11 @@ class TestActionAttachEnableByDefault:
                         m_contract_machine_attach, m_discharge_root_macaroon,
                         m_perform_enable, capsys):
         """Test a mixture of enableByDefault and not"""
+        # Note that enable1 is after the others, but we assert that it's
+        # before; as dicts don't have a stable ordering in all of our target
+        # releases, this ensures that the order in which things happens will be
+        # consistent
         entitlements = [
-            {'type': 'enable1', 'obligations': {'enableByDefault': True}},
             {'type': 'dont1', 'obligations': {'enableByDefault': False}},
             {'type': 'enable2', 'obligations': {'enableByDefault': True}},
             {'type': 'dont2', 'obligations': {'otherValue': True}},
@@ -236,6 +239,7 @@ class TestActionAttachEnableByDefault:
             {'type': 'dont2', 'obligations': {}},
             {'type': 'enable4', 'obligations': {'enableByDefault': True}},
             {'type': 'dont3'},
+            {'type': 'enable1', 'obligations': {'enableByDefault': True}},
         ]
         token = 'contract-token'
         args = mock.MagicMock(token=token)


### PR DESCRIPTION
This implements `enableByDefault` support so that ubuntu-advantage-client will enable the appropriate entitlements at attach time.

(More code will follow to address #411, so that we only attempt to enable entitlements if they are applicable to the current system.)

Fixes #239.