### PR TITLE
attach: suppress messages from inapplicable default entitlements

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -185,7 +185,8 @@ def action_disable(args, cfg):
         return 1
 
 
-def _perform_enable(entitlement_name: str, cfg: config.UAConfig) -> bool:
+def _perform_enable(entitlement_name: str, cfg: config.UAConfig,
+                    silent_if_inapplicable: bool = False) -> bool:
     """Perform the enable action on a named entitlement.
 
     (This helper excludes any messaging, so that different enablement code
@@ -193,12 +194,15 @@ def _perform_enable(entitlement_name: str, cfg: config.UAConfig) -> bool:
 
     :param entitlement_name: the name of the entitlement to enable
     :param cfg: the UAConfig to pass to the entitlement
+    :param silent_if_inapplicable:
+        don't output messages when determining if an entitlement can be
+        enabled on this system
 
     @return: True on success, False otherwise
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
     entitlement = ent_cls(cfg)
-    return entitlement.enable()
+    return entitlement.enable(silent_if_inapplicable=silent_if_inapplicable)
 
 
 @assert_attached_root

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -185,7 +185,7 @@ def action_disable(args, cfg):
         return 1
 
 
-def _perform_enable(entitlement_name: str, cfg: config.UAConfig,
+def _perform_enable(entitlement_name: str, cfg: config.UAConfig, *,
                     silent_if_inapplicable: bool = False) -> bool:
     """Perform the enable action on a named entitlement.
 
@@ -281,7 +281,7 @@ def action_attach(args, cfg):
     if enable_by_default_entitlements:
         print(ua_status.MESSAGE_ATTACH_ENABLING_DEFAULTS)
         for entitlement_name in enable_by_default_entitlements:
-            _perform_enable(entitlement_name, cfg)
+            _perform_enable(entitlement_name, cfg, silent_if_inapplicable=True)
         print()  # Add a line before status output
 
     action_status(args=None, cfg=cfg)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -187,7 +187,8 @@ class TestActionAttachEnableByDefault:
         cfg = FakeConfig.with_account()
 
         # Make our mocks output something, so we can test the output layout
-        m_perform_enable.side_effect = lambda *args: print('perform_enable')
+        m_perform_enable.side_effect = (
+            lambda *args, **kwargs: print('perform_enable'))
         m_action_status.side_effect = (
             lambda *args, **kwargs: print('action_status'))
 
@@ -205,7 +206,8 @@ class TestActionAttachEnableByDefault:
 
         assert 0 == ret
         assert 1 == m_action_status.call_count
-        expected_calls = [mock.call(entitlement['type'], cfg)]
+        expected_calls = [
+            mock.call(entitlement['type'], cfg, silent_if_inapplicable=True)]
         assert expected_calls == m_perform_enable.call_args_list
         stdout, _ = capsys.readouterr()
         expected_output = (
@@ -247,7 +249,7 @@ class TestActionAttachEnableByDefault:
 
         # Make our mocks output something, so we can test the output layout
         m_perform_enable.side_effect = (
-            lambda name, _: print('perform_enable: {}'.format(name)))
+            lambda name, _, **kwargs: print('perform_enable: {}'.format(name)))
         m_action_status.side_effect = (
             lambda *args, **kwargs: print('action_status'))
 
@@ -266,7 +268,7 @@ class TestActionAttachEnableByDefault:
         assert 0 == ret
         assert 1 == m_action_status.call_count
         expected_calls = [
-            mock.call(ent_name, cfg)
+            mock.call(ent_name, cfg, silent_if_inapplicable=True)
             for ent_name in ['enable1', 'enable2', 'enable3', 'enable4']]
         assert expected_calls == m_perform_enable.call_args_list
         stdout, _ = capsys.readouterr()

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -19,18 +19,27 @@ class TestPerformEnable:
         with pytest.raises(KeyError):
             _perform_enable('entitlement', mock.Mock())
 
+    @pytest.mark.parametrize('silent_if_inapplicable', (True, False, None))
     @mock.patch('uaclient.cli.entitlements')
-    def test_entitlement_instantiated_and_enabled(self, m_entitlements):
+    def test_entitlement_instantiated_and_enabled(self, m_entitlements,
+                                                  silent_if_inapplicable):
         m_entitlement_cls = mock.Mock()
         m_cfg = mock.Mock()
         m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
             'testitlement': m_entitlement_cls,
         }
 
-        ret = _perform_enable('testitlement', m_cfg)
+        kwargs = {}
+        if silent_if_inapplicable is not None:
+            kwargs['silent_if_inapplicable'] = silent_if_inapplicable
+        ret = _perform_enable('testitlement', m_cfg, **kwargs)
 
         assert [mock.call(m_cfg)] == m_entitlement_cls.call_args_list
 
         m_entitlement = m_entitlement_cls.return_value
-        assert [mock.call()] == m_entitlement.enable.call_args_list
+        if silent_if_inapplicable:
+            expected_enable_call = mock.call(silent_if_inapplicable=True)
+        else:
+            expected_enable_call = mock.call(silent_if_inapplicable=False)
+        assert [expected_enable_call] == m_entitlement.enable.call_args_list
         assert ret == m_entitlement.enable.return_value


### PR DESCRIPTION
`ua enable` will emit messages when determining if an entitlement is
applicable to the current system.  For a less noisy user experience, we
don't want to emit these messages when enabling default entitlements
during `ua attach`.  This patch silences that output (but retains the
output from entitlements that are applicable).

Fixes #411.