### PR TITLE
contract: process_entitlement_delta to react to apt directive deltas

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -185,7 +185,6 @@ class UAConfig:
         """Remove configuration cached response files class attributes."""
         for path_key in self.data_paths.keys():
             self.delete_cache_key(path_key)
-        self.flush_cache()
 
     def read_cache(self, key, silent=False):
         cache_path = self.data_path(key)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -127,8 +127,10 @@ class UAConfig:
         ent_by_name = dict(
             (e['type'], e) for e in contractInfo['resourceEntitlements'])
         for entitlement_name, ent_value in ent_by_name.items():
-            entitlement_cfg = self.read_cache(
-                'machine-access-%s' % entitlement_name, silent=True)
+            entitlement_cfg = {}
+            if ent_value.get('entitled'):
+                entitlement_cfg = self.read_cache(
+                    'machine-access-%s' % entitlement_name, silent=True)
             if not entitlement_cfg:
                 # Fallback to machine-token info on unentitled
                 entitlement_cfg = {'entitlement': ent_value}

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -170,12 +170,11 @@ class UAConfig:
         if not key:
             raise RuntimeError(
                 'Invalid or empty key provided to delete_cache_key')
-        if key.startswith('machine-access'):
+        if key.startswith('machine-access') or key == 'machine-token':
             self._entitlements = None
+            self._machine_token = None
         elif key == 'account-contracts':
             self._contracts = None
-        elif key == 'machine-token':
-            self._machine_token = None
         for private in (True, False):
             cache_path = self.data_path(key, private)
             if os.path.exists(cache_path):
@@ -206,6 +205,11 @@ class UAConfig:
         data_dir = os.path.dirname(filepath)
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
+        if key.startswith('machine-access') or key == 'machine-token':
+            self._machine_token = None
+            self._entitlements = None
+        elif key == 'account-contracts':
+            self._contracts = None
         if not isinstance(content, str):
             content = json.dumps(content)
         if private:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -159,12 +159,6 @@ class UAConfig:
             return os.path.join(data_dir, self.data_paths[key])
         return os.path.join(data_dir, key)
 
-    def flush_cache(self):
-        """Clear any cached locals so new cache values are read."""
-        self._contracts = None
-        self._entitlements = None
-        self._machine_token = None
-
     def delete_cache_key(self, key):
         """Remove specific cache file."""
         if not key:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -159,6 +159,12 @@ class UAConfig:
             return os.path.join(data_dir, self.data_paths[key])
         return os.path.join(data_dir, key)
 
+    def flush_cache(self):
+        """Clear any cached locals so new cache values are read."""
+        self._contracts = None
+        self._entitlements = None
+        self._machine_token = None
+
     def delete_cache_key(self, key):
         """Remove specific cache file."""
         if not key:
@@ -179,6 +185,7 @@ class UAConfig:
         """Remove configuration cached response files class attributes."""
         for path_key in self.data_paths.keys():
             self.delete_cache_key(path_key)
+        self.flush_cache()
 
     def read_cache(self, key, silent=False):
         cache_path = self.data_path(key)

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -277,14 +277,14 @@ def process_entitlement_delta(orig_access, new_access):
     :param orig_access: Dict with updated entitlement access details after
         contract refresh
     """
-    from uaclient import entitlements
+    from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
     if not orig_access or orig_access == new_access:
         return {}
     deltas = get_dict_deltas(orig_access, new_access)
     if deltas:
         name = orig_access['entitlement']['type']
-        ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[name]
+        ent_cls = ENTITLEMENT_CLASS_BY_NAME[name]
         entitlement = ent_cls()
         entitlement.process_contract_deltas(orig_access, deltas)
     return deltas

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -254,6 +254,7 @@ def process_entitlement_delta(orig_access, new_access):
     """
     from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
+    # TODO: handle initial install deltas where orig_access is empty
     if not orig_access or orig_access == new_access:
         return {}
     deltas = util.get_dict_deltas(orig_access, new_access)

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -244,31 +244,6 @@ def get_contract_token_for_account(contract_client, macaroon, account_id):
     return contract_token_response['contractToken']
 
 
