### PR TITLE
cc: update cc to cc-eal in docs, parameters and commandline help

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ The Ubuntu Advantage client provides users with a simple mechanism to
 view, enable, and disable offerings from Canonical on their system. The
 following entitlements are supported:
 
+- [Common Criteria EAL2 certification artifacts provisioning](https://ubuntu.com/cc-eal)
+- [Canonical CIS Benchmark Audit Tool](https://ubuntu.com/cis)
 - [Ubuntu Extended Security Maintenance](https://ubuntu.com/esm)
+- [FIPS 140-2 Certified Modules](https://ubuntu.com/fips)
+- [FIPS 140-2 Non-Certified Module Updates](https://ubuntu.com/fips-updates)
 - [Livepatch Service](https://www.ubuntu.com/livepatch)
-- FIPS 140-2 Certified Modules
-- FIPS 140-2 Non-Certified Module Updates
-- Common Criteria EAL2 certification artifacts provisioning
 
 ## Obtaining the Client
 

--- a/tools/ua.bash
+++ b/tools/ua.bash
@@ -1,6 +1,6 @@
 # bash completion for ubuntu-advantage-tools
 
-SERVICES="cc cis-audit esm fips fips-updates livepatch"
+SERVICES="cc-eal cis-audit esm fips fips-updates livepatch"
 
 _ua_complete()
 {

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -4,7 +4,8 @@
 Client to manage Ubuntu Advantage support services on a machine.
 
 Available services:
- - cc: Canonical Common Criteria EAL2 Provisioning (https://ubuntu.com/cc)
+ - cc-eal: Canonical Common Criteria EAL2 Provisioning
+   (https://ubuntu.com/cc-eal)
  - cis-audit: Canonical CIS Benchmark Audit Tool (https://ubuntu.com/cis)
  - esm: Extended Security Maintenance (https://ubuntu.com/esm)
  - fips: FIPS 140-2 (https://ubuntu.com/fips)

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -65,7 +65,7 @@ class UAConfig:
         'contract-token': 'contract-token.json',
         'local-access': 'local-access',
         'machine-contracts': 'machine-contracts.json',
-        'machine-access-cc': 'machine-access-cc.json',
+        'machine-access-cc-eal': 'machine-access-cc-eal.json',
         'machine-access-cis-audit': 'machine-access-cis-audit.json',
         'machine-access-esm': 'machine-access-esm.json',
         'machine-access-fips': 'machine-access-fips.json',

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -9,7 +9,7 @@ CC_README = '/usr/share/doc/ubuntu-commoncriteria/README'
 
 class CommonCriteriaEntitlement(repo.RepoEntitlement):
 
-    name = 'cc'
+    name = 'cc-eal'
     title = 'Canonical Common Criteria EAL2 Provisioning'
     description = (
         'Common Criteria for Information Technology Security Evaluation - EAL2'

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -20,7 +20,7 @@ CC_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'cc', 'entitled': True}]}}}
+                {'type': 'cc-eal', 'entitled': True}]}}}
 
 
 CC_RESOURCE_ENTITLED = {
@@ -29,7 +29,7 @@ CC_RESOURCE_ENTITLED = {
         'obligations': {
             'enableByDefault': False
         },
-        'type': 'cc',
+        'type': 'cc-eal',
         'entitled': True,
         'directives': {
             'aptURL': 'http://CC',
@@ -70,7 +70,7 @@ class TestCommonCriteriaEntitlementOperationalStatus:
         m_platform_info.return_value = unsupported_info
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
-        cfg.write_cache('machine-access-cc', CC_RESOURCE_ENTITLED)
+        cfg.write_cache('machine-access-cc-eal', CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
         op_status, op_status_details = entitlement.operational_status()
         assert status.INAPPLICABLE == op_status
@@ -87,7 +87,7 @@ class TestCommonCriteriaEntitlementCanEnable:
         m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
-        cfg.write_cache('machine-access-cc', CC_RESOURCE_ENTITLED)
+        cfg.write_cache('machine-access-cc-eal', CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
         op_status, op_status_details = entitlement.operational_status()
         assert status.INACTIVE == op_status
@@ -130,7 +130,7 @@ class TestCommonCriteriaEntitlementEnable:
         m_platform_info.side_effect = fake_platform
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
-        cfg.write_cache('machine-access-cc', CC_RESOURCE_ENTITLED)
+        cfg.write_cache('machine-access-cc-eal', CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
 
         with mock.patch('uaclient.apt.add_auth_apt_repo') as m_add_apt:
@@ -142,7 +142,7 @@ class TestCommonCriteriaEntitlementEnable:
                         assert True is entitlement.enable()
 
         add_apt_calls = [
-            mock.call('/etc/apt/sources.list.d/ubuntu-cc-xenial.list',
+            mock.call('/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list',
                       'http://CC', 'TOKEN', ['xenial'],
                       '/usr/share/keyrings/ubuntu-cc-keyring.gpg')]
 

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -328,11 +328,11 @@ class TestMigrateAptSources:
 
         cfg = config.UAConfig({'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', dict(CC_MACHINE_TOKEN))
-        cfg.write_cache('machine-access-cc', cc_unentitled)
+        cfg.write_cache('machine-access-cc-eal', cc_unentitled)
 
         orig_exists = os.path.exists
 
-        apt_files = ['/etc/apt/sources.list.d/ubuntu-cc-trusty.list']
+        apt_files = ['/etc/apt/sources.list.d/ubuntu-cc-eal-trusty.list']
 
         def fake_apt_list_exists(path):
             if path in apt_files:
@@ -359,12 +359,12 @@ class TestMigrateAptSources:
 
         cfg = config.UAConfig({'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', dict(CC_MACHINE_TOKEN))
-        cfg.write_cache('machine-access-cc', dict(CC_RESOURCE_ENTITLED))
+        cfg.write_cache('machine-access-cc-eal', dict(CC_RESOURCE_ENTITLED))
 
         orig_exists = os.path.exists
 
-        glob_files = ['/etc/apt/sources.list.d/ubuntu-cc-trusty.list',
-                      '/etc/apt/sources.list.d/ubuntu-cc-xenial.list']
+        glob_files = ['/etc/apt/sources.list.d/ubuntu-cc-eal-trusty.list',
+                      '/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list']
 
         def fake_platform_info(key=None):
             platform_data = {
@@ -380,7 +380,7 @@ class TestMigrateAptSources:
             return orig_exists(path)
 
         def fake_glob(regex):
-            if regex == '/etc/apt/sources.list.d/ubuntu-cc-*.list':
+            if regex == '/etc/apt/sources.list.d/ubuntu-cc-eal-*.list':
                 return glob_files
             return []
 
@@ -395,7 +395,7 @@ class TestMigrateAptSources:
         assert [] == m_add_apt.call_args_list
         # Only exists checks for for cfg.is_attached and can_enable
         unlink_calls = [
-            mock.call('/etc/apt/sources.list.d/ubuntu-cc-trusty.list')]
+            mock.call('/etc/apt/sources.list.d/ubuntu-cc-eal-trusty.list')]
         assert unlink_calls == m_unlink.call_args_list  # remove nothing
         assert [] == m_exists.call_args_list
 

--- a/ubuntu-advantage.1
+++ b/ubuntu-advantage.1
@@ -36,11 +36,11 @@ Remove the Ubuntu Advantage support contract from this machine. This
 also disables all enabled services that can be.
 
 .TP
-.BR "disable" " [cc|cis-audit|esm|fips|fips-updates|livepatch]"
+.BR "disable" " [cc-eal|cis-audit|esm|fips|fips-updates|livepatch]"
 Disable this machine's access to an Ubuntu Advantage support services.
 
 .TP
-.BR "enable" " [cc|cis-audit|esm|fips|fips-updates|livepatch]"
+.BR "enable" " [cc-eal|cis-audit|esm|fips|fips-updates|livepatch]"
 Activate and configure this machine's access to an Ubuntu Advantage
 services.
 
@@ -77,7 +77,7 @@ Show version of the Ubuntu Advantage package.
 
 .SH SERVICES
 .TP
-.B "Common Criteria EAL2 Provisioning (cc)"
+.B "Common Criteria EAL2 Provisioning (cc-eal)"
 Enables and install the Common Criteria artifacts.
 
 The artifacts include a configure script, a tarball with additional


### PR DESCRIPTION
cc: update cc to cc-eal in docs, parameters and commandline help
    
Per product review in Lyon, change cc to cc-eal to aid in better
search resolution for Ubuntu Support offerings.

This branch depends on fixes landing for:
- ua-contracts backend per
  https://github.com/CanonicalLtd/ua-contracts/issues/295
- new ubuntu.com/cc-eal top-level redirect per
  https://github.com/canonical-web-and-design/www.ubuntu.com/pull/5164
    
Fixes: #502
