### PR TITLE
status: unentitled services will report n/a

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -127,8 +127,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             all defined affordances, False if it doesn't meet any of the
             provided constraints.
         """
-        entitlements = self.cfg.entitlements
-        entitlement_cfg = entitlements.get(self.name)
+        entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
             return True, 'no entitlement affordances checked'
         affordances = entitlement_cfg['entitlement'].get('affordances', {})

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -146,6 +146,11 @@ class LivepatchEntitlement(base.UAEntitlement):
         passed_affordances, details = self.check_affordances()
         if not passed_affordances:
             return status.INAPPLICABLE, details
+        entitlement_cfg = self.cfg.entitlements.get(self.name)
+        if not entitlement_cfg:
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
+        elif entitlement_cfg['entitlement'].get('entitled', False) is False:
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
         operational_status = (status.ACTIVE, '')
         try:
             util.subp(['/snap/bin/canonical-livepatch', 'status'])

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -106,7 +106,9 @@ class RepoEntitlement(base.UAEntitlement):
             return status.INAPPLICABLE, details
         entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
-            return status.INACTIVE, '%s is not configured' % self.title
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
+        elif entitlement_cfg['entitlement'].get('entitled', False) is False:
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
         directives = entitlement_cfg['entitlement'].get('directives', {})
         repo_url = directives.get('aptURL')
         if not repo_url:

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -96,6 +96,23 @@ class TestLivepatchOperationalStatus:
         assert op_status == status.INAPPLICABLE
         assert 'Livepatch is not available for Ubuntu xenial.' == details
 
+    def test_operational_status_inapplicable_on_unentitled(
+            self, tmpdir):
+        """Status inapplicable on absent entitlement contract status."""
+        no_entitlements = copy.deepcopy(dict(LIVEPATCH_MACHINE_TOKEN))
+        # Delete livepatch entitlement info
+        no_entitlements[
+            'machineTokenInfo']['contractInfo']['resourceEntitlements'].pop()
+        cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+        cfg.write_cache('machine-token', no_entitlements)
+        entitlement = LivepatchEntitlement(cfg)
+
+        with mock.patch('uaclient.util.get_platform_info') as m_platform_info:
+            m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
+            op_status, details = entitlement.operational_status()
+        assert op_status == status.INAPPLICABLE
+        assert 'Livepatch is not entitled' == details
+
     def test_contract_status_unentitled(self, tmpdir):
         """The contract_status returns NONE when entitled is False."""
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})


### PR DESCRIPTION
Only report inactive if service is both entitled and meets all affordances.

Report n/a for the following cases:
 - service is **not** entitled
 - service is entitled, but doesn't pass affordance (platform requirements) checks like proper series, kernel, kernelflavor, is/is-not container

Fixes: #442