-def get_dict_deltas(orig_dict, new_dict, path=''):
-    """Return a dictionary of delta between orig_dict and new_dict."""
-    deltas = {}
-    for key, value in orig_dict.items():
-        if isinstance(value, dict):
-            if path:
-                sub_path = path + '.' + key
-            else:
-                sub_path = key
-            sub_delta = get_dict_deltas(
-                value, new_dict.get(key, {}), path=sub_path)
-            if sub_delta:
-                deltas[key] = sub_delta
-        elif value != new_dict.get(key):
-            key_path = key if not path else path + '.' + key
-            logging.debug(
-                "Contract value for '%s' changed to '%s'",
-                key_path, new_dict.get(key))
-            deltas[key] = new_dict.get(key)
-    for key, value in new_dict.items():
-        if key not in orig_dict:
-            deltas[key] = value
-    return deltas
-
-
 def process_entitlement_delta(orig_access, new_access):
     """Process a entitlement access dictionary deltas if they exist.
 
@@ -281,7 +256,7 @@ def process_entitlement_delta(orig_access, new_access):
 
     if not orig_access or orig_access == new_access:
         return {}
-    deltas = get_dict_deltas(orig_access, new_access)
+    deltas = util.get_dict_deltas(orig_access, new_access)
     if deltas:
         name = orig_access['entitlement']['type']
         ent_cls = ENTITLEMENT_CLASS_BY_NAME[name]

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -309,7 +309,7 @@ def request_updated_contract(cfg, contract_token=None):
                 'Could not refresh machine token. %s', str(e))
             return False
     try:
-        for name, entitlement in cfg.entitlements.items():
+        for name, entitlement in sorted(cfg.entitlements.items()):
             if entitlement['entitlement'].get('entitled'):
                 # Obtain each entitlement's accessContext for this machine
                 new_access = contract_client.request_resource_machine_access(

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -210,8 +210,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         :param deltas: Dictionary which contains only the changed access keys
         and values.
         """
+        if not deltas:
+            return
         entitled_delta = deltas.get('entitlement', {}).get('entitled')
