### PR TITLE
bug: do not try remove_apt_auth_apt_repo if old_url is None

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -158,12 +158,14 @@ class RepoEntitlement(base.UAEntitlement):
                 name=self.name)
             logging.info(msg)
         if delta_entitlement.get('directives', {}).get('aptURL'):
-            # Remove original aptURL and auth and rewrite
-            old_url = orig_access.get('directives', {}).get('aptURL')
-            series = util.get_platform_info('series')
-            repo_filename = self.repo_list_file_tmpl.format(
-                name=self.name, series=series)
-            apt.remove_auth_apt_repo(repo_filename, old_url)
+            orig_entitlement = orig_access.get('entitlement', {})
+            old_url = orig_entitlement.get('directives', {}).get('aptURL')
+            if old_url:
+                # Remove original aptURL and auth and rewrite
+                series = util.get_platform_info('series')
+                repo_filename = self.repo_list_file_tmpl.format(
+                    name=self.name, series=series)
+                apt.remove_auth_apt_repo(repo_filename, old_url)
         self.remove_apt_config()
         self.setup_apt_config()
         return True


### PR DESCRIPTION
On fresh ua attach deltas, old aptURL does not exist.
    
process_contract_deltas will not attempt apt_auth_apt_repo in this case.
Drive by add unit test for contract ordering.
    
Fixes: #449