### PR TITLE
tests: add some missing mocks

### DIFF
--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -79,9 +79,10 @@ class TestCommonCriteriaEntitlementOperationalStatus:
 
 class TestCommonCriteriaEntitlementCanEnable:
 
+    @mock.patch('uaclient.util.subp', return_value=('', ''))
     @mock.patch('uaclient.util.get_platform_info')
     def test_can_enable_true_on_entitlement_inactive(
-            self, m_platform_info, tmpdir):
+            self, m_platform_info, _m_subp, tmpdir):
         """When operational status is INACTIVE, can_enable returns True."""
         m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -3,7 +3,7 @@
 import mock
 from io import StringIO
 
-from uaclient import config
+from uaclient import config, status
 from uaclient.entitlements.cis import CISEntitlement
 from uaclient.testing.helpers import TestCase
 
@@ -47,8 +47,10 @@ class TestCISEntitlementCanEnable(TestCase):
         entitlement = CISEntitlement(cfg)
         # Unset static affordance container check
         entitlement.static_affordances = ()
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            self.assertTrue(entitlement.can_enable())
+        with mock.patch.object(entitlement, 'operational_status',
+                               return_value=(status.INACTIVE, '')):
+            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+                self.assertTrue(entitlement.can_enable())
         self.assertEqual('', m_stdout.getvalue())
 
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from uaclient import config
+from uaclient import config, status
 from uaclient.entitlements.fips import FIPSEntitlement, FIPSUpdatesEntitlement
 
 try:
@@ -72,8 +72,10 @@ class TestFIPSEntitlementCanEnable:
 
     def test_can_enable_true_on_entitlement_inactive(self, entitlement):
         """When operational status is INACTIVE, can_enable returns True."""
-        with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            assert True is entitlement.can_enable()
+        with mock.patch.object(entitlement, 'operational_status',
+                               return_value=(status.INACTIVE, '')):
+            with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+                assert True is entitlement.can_enable()
         assert '' == m_stdout.getvalue()
 
 


### PR DESCRIPTION
This makes the tests more correct, and also speeds them up by ~a second
(almost half their running time) on my local system.