### PR TITLE
esm: all repo entitlements now call apt-get update on enable

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -96,10 +96,14 @@ class RepoEntitlement(base.UAEntitlement):
         except apt.InvalidAPTCredentialsError as e:
             logging.error(str(e))
             return False
+        # Run apt-update on any repo-entitlement enable because the machine
+        # probably wants access to the repo that was just enabled.
+        # Side-effect is that apt policy will new report the repo as accessible
+        # which allows ua status to report correct info
+        print('Updating package lists ...')
+        util.subp(['apt-get', 'update'], capture=True)
         if self.packages:
             try:
-                print('Updating package lists ...')
-                util.subp(['apt-get', 'update'], capture=True)
                 print(
                     'Installing {title} packages ...'.format(title=self.title))
                 util.subp(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -1,16 +1,61 @@
-import mock
+from textwrap import dedent
 
+import mock
 import pytest
 
+from uaclient import apt
 from uaclient import config
 from uaclient.entitlements.repo import RepoEntitlement
 
 
+M_PATH = 'uaclient.entitlements.repo.'
+
+REPO_MACHINE_TOKEN = {
+    'machineToken': 'blah',
+    'machineTokenInfo': {
+        'contractInfo': {
+            'resourceEntitlements': [
+                {'type': 'repotest'}]}}}
+REPO_RESOURCE_ENTITLED = {
+    'resourceToken': 'TOKEN',
+    'entitlement': {
+        'obligations': {
+            'enableByDefault': True
+        },
+        'type': 'repotest',
+        'entitled': True,
+        'directives': {
+            'aptURL': 'http://REPOTEST',
+            'aptKey': 'APTKEY',
+            'suites': ['xenial']
+        },
+        'affordances': {
+            'series': ['xenial']
+        }
+    }
+}
+
+
 class RepoTestEntitlement(RepoEntitlement):
     """Subclass so we can test shared repo functionality"""
+    name = 'repotest'
+    title = 'Repo Test Class'
 
     def disable(self, *args, **kwargs):
         pass
+
+
+@pytest.fixture
+def entitlement(tmpdir):
+    """
+    A pytest fixture to create a RepoTestEntitlement with some default config
+
+    (Uses the tmpdir fixture for the underlying config cache.)
+    """
+    cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+    cfg.write_cache('machine-token', dict(REPO_MACHINE_TOKEN))
+    cfg.write_cache('machine-access-repotest', dict(REPO_RESOURCE_ENTITLED))
+    return RepoTestEntitlement(cfg)
 
 
 class TestRepoEnable:
@@ -30,3 +75,44 @@ class TestRepoEnable:
 
         expected_call = mock.call(silent=bool(silent_if_inapplicable))
         assert [expected_call] == m_can_enable.call_args_list
+
+    @pytest.mark.parametrize('packages', (['a'], [], None))
+    @mock.patch(M_PATH + 'util.subp')
+    @mock.patch(M_PATH + 'apt.add_auth_apt_repo')
+    @mock.patch(M_PATH + 'os.path.exists', return_value=True)
+    @mock.patch(M_PATH + 'util.get_platform_info')
+    @mock.patch.object(RepoTestEntitlement, 'can_enable', return_value=True)
+    def test_enable_calls_adds_apt_repo_and_calls_apt_update(
+            self, m_can_enable, m_platform, m_exists, m_apt_add, m_subp,
+            entitlement, capsys, caplog_text, tmpdir, packages):
+        """On enable add authenticated apt repo and refresh package lists."""
+        m_platform.return_value = 'xenial'  # from 'series' param
+
+        expected_apt_calls = [mock.call(['apt-get', 'update'], capture=True)]
+        expected_output = dedent("""\
+        Updating package lists ...
+        Repo Test Class enabled.
+        """)
+        if packages is not None:
+            entitlement.packages = packages
+            if len(packages) > 0:
+                expected_apt_calls.append(
+                    mock.call(['apt-get', 'install', '--assume-yes',
+                              ' '.join(packages)], capture=True))
+                expected_output = dedent("""\
+                    Updating package lists ...
+                    Installing Repo Test Class packages ...
+                    Repo Test Class enabled.
+                    """)
+        entitlement.enable()
+
+        expected_calls = [mock.call(apt.APT_METHOD_HTTPS_FILE),
+                          mock.call(apt.CA_CERTIFICATES_FILE)]
+        assert expected_calls in m_exists.call_args_list
+        assert expected_apt_calls == m_subp.call_args_list
+        assert [mock.call(
+            '/etc/apt/sources.list.d/ubuntu-repotest-xenial.list',
+            'http://REPOTEST', 'TOKEN', ['xenial'],
+            '/usr/share/keyrings/UNSET')] == m_apt_add.call_args_list
+        stdout, _ = capsys.readouterr()
+        assert expected_output == stdout


### PR DESCRIPTION
Expectation is that a machine that is enabling a service would need to
access that services packages from the repo they just enabled.

Fixes: #377