-        if orig_access and entitled_delta is False:
+        if orig_access and entitled_delta in (util.DROPPED_DICT_KEY, False):
             if self.can_disable(silent=True):
                 logging.debug(
                     "Due to contract refresh, '%s' is now disabled.",

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -219,11 +219,17 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             transition_to_unentitled = (
                 deltas['entitlement']['entitled'] in (False, util.DROPPED_KEY))
         if transition_to_unentitled:
-            if self.can_disable(silent=True):
-                logging.debug(
-                    "Due to contract refresh, '%s' is now disabled.",
-                    self.name)
-                self.disable()
+            op_status, _details = self.operational_status()
+            if op_status == status.ACTIVE:
+                if self.can_disable(silent=True):
+                    logging.info(
+                        "Due to contract refresh, '%s' is now disabled.",
+                        self.name)
+                    self.disable()
+                else:
+                    logging.warning(
+                        "Unable to disable '%s' as recommended during contract"
+                        " refresh. Service is still active. See `ua status`")
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -63,11 +63,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """
         message = ''
         retval = True
-        if not any([self.contract_status() == status.ENTITLED, force]):
-            message = status.MESSAGE_UNENTITLED_TMPL.format(title=self.title)
-            retval = False
-        elif not force:
-            op_status, status_details = self.operational_status()
+        op_status, status_details = self.operational_status()
+
+        if not force:
             if op_status == status.INACTIVE:
                 message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
                     title=self.title
@@ -229,7 +227,8 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 else:
                     logging.warning(
                         "Unable to disable '%s' as recommended during contract"
-                        " refresh. Service is still active. See `ua status`")
+                        " refresh. Service is still active. See `ua status`" %
+                        self.name)
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -1,9 +1,4 @@
-import os
-
-from uaclient import apt
 from uaclient.entitlements import repo
-from uaclient import status
-from uaclient import util
 
 
 class ESMEntitlement(repo.RepoEntitlement):
@@ -16,31 +11,4 @@ class ESMEntitlement(repo.RepoEntitlement):
         ' (https://ubuntu.com/esm)')
     repo_url = 'https://esm.ubuntu.com'
     repo_key_file = 'ubuntu-esm-v2-keyring.gpg'
-
-    def disable(self, silent=False, force=False):
-        """Disable specific entitlement
-
-        @return: True on success, False otherwise.
-        """
-        if not self.can_disable(silent, force):
-            return False
-        series = util.get_platform_info('series')
-        entitlement_cfg = self.cfg.read_cache(
-            'machine-access-%s' % self.name)['entitlement']
-        access_directives = entitlement_cfg.get('directives', {})
-        repo_url = access_directives.get('aptURL', self.repo_url)
-        if not repo_url:
-            repo_url = self.repo_url
-        # We only remove the repo from the apt auth file, because ESM is a
-        # special-case: we want to be able to report on the available ESM
-        # updates even when it's disabled
-        apt.remove_repo_from_apt_auth_file(repo_url)
-        if self.repo_pin_priority:
-            repo_pref_file = self.repo_pref_file_tmpl.format(
-                name=self.name, series=series)
-            if os.path.exists(repo_pref_file):
-                os.unlink(repo_pref_file)
-        self._set_local_enabled(False)
-        if not silent:
-            print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
-        return True
+    disable_apt_auth_only = True  # Only remove apt auth files when disabling

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,6 +1,3 @@
-import os
-
-from uaclient import apt
 from uaclient.entitlements import repo
 from uaclient import util
 
@@ -12,39 +9,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                 'libssl1.0.0-hmac', 'linux-fips', 'strongswan-hmac',
                 'openssh-client', 'openssh-server', 'openssl', 'libssl1.0.0',
                 'fips-initramfs', 'strongswan']
-
-    def disable(self, silent=False, force=False):
-        if not self.can_disable(silent, force):
-            return False
-        if force:  # Force config cleanup as broke during setup attempt.
-            series = util.get_platform_info('series')
-            repo_filename = self.repo_list_file_tmpl.format(
-                name=self.name, series=series)
-            keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
-            entitlement = self.cfg.read_cache(
-                'machine-access-%s' % self.name).get('entitlement', {})
-            access_directives = entitlement.get('directives', {})
-            repo_url = access_directives.get('aptURL', self.repo_url)
-            if not repo_url:
-                repo_url = self.repo_url
-            apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
-            if self.repo_pin_priority:
-                repo_pref_file = self.repo_pref_file_tmpl.format(
-                    name=self.name, series=series)
-                if os.path.exists(repo_pref_file):
-                    os.unlink(repo_pref_file)
-            apt.remove_apt_list_files(repo_url, series)
-            try:
-                util.subp(
-                    ['apt-get', 'remove', '--assume-yes'] + self.packages)
-            except util.ProcessExecutionError:
-                pass
-            self._set_local_enabled(False)
-        if not silent:
-            print('Warning: no option to disable {title}'.format(
-                title=self.title)
-            )
-        return False
+    force_disable = True
 
 
 class FIPSEntitlement(FIPSCommonEntitlement):

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -146,9 +146,9 @@ class RepoEntitlement(base.UAEntitlement):
             msg = status.MESSAGE_ENABLE_BY_DEFAULT_TMPL.format(
                 name=self.name)
             logging.info(msg)
-        old_url = orig_access.get('directives', {}).get('aptURL')
-        if old_url:
+        if delta_entitlement.get('directives', {}).get('aptURL'):
             # Remove original aptURL and auth and rewrite
+            old_url = orig_access.get('directives', {}).get('aptURL')
             series = util.get_platform_info('series')
             repo_filename = self.repo_list_file_tmpl.format(
                 name=self.name, series=series)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -134,9 +134,10 @@ class RepoEntitlement(base.UAEntitlement):
             resourceToken = deltas.get('resourceToken')
         delta_entitlement = deltas.get('entitlement', {})
         delta_obligations = delta_entitlement.get('obligations', {})
+        can_enable = self.can_enable(silent=True)
         enableByDefault = bool(
             delta_obligations.get('enableByDefault') and resourceToken)
-        if not any([op_status == status.ACTIVE, enableByDefault]):
+        if not any([op_status == status.ACTIVE, enableByDefault and can_enable]):
             return True
         if op_status == status.ACTIVE:
             logging.info(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -137,7 +137,8 @@ class RepoEntitlement(base.UAEntitlement):
         can_enable = self.can_enable(silent=True)
         enableByDefault = bool(
             delta_obligations.get('enableByDefault') and resourceToken)
-        if not any([op_status == status.ACTIVE, enableByDefault and can_enable]):
+        if not any(
+                [op_status == status.ACTIVE, enableByDefault and can_enable]):
             return True
         if op_status == status.ACTIVE:
             logging.info(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -180,8 +180,9 @@ class RepoEntitlement(base.UAEntitlement):
         creds = 'bearer:%s' % new_token
         if new_url:
             # Remove original aptURL and auth and rewrite
-            apt.remove_auth_apt_repo(
-                repo_filename, orig_access.get('directives', {}).get('aptURL'))
+            old_url = orig_access.get('directives', {}).get('aptURL')
+            if old_url:
+                apt.remove_auth_apt_repo(repo_filename, old_url)
         else:
             new_url = orig_access.get('directives', {}).get('aptURL')
         if not new_suites:

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -296,4 +296,6 @@ class TestUaEntitlement:
         # Cache was cleaned
         assert None is entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
-        assert [('operational_status', ), ('disable', )] == entitlement.calls()
+        expected_calls = [
+            ('operational_status', ), ('operational_status', ), ('disable', )]
+        assert expected_calls == entitlement.calls()

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -85,7 +85,7 @@ class TestUaEntitlement:
         entitlement = ConcreteTestEntitlement(cfg)
         assert '/some/path' == entitlement.cfg.data_dir
 
-    def test_can_disable_false_on_unentitled(
+    def test_can_disable_true_on_unentitled_operational_status_active(
             self, capsys, concrete_entitlement_factory):
         """When entitlement is active yet unentitled, can_disable is True."""
         entitlement = concrete_entitlement_factory(

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -259,7 +259,7 @@ class TestUaEntitlement:
     @pytest.mark.parametrize(
         'orig_access,delta',
         (({'entitlement': {'entitled': True}},  # Full entitlement dropped
-          {'entitlement': {'entitled': util.DROPPED_DICT_KEY}}),
+          {'entitlement': {'entitled': util.DROPPED_KEY}}),
          ({'entitlement': {'entitled': True}},
           {'entitlement': {'entitled': False}})  # transition to unentitled
          ))
@@ -280,7 +280,7 @@ class TestUaEntitlement:
     @pytest.mark.parametrize(
         'orig_access,delta',
         (({'entitlement': {'entitled': True}},  # Full entitlement dropped
-          {'entitlement': {'entitled': util.DROPPED_DICT_KEY}}),
+          {'entitlement': {'entitled': util.DROPPED_KEY}}),
          ({'entitlement': {'entitled': True}},
           {'entitlement': {'entitled': False}})  # transition to unentitled
          ))

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -53,7 +53,8 @@ def concrete_entitlement_factory(tmpdir):
             'machineTokenInfo': {
                 'contractInfo': {
                     'resourceEntitlements': [
-                        {'type': 'testconcreteentitlement'}]}}}
+                        {'type': 'testconcreteentitlement',
+                         'entitled': True}]}}}
         cfg.write_cache('machine-token', machineToken)
         cfg.write_cache('machine-access-testconcreteentitlement',
                         {'entitlement': {'entitled': entitled}})
@@ -86,17 +87,11 @@ class TestUaEntitlement:
 
     def test_can_disable_false_on_unentitled(
             self, capsys, concrete_entitlement_factory):
-        """When entitlement contract is not enabled, can_disable is False."""
+        """When entitlement is active yet unentitled, can_disable is True."""
         entitlement = concrete_entitlement_factory(
-            entitled=False, operational_status=(status.INACTIVE, ''))
+            entitled=False, operational_status=(status.ACTIVE, ''))
 
-        assert not entitlement.can_disable()
-
-        expected_stdout = (
-            'This subscription is not entitled to Test Concrete Entitlement.\n'
-            'See `ua status` or https://ubuntu.com/advantage\n')
-        stdout, _ = capsys.readouterr()
-        assert expected_stdout == stdout
+        assert entitlement.can_disable()
 
     def test_can_disable_false_on_entitlement_inactive(
             self, capsys, concrete_entitlement_factory):

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -20,7 +20,7 @@ CC_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'cc'}]}}}
+                {'type': 'cc', 'entitled': True}]}}}
 
 
 CC_RESOURCE_ENTITLED = {

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -13,7 +13,7 @@ CIS_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'cis-audit'}]}}}
+                {'type': 'cis-audit', 'entitled': True}]}}}
 
 
 CIS_RESOURCE_ENTITLED = {

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -17,7 +17,7 @@ FIPS_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'fips'}]}}}
+                {'type': 'fips', 'entitled': True}]}}}
 
 
 FIPS_RESOURCE_ENTITLED = {

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -18,7 +18,7 @@ LIVEPATCH_MACHINE_TOKEN = MappingProxyType({
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'livepatch'}]}}})
+                {'type': 'livepatch', 'entitled': True}]}}})
 
 
 LIVEPATCH_RESOURCE_ENTITLED = MappingProxyType({

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -15,7 +15,7 @@ REPO_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'repotest'}]}}}
+                {'type': 'repotest', 'entitled': True}]}}}
 REPO_RESOURCE_ENTITLED = {
     'resourceToken': 'TOKEN',
     'entitlement': {

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -92,7 +92,7 @@ class TestProcessContractDeltas:
             {'entitlement': {'entitled': True}},
             {'entitlement': {'obligations': {'enableByDefault': False}},
              'resourceToken': 'TOKEN'})
-        assert [mock.call()] == m_op_status.call_args_list
+        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         assert [] == m_remove_apt_config.call_args_list
 
     @mock.patch.object(RepoTestEntitlement, 'setup_apt_config')
@@ -107,7 +107,7 @@ class TestProcessContractDeltas:
             {'entitlement': {'entitled': True}},
             {'entitlement': {'obligations': {'enableByDefault': True}},
              'resourceToken': 'TOKEN'})
-        assert [mock.call()] == m_op_status.call_args_list
+        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         assert [mock.call()] == m_remove_apt_config.call_args_list
         assert [mock.call()] == m_setup_apt_config.call_args_list
 
@@ -123,7 +123,7 @@ class TestProcessContractDeltas:
             {'entitlement': {'entitled': True}},
             {'entitlement': {'obligations': {'enableByDefault': False}},
              'resourceToken': 'TOKEN'})
-        assert [mock.call()] == m_op_status.call_args_list
+        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         assert [mock.call()] == m_remove_apt_config.call_args_list
         assert [mock.call()] == m_setup_apt_config.call_args_list
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -71,7 +71,9 @@ Could not attach machine. Error contacting server {url}"""
 MESSAGE_ATTACH_SUCCESS_TMPL = """\
 This machine is now attached to '{contract_name}'.
 """
+
 MESSAGE_ATTACH_ENABLING_DEFAULTS = 'Enabling default entitlements...'
+MESSAGE_ENABLE_BY_DEFAULT_TMPL = 'Enabling default entitlement {name}'
 MESSAGE_DETACH_SUCCESS = 'This machine is now detached'
 
 MESSAGE_REFRESH_ENABLE = 'Refreshing contracts prior to enable'

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -58,7 +58,9 @@ class FakeConfig(UAConfig):
             'accounts': {'accounts': [{'name': account_name}]},
             'machine-token': {
                 'machineToken': 'not-null',
-                'machineTokenInfo': {'contractInfo': {'id': 'cid'}}}
+                'machineTokenInfo': {
+                    'contractInfo': {'id': 'cid',
+                                     'resourceEntitlements': []}}}
         }
         if machine_token:
             value['machine-token'] = machine_token

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -238,9 +238,9 @@ class TestActionAttachEnableByDefault:
             {'type': 'enable2', 'obligations': {'enableByDefault': True}},
             {'type': 'dont2', 'obligations': {'otherValue': True}},
             {'type': 'enable3', 'obligations': {'enableByDefault': True}},
