### PR TITLE
fips: only install/upgrade optional packages that are already on the system

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -256,3 +256,11 @@ def migrate_apt_sources(clean=False, cfg=None, platform_info=None):
                 'Disabled %s after package upgrade/downgrade. %s',
                 entitlement.title, details)
         entitlement.enable()  # Re-enable on current series
+
+
+def is_pkg_installed(pkg_name: str) -> bool:
+    try:
+        util.subp(['dpkg', '-s', pkg_name])
+    except util.ProcessExecutionError:
+        return False
+    return True

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,8 +1,8 @@
 from uaclient.entitlements import repo
-from uaclient import util
+from uaclient import apt, util
 
 try:
-    from typing import List  # noqa
+    from typing import Dict, List, Set  # noqa
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
@@ -11,15 +11,24 @@ except ImportError:
 class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
-    fips_required_packages = [
-        'openssh-client-hmac', 'openssh-server-hmac', 'libssl1.0.0-hmac',
-        'linux-fips', 'strongswan-hmac', 'openssh-client', 'openssh-server',
-        'openssl', 'libssl1.0.0', 'fips-initramfs', 'strongswan']
+    fips_required_packages = frozenset({'fips-initramfs', 'linux-fips'})
+    fips_packages = {
+        'libssl1.0.0': {'libssl1.0.0-hmac'},
+        'openssh-client': {'openssh-client-hmac'},
+        'openssh-server': {'openssh-server-hmac'},
+        'openssl': set(),
+        'strongswan': {'strongswan-hmac'},
+    }  # type: Dict[str, Set[str]]
     force_disable = True
 
     @property
     def packages(self) -> 'List[str]':
-        return self.fips_required_packages
+        packages = list(self.fips_required_packages)
+        for pkg_name, extra_pkgs in self.fips_packages.items():
+            if apt.is_pkg_installed(pkg_name):
+                packages.append(pkg_name)
+                packages.extend(extra_pkgs)
+        return packages
 
 
 class FIPSEntitlement(FIPSCommonEntitlement):

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -1,15 +1,25 @@
 from uaclient.entitlements import repo
 from uaclient import util
 
+try:
+    from typing import List  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 
 class FIPSCommonEntitlement(repo.RepoEntitlement):
 
     repo_pin_priority = 1001
-    packages = ['openssh-client-hmac', 'openssh-server-hmac',
-                'libssl1.0.0-hmac', 'linux-fips', 'strongswan-hmac',
-                'openssh-client', 'openssh-server', 'openssl', 'libssl1.0.0',
-                'fips-initramfs', 'strongswan']
+    fips_required_packages = [
+        'openssh-client-hmac', 'openssh-server-hmac', 'libssl1.0.0-hmac',
+        'linux-fips', 'strongswan-hmac', 'openssh-client', 'openssh-server',
+        'openssl', 'libssl1.0.0', 'fips-initramfs', 'strongswan']
     force_disable = True
+
+    @property
+    def packages(self) -> 'List[str]':
+        return self.fips_required_packages
 
 
 class FIPSEntitlement(FIPSCommonEntitlement):


### PR DESCRIPTION
The effect of this is to upgrade the optional FIPS packages that a user already has present (as well as installing their HMACs).  Previously, we would install _every_ optional FIPS package, whether or not the user was likely to want them.

Fixes #440 