### PR TITLE
OC: ua trusty disable flake8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,12 @@
 ubuntu-advantage-tools (10ubuntu0.14.04.3) trusty; urgency=medium
 
-  * Enabled support for Trusty ESM (LP: #1825239)
-  * Re-enabled tests at package build time:
+  * Enable support for Trusty ESM (LP: #1825239)
+  * Re-enable tests at package build time, just not flake8 as python3-flake8
+    is in universe:
     - d/rules: run tests
     - d/control: add test dependencies
 
- -- Andreas Hasenack <andreas@canonical.com>  Wed, 17 Apr 2019 20:18:12 +0000
+ -- Andreas Hasenack <andreas@canonical.com>  Thu, 18 Apr 2019 15:20:23 +0000
 
 ubuntu-advantage-tools (10ubuntu0.14.04.2) trusty; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: ubuntu-advantage-tools
 Section: misc
 Priority: important
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Build-Depends: debhelper (>=9), python3-flake8, python3 (>= 3.4),
- fakeroot, python3-fixtures, lsb-release
+Build-Depends: debhelper (>=9), python3 (>= 3.4), fakeroot, python3-fixtures,
+ lsb-release
 Standards-Version: 3.9.6
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/rules
+++ b/debian/rules
@@ -4,4 +4,3 @@
 
 override_dh_auto_test:
 	python3 -m unittest discover tests
-	flake8 tests


### PR DESCRIPTION
Trusty has a stricter policy regarding universe dependencies. In later ubuntu releases, a universe build dependency was allowed as long as it didn't introduce an equivalent runtime dependency, but in trusty they are just not allowed. Universe is not enabled in the build environment. As a result, we cannot have python3-flake8 as a build-dep, because it's in universe.

This branch removes just the flake8 check, but keeps the unittest one, since those deps are in main:
```
$ rmadison python3 python3-fixtures fakeroot lsb-releae|grep trusty
 python3          | 3.4.0-0ubuntu2   | trusty          | amd64, arm64, armhf, i386, powerpc, ppc64el
 python3-fixtures | 0.3.14-1ubuntu2  | trusty          | all
 fakeroot         | 1.20-3ubuntu2    | trusty          | source, amd64, arm64, armhf, i386, powerpc, ppc64el
```

The builds we did so far of the package without this change, in a ppa, worked, because universe is enabled there. But not in the official launchpad builders for trusty, as can be seen in this build log for trusty: https://launchpad.net/ubuntu/+source/ubuntu-advantage-tools/10ubuntu0.14.04.1/+build/13686457