-            {'type': 'dont2', 'obligations': {}},
+            {'type': 'dont3', 'obligations': {}},
             {'type': 'enable4', 'obligations': {'enableByDefault': True}},
-            {'type': 'dont3'},
+            {'type': 'dont4'},
             {'type': 'enable1', 'obligations': {'enableByDefault': True}},
         ]
         token = 'contract-token'

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -2,7 +2,8 @@ import mock
 import pytest
 
 from uaclient.contract import (
-    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH, request_updated_contract)
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH,
+    API_V1_TMPL_RESOURCE_MACHINE_ACCESS, request_updated_contract)
 
 from uaclient.testing.fakes import FakeConfig, FakeContractClient
 
@@ -32,10 +33,12 @@ class TestRequestUpdatedContract:
     @mock.patch(M_PATH + 'UAContractClient')
     def test_attached_config_refresh_machine_token_and_services(
             self, client, get_machine_id):
-        """When attached, refresh machine token and all entitlements."""
+        """When attached, refresh machine token and all enabled services."""
 
         refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH.format(
             contract='cid', machine='mid')
+        access_route_ent1 = API_V1_TMPL_RESOURCE_MACHINE_ACCESS.format(
+            resource='ent1', machine='mid')
 
         machine_token = {
             'machineToken': 'mToken',
@@ -46,7 +49,11 @@ class TestRequestUpdatedContract:
 
         def fake_contract_client(cfg):
             client = FakeContractClient(cfg)
-            client._responses = {refresh_route: machine_token}
+            # Note ent2 access route is not called
+            client._responses = {
+                refresh_route: machine_token,
+                access_route_ent1: {
+                    'entitlement': {'entitled': True, 'type': 'ent1'}}}
             return client
 
         client.side_effect = fake_contract_client

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -20,8 +20,9 @@ class TestProcessEntitlementDeltas:
         """Raise an error when neither dict contains entitlement type."""
         error_msg = ('Could not determine contract delta service type %s %s' %
                      ({}, {'something': 'non-empty'}))
-        with pytest.raises(RuntimeError, match=error_msg):
+        with pytest.raises(RuntimeError) as exc:
             process_entitlement_delta({}, {'something': 'non-empty'})
+        assert error_msg == str(exc.value)
 
     def test_no_delta_on_equal_dicts(self):
         """No deltas are reported or processed when dicts are equal."""

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -86,9 +86,9 @@ class TestGetDictDeltas:
 
     def test_diffs_return_dropped_keys_set_dropped(self):
         """Old keys which are now dropped are returned as DROPPED_KEY."""
-        expected = {'oldkey': util.DROPPED_KEY}
+        expected = {'oldkey': util.DROPPED_KEY, 'oldkey2': util.DROPPED_KEY}
         assert expected == util.get_dict_deltas(
-            {'oldkey': 'v', 'k': 'v'}, {'k': 'v'})
+            {'oldkey': 'v', 'k': 'v', 'oldkey2': {}}, {'k': 'v'})
 
     def test_return_only_keys_which_represent_deltas(self):
         """Only return specific keys which have deltas."""

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -85,8 +85,8 @@ class TestGetDictDeltas:
             {'k': 'v'}, {'newkey': 'val', 'k': 'v'})
 
     def test_diffs_return_dropped_keys_set_dropped(self):
