### PR TITLE
Feature/retry snap install

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -4,6 +4,8 @@ from uaclient.entitlements import base
 from uaclient import status
 from uaclient import util
 
+SNAP_INSTALL_RETRIES = [0.5, 1, 5]
+
 try:
     from typing import Any, Dict  # noqa: F401
 except ImportError:
@@ -91,7 +93,7 @@ class LivepatchEntitlement(base.UAEntitlement):
             print('Installing canonical-livepatch snap...')
             try:
                 util.subp(['snap', 'install', 'canonical-livepatch'],
-                          capture=True)
+                          capture=True, retry_sleeps=SNAP_INSTALL_RETRIES)
             except util.ProcessExecutionError as e:
                 msg = 'Unable to install Livepatch client: ' + str(e)
                 print(msg)

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -4,7 +4,7 @@ from uaclient.entitlements import base
 from uaclient import status
 from uaclient import util
 
-SNAP_INSTALL_RETRIES = [0.5, 1, 5]
+SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
 
 try:
     from typing import Any, Dict  # noqa: F401

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -294,7 +294,8 @@ class TestLivepatchEntitlementEnable:
         mock.call(['snap', 'wait', 'system', 'seed.loaded'], capture=True),
     ]
     mocks_livepatch_install = [
-        mock.call(['snap', 'install', 'canonical-livepatch'], capture=True),
+        mock.call(['snap', 'install', 'canonical-livepatch'], capture=True,
+                  retry_sleeps=[0.5, 1, 5]),
     ]
     mocks_install = mocks_snapd_install + mocks_livepatch_install
     mocks_config = [

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -167,19 +167,13 @@ def readurl(url: str, data: 'Optional[bytes]' = None,
     return content, resp.headers
 
 
-def subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
-         capture: bool = False,
-         retry_sleeps: 'Optional[List[int]]' = None) -> 'Tuple[str, str]':
+def _subp(args, rcs=None, capture=False):
     """Run a command and return a tuple of decoded stdout, stderr.
 
     @param subp: A list of arguments to feed to subprocess.Popen
     @param rcs: A list of allowed return_codes. If returncode not in rcs
         raise a ProcessExecutionError.
-    @param capture: Boolean set True to log the command and response.
-    @param retry_sleeps: Optional list of sleep lengths to apply between
-        retries. Specifying a list of [0.5, 1] instructs subp to retry twice
-        on failure; sleeping half a second before the first retry and 1 second
-        before the next retry.
+     @param capture: Boolean set True to log the command and response.
 
     @return: Tuple of utf-8 decoded stdout, stderr
     @raises ProcessExecutionError on invalid command or returncode not in rcs.
@@ -188,32 +182,58 @@ def subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
                   for x in args]
     if rcs is None:
         rcs = [0]
-    while True:
+    try:
+        proc = subprocess.Popen(
+            bytes_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (out, err) = proc.communicate()
+    except OSError:
         try:
-            proc = subprocess.Popen(
-                bytes_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (out, err) = proc.communicate()
-        except OSError:
-            try:
-                returncode = proc.returncode
-                stderr = err
-                stdout = out
-            except UnboundLocalError:
-                returncode = None
-                stderr = b''
-                stdout = b''
-            _raise_or_retry(
-                args, returncode, stdout, stderr, capture, retry_sleeps)
-            continue
-        if proc.returncode not in rcs:
-            _raise_or_retry(
-                args, proc.returncode, out, err, capture, retry_sleeps)
-            continue
-        break  # Success
+            raise ProcessExecutionError(
+                cmd=' '.join(args), exit_code=proc.returncode, stderr=err)
+        except UnboundLocalError:
+            raise ProcessExecutionError(cmd=' '.join(args))
+    if proc.returncode not in rcs:
+        raise ProcessExecutionError(
+            cmd=' '.join(args), exit_code=proc.returncode, stdout=out,
+            stderr=err)
     if capture:
         logging.debug('Ran cmd: %s, rc: %s stderr: %s',
                       ' '.join(args), proc.returncode, err)
     return out.decode('utf-8'), err.decode('utf-8')
+
+
+def subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
+         capture: bool = False,
+         retry_sleeps: 'Optional[List[float]]' = None) -> 'Tuple[str, str]':
+    """Run a command and return a tuple of decoded stdout, stderr.
+
+     @param subp: A list of arguments to feed to subprocess.Popen
+     @param rcs: A list of allowed return_codes. If returncode not in rcs
+         raise a ProcessExecutionError.
+     @param capture: Boolean set True to log the command and response.
+     @param retry_sleeps: Optional list of sleep lengths to apply between
+        retries. Specifying a list of [0.5, 1] instructs subp to retry twice
+        on failure; sleeping half a second before the first retry and 1 second
+        before the next retry.
+
+    @return: Tuple of utf-8 decoded stdout, stderr
+    @raises ProcessExecutionError on invalid command or returncode not in rcs.
+    """
+    while True:
+        try:
+            out, err = _subp(args, rcs, capture)
+            break
+        except ProcessExecutionError as e:
+            message = str(e)
+            if retry_sleeps:
+                logging.debug(
+                    message + " Retrying %d more times.", len(retry_sleeps))
+                time.sleep(retry_sleeps.pop(0))
+            else:
+                if capture:
+                    logging.error(str(e))
+                raise
+    return out, err
 
 
 def which(program: str) -> 'Optional[str]':


### PR DESCRIPTION
livepatch: add 3 retries for snap install command

Add optional retry_sleeps list param to subp function. The retry_sleeps param is a list of sleep durations to perform between retries to allow for a simple backoff algorithm when retrying a command. 

Add the following retry_sleeps when installing the livepatch snap, [05, 1, 5] which will allow for 3 retries if the snap install fails. 

Fixes: #308
