### PR TITLE
Fix/empty config values

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -399,7 +399,7 @@ def main(sys_argv=None):
     args = parser.parse_args(args=cli_arguments)
     cfg = config.UAConfig()
     try:
-        log_level = int(cfg.log_level)
+        log_level = cfg.log_level
     except TypeError:
         log_level = getattr(logging, '%s' % cfg.log_file.upper())
     console_level = logging.DEBUG if args.debug else logging.INFO

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -398,10 +398,7 @@ def main(sys_argv=None):
         sys.exit(1)
     args = parser.parse_args(args=cli_arguments)
     cfg = config.UAConfig()
-    try:
-        log_level = cfg.log_level
-    except TypeError:
-        log_level = getattr(logging, '%s' % cfg.log_file.upper())
+    log_level = cfg.log_level
     console_level = logging.DEBUG if args.debug else logging.INFO
     setup_logging(console_level, log_level, cfg.log_file)
     return args.action(args, cfg)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -90,13 +90,10 @@ class UAConfig:
     @property
     def log_level(self):
         log_level = self.cfg.get('log_level')
-        if log_level:
-            log_level = getattr(logging, log_level.upper())
         try:
-            int(log_level)
-        except TypeError:
-            return CONFIG_DEFAULTS['log_level']
-        return log_level
+            return getattr(logging, log_level.upper())
+        except AttributeError:
+            return getattr(logging, CONFIG_DEFAULTS['log_level'])
 
     @property
     def log_file(self):

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -4,8 +4,6 @@ Project-wide default settings
 These are in their own file so they can be imported by setup.py before we have
 any of our dependencies installed.
 """
-import logging
-
 
 DEFAULT_CONFIG_FILE = '/etc/ubuntu-advantage/uaclient.conf'
 BASE_AUTH_URL = 'https://login.ubuntu.com'

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -15,6 +15,6 @@ CONFIG_DEFAULTS = {
     'sso_auth_url': BASE_AUTH_URL,
     'service_url': BASE_SERVICE_URL,
     'data_dir': '/var/lib/ubuntu-advantage',
-    'log_level': logging.INFO,
+    'log_level': 'INFO',
     'log_file': '/var/log/ubuntu-advantage.log'
 }


### PR DESCRIPTION
The default value for logging when it was missing was becoming an
integer (logging.INFO == 20) and then being passed around between
functions that expected a string value for the level.

Rather than storing logging.INFO as the default value for logging, use
the same value/string that we print to the file, namely 'INFO' and then
do the right thing with the string.

Fixes #406