### PR TITLE
/etc/apt/auth.conf: ensure newline always exists

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -128,6 +128,7 @@ def add_apt_auth_conf_entry(repo_url, login, password):
         new_lines.append(line)
     if not added_new_auth:
         new_lines.append(repo_auth_line)
+    new_lines.append('')
     util.write_file(apt_auth_file, '\n'.join(new_lines), mode=0o600)
 
 

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -262,7 +262,7 @@ class TestAddAuthAptRepo:
             suites=('xenial',), fingerprint='APTKEY')
 
         expected_content = (
-            'machine fakerepo/ login user password password%s' %
+            'machine fakerepo/ login user password password%s\n' %
             APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
@@ -285,7 +285,7 @@ class TestAddAuthAptRepo:
             fingerprint='APTKEY')
 
         expected_content = (
-            'machine fakerepo/ login bearer password SOMELONGTOKEN%s'
+            'machine fakerepo/ login bearer password SOMELONGTOKEN%s\n'
             % APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
@@ -311,8 +311,8 @@ class TestAddAptAuthConfEntry:
         expected_content = dedent("""\
             machine fakerepo1/ login me password password1
             machine fakerepo/ login newlogin password newpass%s
-            machine fakerepo2/ login other password otherpass\
-""" % APT_AUTH_COMMENT)
+            machine fakerepo2/ login other password otherpass
+        """ % APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
@@ -336,8 +336,8 @@ class TestAddAptAuthConfEntry:
             machine fakerepo1/ login me password password1
             machine fakerepo/subroute/ login new password newpass%s
             machine fakerepo/ login old password oldpassword
-            machine fakerepo2/ login other password otherpass\
-""" % APT_AUTH_COMMENT)
+            machine fakerepo2/ login other password otherpass
+        """ % APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
 


### PR DESCRIPTION
The original implementation would join the strings of an array
with a newline. However, when that array only consisted of a single
element the new line would not get added. This ensures there is always a
newline in every auth entry.

Fixes #376