### PR TITLE
status: technical support level comes from ua-contract service

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -259,6 +259,12 @@ class UAConfig:
                 'name': ent.name, 'entitled': contract_status,
                 'status': op_status, 'statusDetails': op_details}
             response['services'].append(service_status)
+        support = self.entitlements.get('support', {}).get('entitlement')
+        if support:
+            supportLevel = support.get('affordances', {}).get('supportLevel')
+            if not supportLevel:
+                supportLevel = DEFAULT_STATUS['techSupportLevel']
+            response['techSupportLevel'] = supportLevel
         return response
 
     def status(self) -> 'Dict[str, Any]':

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -241,7 +241,7 @@ class UAConfig:
     def _status(self) -> 'Dict[str, Any]':
         """Return configuration status as a dictionary."""
         from uaclient.entitlements import ENTITLEMENT_CLASSES
-        response = DEFAULT_STATUS
+        response = copy.deepcopy(DEFAULT_STATUS)
         response['attached'] = self.is_attached
         if not self.is_attached:
             return response

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -16,7 +16,6 @@ INAPPLICABLE = 'n/a'
 ENTITLED = 'entitled'
 EXPIRED = 'expired'
 NONE = 'none'
-COMMUNITY = 'not included'
 STANDARD = 'standard'
 ADVANCED = 'advanced'
 
@@ -28,7 +27,6 @@ STATUS_COLOR = {
     ENTITLED: TxtColor.OKGREEN + ENTITLED + TxtColor.ENDC,
     EXPIRED: TxtColor.FAIL + EXPIRED + TxtColor.ENDC,
     NONE: TxtColor.DISABLEGREY + NONE + TxtColor.ENDC,
-    COMMUNITY: TxtColor.DISABLEGREY + COMMUNITY + TxtColor.ENDC,
     STANDARD: TxtColor.OKGREEN + STANDARD + TxtColor.ENDC,
     ADVANCED: TxtColor.OKGREEN + ADVANCED + TxtColor.ENDC
 }

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -308,6 +308,8 @@ class TestStatus:
             'techSupportLevel': status.INAPPLICABLE,
         }
         assert expected == cfg.status()
+        # cfg.status() idempotent
+        assert expected == cfg.status()
 
     @mock.patch('uaclient.config.os.getuid')
     def test_nonroot_without_cache_is_same_as_unattached_root(self, m_getuid):

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -9,11 +9,13 @@ import pytest
 
 from uaclient import entitlements, status
 from uaclient.config import DataPath, PRIVATE_SUBDIR, UAConfig
+from uaclient.entitlements import ENTITLEMENT_CLASSES
 from uaclient.testing.fakes import FakeConfig
 
 
 KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
                     ('accounts', 'accounts.json'))
+M_PATH = 'uaclient.entitlements.'
 
 
 class TestAccounts:
@@ -289,7 +291,7 @@ class TestStatus:
         assert expected == cfg.status()
 
     @mock.patch('uaclient.config.os.getuid', return_value=0)
-    def test_nonroot_attached(self, _m_getuid):
+    def test_root_attached(self, _m_getuid):
         """Test we get the correct status dict when attached with basic conf"""
         cfg = FakeConfig.for_attached_machine()
         expected_services = [{'entitled': status.NONE,
@@ -349,3 +351,45 @@ class TestStatus:
 
         assert 0o644 == stat.S_IMODE(
             os.lstat(cfg.data_path('status-cache')).st_mode)
+
+    @pytest.mark.parametrize('entitlements', (
+        [],
+        [{'type': 'support', 'entitled': True,
+          'affordances': {'supportLevel': 'anything'}}]))
+    @mock.patch('uaclient.config.os.getuid', return_value=0)
+    @mock.patch(M_PATH + 'livepatch.LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'repo.RepoEntitlement.operational_status')
+    def test_attached_reports_contract_and_service_status(
+            self, m_repo_op_status, m_livepatch_op_status, _m_getuid, tmpdir,
+            entitlements):
+        """When attached, return contract and service operational status."""
+        m_repo_op_status.return_value = status.INAPPLICABLE, 'repo details'
+        m_livepatch_op_status.return_value = status.ACTIVE, 'livepatch details'
+        token = {
+            'machineTokenInfo': {
+                'accountInfo': {'id': '1', 'name': 'accountname'},
+                'contractInfo': {'name': 'contractname',
+                                 'resourceEntitlements': entitlements}}}
+        cfg = FakeConfig.for_attached_machine(
+            account_name='accountname', machine_token=token)
+        if not entitlements:
+            support_level = status.INAPPLICABLE
+        else:
+            support_level = entitlements[0]['affordances']['supportLevel']
+        expected = {
+            'attached': True, 'account': 'accountname',
+            'expires': status.INAPPLICABLE, 'subscription': 'contractname',
+            'techSupportLevel': support_level, 'services': []}
+        for cls in ENTITLEMENT_CLASSES:
+            if cls.name == 'livepatch':
+                op_status = status.ACTIVE
+                op_details = 'livepatch details'
+            else:
+                op_status = status.INAPPLICABLE
+                op_details = 'repo details'
+            expected['services'].append(
+                {'name': cls.name, 'entitled': status.NONE,
+                 'status': op_status, 'statusDetails': op_details})
+        assert expected == cfg.status()
+        assert len(ENTITLEMENT_CLASSES) - 1 == m_repo_op_status.call_count
+        assert 1 == m_livepatch_op_status.call_count


### PR DESCRIPTION
The backend service returns a 'supportLevel' affordance value that
should be reported by `ua status` as the Techincal support level.

When no supportLevel value is present in the machine token response,
return 'n/a' (status.INAPPLICABLE) from ua client.

Fixes: #486