### PR TITLE
docker: fix persisting generated uuid on images without machine-id files

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -73,6 +73,7 @@ class UAConfig:
         'machine-access-livepatch': 'machine-access-livepatch.json',
         'machine-access-support': 'machine-access-support.json',
         'machine-detach': 'machine-detach.json',
+        'machine-id': 'machine-id',
         'machine-token': 'machine-token.json',
         'machine-token-refresh': 'machine-token-refresh.json',
         'macaroon': 'sso-macaroon.json',

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1,4 +1,5 @@
 """Tests related to uaclient.util module."""
+import uuid
 
 import mock
 import pytest
@@ -250,7 +251,8 @@ class TestGetMachineId:
         with mock.patch('uaclient.util.os.path.exists') as m_exists:
             with mock.patch('uaclient.util.uuid.uuid4') as m_uuid4:
                 m_exists.return_value = False
-                m_uuid4.return_value = '1234...1234'
+                m_uuid4.return_value = uuid.UUID(
+                    '0123456789abcdef0123456789abcdef')
                 value = util.get_machine_id(data_dir=tmpdir.strpath)
-        assert '1234...1234' == value
-        assert '1234...1234' == data_machine_id.read()
+        assert '01234567-89ab-cdef-0123-456789abcdef' == value
+        assert '01234567-89ab-cdef-0123-456789abcdef' == data_machine_id.read()

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -292,9 +292,12 @@ def get_machine_id(data_dir):
     if os.path.exists(DBUS_MACHINE_ID):  # Trusty
         return load_file(DBUS_MACHINE_ID).rstrip('\n')
     fallback_machine_id_file = os.path.join(data_dir, 'machine-id')
-    if os.path.exists(fallback_machine_id_file):  # Gen our own if needed
+    # Generate, cache our own uuid if not present on the system
+    # Docker images do not define ETC_MACHINE_ID or DBUS_MACHINE_ID on trusty
+    # per Issue: #489
+    if os.path.exists(fallback_machine_id_file):  # Use our generated uuid
         return load_file(fallback_machine_id_file).rstrip('\n')
-    machine_id = uuid.uuid4()
+    machine_id = str(uuid.uuid4())
     write_file(fallback_machine_id_file, machine_id)
     return machine_id
 


### PR DESCRIPTION
On docker ubuntu images, neither /etc/machine-id nor
/var/lib/dbus/machine-id exist. Fix the path where uaclient generates
and persists its own machine-id using uuid4().

Fixes: #489