### PR TITLE
tox.ini: configure pytest log format

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,6 @@ commands =
 #       now-recommended-by-PEP-8 parameter spacing for annotated function
 #       arguments with defaults (e.g.  `def spam(ham: str = "eggs"):`).
 ignore = E251
+
+[pytest]
+log_format = %(filename)-25s %(lineno)4d %(levelname)-8s %(message)s


### PR DESCRIPTION
pytest 4.5.0 modified the default log format, breaking our tests.  This
configures pytest explicitly with the previous log format.

Fixes #499