-        """Old keys which are now dropped are returned as DROPPED."""
-        expected = {'oldkey': util.DROPPED_DICT_KEY}
+        """Old keys which are now dropped are returned as DROPPED_KEY."""
+        expected = {'oldkey': util.DROPPED_KEY}
         assert expected == util.get_dict_deltas(
             {'oldkey': 'v', 'k': 'v'}, {'k': 'v'})
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -12,7 +12,7 @@ SENSITIVE_KEYS = ['caveat_id', 'password', 'resourceToken', 'machineToken']
 
 ETC_MACHINE_ID = '/etc/machine-id'
 DBUS_MACHINE_ID = '/var/lib/dbus/machine-id'
-DROPPED_DICT_KEY = 'DROPPED'
+DROPPED_KEY = object()
 
 
 class UrlError(IOError):
@@ -66,7 +66,7 @@ def get_dict_deltas(orig_dict, new_dict, path=''):
     """Return a dictionary of delta between orig_dict and new_dict."""
     deltas = {}
     for key, value in orig_dict.items():
-        new_value = new_dict.get(key, DROPPED_DICT_KEY)
+        new_value = new_dict.get(key, DROPPED_KEY)
         if isinstance(value, dict):
             if path:
                 sub_path = path + '.' + key

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -12,6 +12,7 @@ SENSITIVE_KEYS = ['caveat_id', 'password', 'resourceToken', 'machineToken']
 
 ETC_MACHINE_ID = '/etc/machine-id'
 DBUS_MACHINE_ID = '/var/lib/dbus/machine-id'
