### PR TITLE
apt: retry apt install and update commands 3 times simple backoff

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -1,6 +1,7 @@
 import logging
 
 from uaclient.entitlements import base
+from uaclient.entitlements.repo import APT_RETRIES
 from uaclient import status
 from uaclient import util
 
@@ -87,7 +88,7 @@ class LivepatchEntitlement(base.UAEntitlement):
             if not util.which('snap'):
                 print('Installing snapd...')
                 util.subp(['apt-get', 'install', '--assume-yes', 'snapd'],
-                          capture=True)
+                          capture=True, retry_sleeps=APT_RETRIES)
                 util.subp(['snap', 'wait', 'system', 'seed.loaded'],
                           capture=True)
             print('Installing canonical-livepatch snap...')

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -17,6 +17,8 @@ from uaclient import status
 from uaclient import util
 
 APT_DISABLED_PIN = '-32768'
+# charm-helpers uses 10 seconds between retries. Hope for an optimal first try
+APT_RETRIES = [1.0, 10.0, 10.0]
 
 
 class RepoEntitlement(base.UAEntitlement):
@@ -74,7 +76,7 @@ class RepoEntitlement(base.UAEntitlement):
                     'Installing {title} packages ...'.format(title=self.title))
                 util.subp(
                     ['apt-get', 'install', '--assume-yes'] + self.packages,
-                    capture=True)
+                    capture=True, retry_sleeps=APT_RETRIES)
             except util.ProcessExecutionError:
                 self.disable(silent=True, force=True)
                 logging.error(
@@ -220,7 +222,7 @@ class RepoEntitlement(base.UAEntitlement):
             try:
                 util.subp(
                     ['apt-get', 'install', '--assume-yes'] + prerequisite_pkgs,
-                    capture=True)
+                    capture=True, retry_sleeps=APT_RETRIES)
             except util.ProcessExecutionError as e:
                 logging.error(str(e))
                 return False
@@ -236,7 +238,8 @@ class RepoEntitlement(base.UAEntitlement):
         # Side-effect is that apt policy will new report the repo as accessible
         # which allows ua status to report correct info
         print('Updating package lists ...')
-        util.subp(['apt-get', 'update'], capture=True)
+        util.subp(
+            ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES)
         return True
 
     def remove_apt_config(self):

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -13,6 +13,7 @@ from uaclient import apt
 from uaclient import config
 from uaclient import status
 from uaclient.entitlements.cc import CC_README, CommonCriteriaEntitlement
+from uaclient.entitlements.repo import APT_RETRIES
 
 
 CC_MACHINE_TOKEN = {
@@ -161,15 +162,16 @@ class TestCommonCriteriaEntitlementEnable:
             subp_apt_cmds.append(
                 mock.call(
                     ['apt-get', 'install', '--assume-yes'] + prerequisite_pkgs,
-                    capture=True))
+                    capture=True, retry_sleeps=APT_RETRIES))
         else:
             expected_stdout = ''
 
         subp_apt_cmds.extend([
-            mock.call(['apt-get', 'update'], capture=True),
+            mock.call(
+                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
             mock.call(
                 ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
-                capture=True)])
+                capture=True, retry_sleeps=APT_RETRIES)])
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -5,6 +5,7 @@ from io import StringIO
 
 from uaclient import config, status
 from uaclient.entitlements.cis import CISEntitlement
+from uaclient.entitlements.repo import APT_RETRIES
 
 
 CIS_MACHINE_TOKEN = {
@@ -92,10 +93,11 @@ class TestCISEntitlementEnable:
 
         subp_apt_cmds = [
             mock.call(['apt-cache', 'policy']),
-            mock.call(['apt-get', 'update'], capture=True),
+            mock.call(
+                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
             mock.call(
                 ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
-                capture=True)]
+                capture=True, retry_sleeps=APT_RETRIES)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cis-audit

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -12,6 +12,7 @@ import pytest
 from uaclient import config, status
 from uaclient.entitlements.fips import (
     FIPSCommonEntitlement, FIPSEntitlement, FIPSUpdatesEntitlement)
+from uaclient.entitlements.repo import APT_RETRIES
 
 try:
     from typing import Any, Dict  # noqa
@@ -121,10 +122,12 @@ class TestFIPSEntitlementEnable:
                 'http://FIPS', entitlement.origin, 1001)]
         install_cmd = mock.call(
             ['apt-get', 'install', '--assume-yes'] + patched_packages,
-            capture=True)
+            capture=True, retry_sleeps=APT_RETRIES)
 
         subp_calls = [
-            mock.call(['apt-get', 'update'], capture=True), install_cmd]
+            mock.call(
+                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
+            install_cmd]
 
         assert [mock.call(silent=mock.ANY)] == m_can_enable.call_args_list
         assert add_apt_calls == m_add_apt.call_args_list

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -10,6 +10,7 @@ import pytest
 from uaclient import config
 from uaclient.entitlements.livepatch import (
     LivepatchEntitlement, process_config_directives)
+from uaclient.entitlements.repo import APT_RETRIES
 from uaclient import status
 
 
@@ -290,7 +291,8 @@ class TestLivepatchEntitlementEnable:
 
     mocks_snapd_install = [
         mock.call(
-            ['apt-get', 'install', '--assume-yes', 'snapd'], capture=True),
+            ['apt-get', 'install', '--assume-yes', 'snapd'], capture=True,
+            retry_sleeps=APT_RETRIES),
         mock.call(['snap', 'wait', 'system', 'seed.loaded'], capture=True),
     ]
     mocks_livepatch_install = [

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 
 from uaclient import apt
 from uaclient import config
-from uaclient.entitlements.repo import RepoEntitlement
+from uaclient.entitlements.repo import APT_RETRIES, RepoEntitlement
 from uaclient import status
 from uaclient import util
 
@@ -248,7 +248,8 @@ class TestRepoEnable:
         """On enable add authenticated apt repo and refresh package lists."""
         m_platform.return_value = {'series': 'xenial'}
 
-        expected_apt_calls = [mock.call(['apt-get', 'update'], capture=True)]
+        expected_apt_calls = [mock.call(
+            ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES)]
         expected_output = dedent("""\
         Updating package lists ...
         Repo Test Class enabled.
@@ -256,8 +257,10 @@ class TestRepoEnable:
         if packages is not None:
             if len(packages) > 0:
                 expected_apt_calls.append(
-                    mock.call(['apt-get', 'install', '--assume-yes',
-                              ' '.join(packages)], capture=True))
+                    mock.call(
+                        ['apt-get', 'install', '--assume-yes',
+                         ' '.join(packages)],
+                        capture=True, retry_sleeps=APT_RETRIES))
                 expected_output = dedent("""\
                     Updating package lists ...
                     Installing Repo Test Class packages ...


### PR DESCRIPTION
Prerequsite branch https://github.com/CanonicalLtd/ubuntu-advantage-client/pull/497
-----

Apt commands can fail for a variety of reasons:
- obtaining a dpkg lock during an apt daily update
- remote network connectivity
- remote repository maintenance or remote ppa accessibility
    
Add simple retry logic which logs failure attempts and retries
3 times on failure performing a sleep for the provided retry_sleeps.
Apt retry sleeps of 10 seconds are used by charm-helpers for any juju charm which installs packages.
While juju attempts to wait 10 * 30 retries, we won't instrument 5 minutes of retries as we are most-likely a human sitting at a commandline.

Fixes: #496 