### PR TITLE
fips: replace is_pkg_installed with get_installed_packages

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -6,6 +6,12 @@ import shutil
 
 from uaclient import util
 
+try:
+    from typing import List  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 APT_AUTH_COMMENT = '  # ubuntu-advantage-tools'
 APT_CONFIG_AUTH_FILE = 'Dir::Etc::netrc/'
 APT_CONFIG_AUTH_PARTS_DIR = 'Dir::Etc::netrcparts/'
@@ -264,3 +270,8 @@ def is_pkg_installed(pkg_name: str) -> bool:
     except util.ProcessExecutionError:
         return False
     return True
+
+
+def get_installed_packages() -> 'List[str]':
+    out, _ = util.subp(['dpkg-query', '-W', '--showformat="${Package}\\n"'])
+    return out.splitlines()

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -264,14 +264,6 @@ def migrate_apt_sources(clean=False, cfg=None, platform_info=None):
         entitlement.enable()  # Re-enable on current series
 
 
-def is_pkg_installed(pkg_name: str) -> bool:
-    try:
-        util.subp(['dpkg', '-s', pkg_name])
-    except util.ProcessExecutionError:
-        return False
-    return True
-
-
 def get_installed_packages() -> 'List[str]':
     out, _ = util.subp(['dpkg-query', '-W', '--showformat="${Package}\\n"'])
     return out.splitlines()

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -24,8 +24,9 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     @property
     def packages(self) -> 'List[str]':
         packages = list(self.fips_required_packages)
+        installed_packages = apt.get_installed_packages()
         for pkg_name, extra_pkgs in self.fips_packages.items():
-            if apt.is_pkg_installed(pkg_name):
+            if pkg_name in installed_packages:
                 packages.append(pkg_name)
                 packages.extend(extra_pkgs)
         return packages

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -13,9 +13,8 @@ import pytest
 from uaclient.apt import (
     APT_AUTH_COMMENT, add_apt_auth_conf_entry, add_auth_apt_repo,
     add_ppa_pinning, find_apt_list_files, get_installed_packages,
-    is_pkg_installed, migrate_apt_sources, remove_apt_list_files,
-    remove_auth_apt_repo, remove_repo_from_apt_auth_file,
-    valid_apt_credentials)
+    migrate_apt_sources, remove_apt_list_files, remove_auth_apt_repo,
+    remove_repo_from_apt_auth_file, valid_apt_credentials)
 from uaclient import config
 from uaclient import util
 from uaclient.entitlements.tests.test_cc import (
@@ -594,36 +593,6 @@ class TestRemoveRepoFromAptAuthFile:
         assert 0 == m_unlink.call_count
         assert 0o600 == stat.S_IMODE(os.lstat(auth_file.strpath).st_mode)
         assert after_content == auth_file.read('rb')
-
-
-class TestIsPkgInstalled:
-
-    @mock.patch('uaclient.apt.util.subp')
-    def test_package_installed(self, m_subp):
-        package_name = 'mypkg'
-
-        assert is_pkg_installed(package_name)
-
-        assert [
-            mock.call(['dpkg', '-s', package_name])] == m_subp.call_args_list
-
-    @mock.patch('uaclient.apt.util.subp')
-    def test_package_not_installed(self, m_subp):
-        package_name = 'mypkg'
-        m_subp.side_effect = util.ProcessExecutionError('', exit_code=1)
-
-        assert not is_pkg_installed(package_name)
-
-        assert [
-            mock.call(['dpkg', '-s', package_name])] == m_subp.call_args_list
-
-    @mock.patch('uaclient.apt.util.subp')
-    def test_unrelated_exceptions_bubble_up(self, m_subp):
-        package_name = 'mypkg'
-        m_subp.side_effect = Exception()
-
-        with pytest.raises(Exception):
-            is_pkg_installed(package_name)
 
 
 class TestGetInstalledPackages:


### PR DESCRIPTION
As suggested by @blackboxsw in a review comment on #458, this will only require us to shell out once for all packages, making FIPS enablement a little quicker.