+DROPPED_DICT_KEY = 'DROPPED'
 
 
 class UrlError(IOError):
@@ -65,6 +66,7 @@ def get_dict_deltas(orig_dict, new_dict, path=''):
     """Return a dictionary of delta between orig_dict and new_dict."""
     deltas = {}
     for key, value in orig_dict.items():
+        new_value = new_dict.get(key, DROPPED_DICT_KEY)
         if isinstance(value, dict):
             if path:
                 sub_path = path + '.' + key
@@ -74,12 +76,11 @@ def get_dict_deltas(orig_dict, new_dict, path=''):
                 value, new_dict.get(key, {}), path=sub_path)
             if sub_delta:
                 deltas[key] = sub_delta
-        elif value != new_dict.get(key):
+        elif value != new_value:
             key_path = key if not path else path + '.' + key
             logging.debug(
-                "Contract value for '%s' changed to '%s'",
-                key_path, new_dict.get(key))
-            deltas[key] = new_dict.get(key)
+                "Contract value for '%s' changed to '%s'", key_path, new_value)
+            deltas[key] = new_value
     for key, value in new_dict.items():
         if key not in orig_dict:
             deltas[key] = value

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -61,6 +61,31 @@ def encode_text(text, encoding='utf-8'):
     return text.encode(encoding)
 
 
