### PR TITLE
Review fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 ubuntu-advantage-tools (10ubuntu0.14.04.3) trusty; urgency=medium
 
   * Enable support for Trusty ESM (LP: #1825239)
+  * Install an unattended-upgrades configuration that allows for the
+    UbuntuESM trusty-security origin.
   * Re-enable tests at package build time, just not flake8 as python3-flake8
     is in universe:
     - d/rules: run tests

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -57,6 +57,13 @@ class ESMTest(UbuntuAdvantageTest):
             'Installing missing dependency apt-transport-https',
             process.stdout)
 
+    def test_enable_esm_already_enabled(self):
+        """The enable-esm option fails if ESM is already enabled."""
+        self.make_fake_binary('apt-cache', command='echo esm.ubuntu.com')
+        process = self.script('enable-esm', 'user:pass')
+        self.assertEqual(1, process.returncode)
+        self.assertIn('Ubuntu ESM is already enabled.', process.stderr)
+
     def test_enable_esm_auth_with_other_entries(self):
         """Existing auth.conf entries are preserved."""
         auth = 'machine example.com login user password pass\n'

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -467,7 +467,7 @@ case "$1" in
         check_user
         check_esm_support
         if is_esm_enabled; then
-            echo 'ESM is already enabled.' >&2
+            echo 'Ubuntu ESM is already enabled.' >&2
             exit 1
         fi
         token="$2"

--- a/ubuntu-advantage
+++ b/ubuntu-advantage
@@ -466,6 +466,10 @@ case "$1" in
     enable-esm)
         check_user
         check_esm_support
+        if is_esm_enabled; then
+            echo 'ESM is already enabled.' >&2
+            exit 1
+        fi
         token="$2"
         if ! validate_user_pass_token "$token"; then
             echo 'Invalid token, it must be in the form "user:password"' >&2


### PR DESCRIPTION
Addresses review comments from https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1825239/comments/1

In the esm-is-already-enabled case, I opted to exit 1, which is documented in the manpage as:
```
1
Invalid command or option
```
Only in later releases did we add an exit code for `<service> is already enabled`, and that was 8.

enable-fips already checks for "fips is already enabled", and also exits non-zero (6 in this case).