### PR TITLE
logs: separate console log devel from logfile level

### DIFF
--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -2,5 +2,5 @@
 sso_auth_url: 'https://login.ubuntu.com'
 contract_url: 'https://contracts.staging.canonical.com'
 data_dir: /tmp/uaclient
-log_level: error
+log_level: debug
 log_file: ubuntu-advantage-devel.log

--- a/uaclient.conf
+++ b/uaclient.conf
@@ -2,5 +2,5 @@
 sso_auth_url: 'https://login.ubuntu.com'
 contract_url: 'https://contracts.canonical.com'
 data_dir: /var/lib/ubuntu-advantage
-log_level: info
+log_level: debug
 log_file: /var/log/ubuntu-advantage.log


### PR DESCRIPTION
The default console log level is logging.INFO.
The console output can be set to debug level with --debug parameter.
The default log file logging level is logging.DEBUG and can be changed
by either providing UA_LOG_LEVEL=(debug|info|warning|error) or changing
log_level setting in /etc/ubuntu-advantage/uaclient.conf.

Fixes: #370