+def get_dict_deltas(orig_dict, new_dict, path=''):
+    """Return a dictionary of delta between orig_dict and new_dict."""
+    deltas = {}
+    for key, value in orig_dict.items():
+        if isinstance(value, dict):
+            if path:
+                sub_path = path + '.' + key
+            else:
+                sub_path = key
+            sub_delta = get_dict_deltas(
+                value, new_dict.get(key, {}), path=sub_path)
+            if sub_delta:
+                deltas[key] = sub_delta
+        elif value != new_dict.get(key):
+            key_path = key if not path else path + '.' + key
+            logging.debug(
+                "Contract value for '%s' changed to '%s'",
+                key_path, new_dict.get(key))
+            deltas[key] = new_dict.get(key)
+    for key, value in new_dict.items():
+        if key not in orig_dict:
+            deltas[key] = value
+    return deltas
+
+
 def is_container(run_path='/run'):
     """Checks to see if this code running in a container of some sort"""
     try:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -67,17 +67,16 @@ def get_dict_deltas(orig_dict, new_dict, path=''):
     deltas = {}
     for key, value in orig_dict.items():
         new_value = new_dict.get(key, DROPPED_KEY)
+        key_path = key if not path else path + '.' + key
         if isinstance(value, dict):
-            if path:
-                sub_path = path + '.' + key
+            if key in new_dict:
+                sub_delta = get_dict_deltas(
+                    value, new_dict[key], path=key_path)
+                if sub_delta:
+                    deltas[key] = sub_delta
             else:
-                sub_path = key
-            sub_delta = get_dict_deltas(
-                value, new_dict.get(key, {}), path=sub_path)
-            if sub_delta:
-                deltas[key] = sub_delta
+                deltas[key] = DROPPED_KEY
         elif value != new_value:
-            key_path = key if not path else path + '.' + key
             logging.debug(
                 "Contract value for '%s' changed to '%s'", key_path, new_value)
             deltas[key] = new_value


### PR DESCRIPTION
Log and handle changes to resourceToken, aptURL and suites directives during a ua
refresh operation. When an active entitlement transitions to unentitled, that entitlement will be disabled.

Refactor Fips and ESMEntitlement.disable methods up into a common RepoEntitlement.disable() method which calls a new remove_apt_config() to manage removal of apt config files. RepoEntitlement.process_contract_deltas calls remove_apt_configto ensure stale apt config information is removed prior to writing updated apt config content.

While livepatch delta disable is handled, handling livepatch token and service configuration deltas will be handled in a separate issue.

Fixes: #385
Fixes: #436 