### PR TITLE
Store only a status cache in the world-readable data directory

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -203,7 +203,9 @@ def _perform_enable(entitlement_name: str, cfg: config.UAConfig, *,
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[entitlement_name]
     entitlement = ent_cls(cfg)
-    return entitlement.enable(silent_if_inapplicable=silent_if_inapplicable)
+    ret = entitlement.enable(silent_if_inapplicable=silent_if_inapplicable)
+    cfg.status()  # Update the status cache
+    return ret
 
 
 @assert_attached_root

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -180,10 +180,9 @@ def action_disable(args, cfg):
     """
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
-    if entitlement.disable():
-        return 0
-    else:
-        return 1
+    ret = 0 if entitlement.disable() else 1
+    cfg.status()  # Update the status cache
+    return ret
 
 
 def _perform_enable(entitlement_name: str, cfg: config.UAConfig, *,

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -222,7 +222,11 @@ class UAConfig:
             self._contracts = None
         if not isinstance(content, str):
             content = json.dumps(content)
-        util.write_file(filepath, content, mode=0o600)
+        mode = 0o600
+        if key in self.data_paths:
+            if not self.data_paths[key].private:
+                mode = 0o644
+        util.write_file(filepath, content, mode=mode)
 
     def status(self):
         """Return configuration status as a dictionary."""

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import yaml
+from collections import namedtuple
 
 from uaclient import util
 from uaclient.defaults import CONFIG_DEFAULTS, DEFAULT_CONFIG_FILE
@@ -24,31 +25,36 @@ class ConfigAbsentError(RuntimeError):
     pass
 
 
+# A data path is a filename
+DataPath = namedtuple('DataPath', ('filename',))
+
+
 class UAConfig:
 
     data_paths = {
-        'bound-macaroon': 'bound-macaroon',
-        'accounts': 'accounts.json',
-        'account-contracts': 'account-contracts.json',
-        'account-users': 'account-users.json',
-        'contract-token': 'contract-token.json',
-        'local-access': 'local-access',
-        'machine-contracts': 'machine-contracts.json',
-        'machine-access-cc-eal': 'machine-access-cc-eal.json',
-        'machine-access-cis-audit': 'machine-access-cis-audit.json',
-        'machine-access-esm': 'machine-access-esm.json',
-        'machine-access-fips': 'machine-access-fips.json',
-        'machine-access-fips-updates': 'machine-access-fips-updates.json',
-        'machine-access-livepatch': 'machine-access-livepatch.json',
-        'machine-access-support': 'machine-access-support.json',
-        'machine-detach': 'machine-detach.json',
-        'machine-id': 'machine-id',
-        'machine-token': 'machine-token.json',
-        'machine-token-refresh': 'machine-token-refresh.json',
-        'macaroon': 'sso-macaroon.json',
-        'root-macaroon': 'root-macaroon.json',
-        'oauth': 'sso-oauth.json'
-    }
+        'bound-macaroon': DataPath('bound-macaroon'),
+        'accounts': DataPath('accounts.json'),
+        'account-contracts': DataPath('account-contracts.json'),
+        'account-users': DataPath('account-users.json'),
+        'contract-token': DataPath('contract-token.json'),
+        'local-access': DataPath('local-access'),
+        'machine-contracts': DataPath('machine-contracts.json'),
+        'machine-access-cc-eal': DataPath('machine-access-cc-eal.json'),
+        'machine-access-cis-audit': DataPath('machine-access-cis-audit.json'),
+        'machine-access-esm': DataPath('machine-access-esm.json'),
+        'machine-access-fips': DataPath('machine-access-fips.json'),
+        'machine-access-fips-updates': DataPath(
+            'machine-access-fips-updates.json'),
+        'machine-access-livepatch': DataPath('machine-access-livepatch.json'),
+        'machine-access-support': DataPath('machine-access-support.json'),
+        'machine-detach': DataPath('machine-detach.json'),
+        'machine-id': DataPath('machine-id'),
+        'machine-token': DataPath('machine-token.json'),
+        'machine-token-refresh': DataPath('machine-token-refresh.json'),
+        'macaroon': DataPath('sso-macaroon.json'),
+        'root-macaroon': DataPath('root-macaroon.json'),
+        'oauth': DataPath('sso-oauth.json')
+    }  # type: Dict[str, DataPath]
 
     _contracts = None  # caching to avoid repetitive file reads
     _entitlements = None  # caching to avoid repetitive file reads
@@ -163,7 +169,7 @@ class UAConfig:
         if not key:
             return data_dir
         if key in self.data_paths:
-            return os.path.join(data_dir, self.data_paths[key])
+            return os.path.join(data_dir, self.data_paths[key].filename)
         return os.path.join(data_dir, key)
 
     def delete_cache_key(self, key: str) -> None:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -24,37 +24,6 @@ class ConfigAbsentError(RuntimeError):
     pass
 
 
-class LocalEnabledManager:
-    """
-    A UAConfig adapter to manage the local-enabled cache for non-root users
-
-    TODO:
-        * cache the contents of local-access so we don't have to read it more
-        than once
-    """
-
-    _cfg_key = 'local-access'
-
-    def __init__(self, cfg: 'UAConfig') -> None:
-        self._cfg = cfg
-
-    def get(self, entitlement_name: str) -> bool:
-        local_access = self._cfg.read_cache(self._cfg_key)
-        if local_access is None:
-            # The only way we get here is if nothing has yet written the
-            # local-access file; that means we haven't enabled any entitlements
-            # so this must necessarily be False
-            return False
-        return local_access.get(entitlement_name, False)
-
-    def set(self, entitlement_name: str, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise RuntimeError('LocalEnabledManager.set passed non-bool value')
-        local_access = self._cfg.read_cache(self._cfg_key) or {}
-        local_access[entitlement_name] = value
-        self._cfg.write_cache(self._cfg_key, local_access, private=False)
-
-
 class UAConfig:
 
     data_paths = {
@@ -91,7 +60,6 @@ class UAConfig:
             self.cfg = cfg
         else:
             self.cfg = parse_config()
-        self.local_enabled_manager = LocalEnabledManager(self)
 
     @property
     def accounts(self):

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -157,12 +157,9 @@ class UAConfig:
             self._machine_token = self.read_cache('machine-token')
         return self._machine_token
 
-    def data_path(self, key=None, private=True):
+    def data_path(self, key: 'Optional[str]' = None) -> str:
         """Return the file path in the data directory represented by the key"""
-        if private:
-            data_dir = os.path.join(self.cfg['data_dir'], 'private')
-        else:
-            data_dir = self.cfg['data_dir']
+        data_dir = os.path.join(self.cfg['data_dir'], PRIVATE_SUBDIR)
         if not key:
             return data_dir
         if key in self.data_paths:
@@ -179,10 +176,9 @@ class UAConfig:
             self._machine_token = None
         elif key == 'account-contracts':
             self._contracts = None
-        for private in (True, False):
-            cache_path = self.data_path(key, private)
-            if os.path.exists(cache_path):
-                os.unlink(cache_path)
+        cache_path = self.data_path(key)
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
 
     def delete_cache(self):
         """Remove configuration cached response files class attributes."""
@@ -194,18 +190,14 @@ class UAConfig:
         try:
             content = util.load_file(cache_path)
         except Exception:
-            public_cache_path = cache_path.replace('%s/' % PRIVATE_SUBDIR, '')
-            try:
-                content = util.load_file(public_cache_path)
-            except Exception:
-                if not os.path.exists(cache_path) and not silent:
-                    logging.debug('File does not exist: %s', cache_path)
-                return None
+            if not os.path.exists(cache_path) and not silent:
+                logging.debug('File does not exist: %s', cache_path)
+            return None
         json_content = util.maybe_parse_json(content)
         return json_content if json_content else content
 
-    def write_cache(self, key: str, content: 'Any', private: bool = True):
-        filepath = self.data_path(key, private)
+    def write_cache(self, key: str, content: 'Any') -> None:
+        filepath = self.data_path(key)
         data_dir = os.path.dirname(filepath)
         if not os.path.exists(data_dir):
             os.makedirs(data_dir)
@@ -216,10 +208,7 @@ class UAConfig:
             self._contracts = None
         if not isinstance(content, str):
             content = json.dumps(content)
-        if private:
-            util.write_file(filepath, content, mode=0o600)
-        else:
-            util.write_file(filepath, content)
+        util.write_file(filepath, content, mode=0o600)
 
     def status(self):
         """Return configuration status as a dictionary."""

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -161,8 +161,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         machine_token, _headers = self.request_url(
             API_V1_CONTEXT_MACHINE_TOKEN, data=data, headers=headers)
         self.cfg.write_cache('machine-token', machine_token)
-        redacted_content = util.redact_sensitive(machine_token)
-        self.cfg.write_cache('machine-token', redacted_content, private=False)
         return machine_token
 
     def request_contract_machine_detach(self, contract_id, user_token):
@@ -204,9 +202,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         if headers.get('expires'):
             resource_access['expires'] = headers['expires']
         self.cfg.write_cache('machine-access-%s' % resource, resource_access)
-        redacted_content = util.redact_sensitive(resource_access)
-        self.cfg.write_cache(
-            'machine-access-%s' % resource, redacted_content, private=False)
         return resource_access
 
     def request_machine_token_refresh(
@@ -231,8 +226,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         if headers.get('expires'):
             response['expires'] = headers['expires']
         self.cfg.write_cache('machine-token', response)
-        redacted_content = util.redact_sensitive(response)
-        self.cfg.write_cache('machine-token', redacted_content, private=False)
         return response
 
 

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -46,5 +46,4 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
-        self._set_local_enabled(False)
         return True

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -40,5 +40,4 @@ class CISEntitlement(repo.RepoEntitlement):
             util.subp(['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
-        self._set_local_enabled(False)
         return True

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -273,6 +273,3 @@ class RepoEntitlement(base.UAEntitlement):
             'Dict[str, Any]',
             self.cfg.read_cache('machine-access-%s' % self.name))
         public_cache['localEnabled'] = value
-        redacted_cache = util.redact_sensitive(public_cache)
-        self.cfg.write_cache(
-            'machine-access-%s' % self.name, redacted_cache, private=False)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -81,7 +81,6 @@ class RepoEntitlement(base.UAEntitlement):
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title))
                 return False
-        self._set_local_enabled(True)
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         for msg in self.messaging.get('post_enable', []):
             print(msg)
@@ -97,7 +96,6 @@ class RepoEntitlement(base.UAEntitlement):
                     ['apt-get', 'remove', '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
-            self._set_local_enabled(False)
         if self.force_disable:
             if not silent:
                 print('Warning: no option to disable {title}'.format(
@@ -266,10 +264,3 @@ class RepoEntitlement(base.UAEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
-
-    def _set_local_enabled(self, value: bool) -> None:
-        """Set local enabled flag true or false."""
-        public_cache = cast(
-            'Dict[str, Any]',
-            self.cfg.read_cache('machine-access-%s' % self.name))
-        public_cache['localEnabled'] = value

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -4,10 +4,11 @@ import os
 import re
 
 try:
-    from typing import Any, Dict, List, Optional  # noqa: F401
+    from typing import Any, cast, Dict, List, Optional  # noqa: F401
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
-    pass
+    def cast(_, x):  # type: ignore
+        return x
 
 
 from uaclient import apt
@@ -268,7 +269,9 @@ class RepoEntitlement(base.UAEntitlement):
 
     def _set_local_enabled(self, value: bool) -> None:
         """Set local enabled flag true or false."""
-        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache = cast(
+            'Dict[str, Any]',
+            self.cfg.read_cache('machine-access-%s' % self.name))
         public_cache['localEnabled'] = value
         redacted_cache = util.redact_sensitive(public_cache)
         self.cfg.write_cache(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -80,7 +80,7 @@ class RepoEntitlement(base.UAEntitlement):
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title))
                 return False
-        self.cfg.local_enabled_manager.set(self.name, True)
+        self._set_local_enabled(True)
         print(status.MESSAGE_ENABLED_TMPL.format(title=self.title))
         for msg in self.messaging.get('post_enable', []):
             print(msg)
@@ -96,7 +96,7 @@ class RepoEntitlement(base.UAEntitlement):
                     ['apt-get', 'remove', '--assume-yes'] + self.packages)
             except util.ProcessExecutionError:
                 pass
-            self.cfg.local_enabled_manager.set(self.name, False)
+            self._set_local_enabled(False)
         if self.force_disable:
             if not silent:
                 print('Warning: no option to disable {title}'.format(
@@ -126,7 +126,7 @@ class RepoEntitlement(base.UAEntitlement):
         match = re.search(r'(?P<pin>(-)?\d+) %s' % repo_url, out)
         if match and match.group('pin') != APT_DISABLED_PIN:
             return status.ACTIVE, '%s is active' % self.title
-        if os.getuid() != 0 and self.cfg.local_enabled_manager.get(self.name):
+        if os.getuid() != 0 and entitlement_cfg.get('localEnabled', False):
             # Use our cached enabled key for non-root users because apt
             # policy will show APT_DISABLED_PIN for authenticated sources
             return status.ACTIVE, '%s is active' % self.title
@@ -265,3 +265,11 @@ class RepoEntitlement(base.UAEntitlement):
                 name=self.name, series=series)
             if os.path.exists(repo_pref_file):
                 os.unlink(repo_pref_file)
+
+    def _set_local_enabled(self, value: bool) -> None:
+        """Set local enabled flag true or false."""
+        public_cache = self.cfg.read_cache('machine-access-%s' % self.name)
+        public_cache['localEnabled'] = value
+        redacted_cache = util.redact_sensitive(public_cache)
+        self.cfg.write_cache(
+            'machine-access-%s' % self.name, redacted_cache, private=False)

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -100,22 +100,6 @@ class TestOperationalStatus:
         assert status.INAPPLICABLE == op_status
         assert 'Repo Test Class is not entitled' == op_details
 
-    @pytest.mark.parametrize('value', (True, False))
-    @mock.patch(M_PATH + 're.search', return_value=None)
-    @mock.patch(M_PATH + 'os.getuid', return_value=1000)
-    def test_local_enabled_manager_used_if_not_root(
-            self, m_getuid, _m_re_match, entitlement, value):
-        entitlement.cfg.local_enabled_manager.set(entitlement.name, value)
-
-        with mock.patch.object(entitlement, 'check_affordances',
-                               return_value=(True, '')):
-            expected_op_status = (
-                status.ACTIVE if value else status.INACTIVE, mock.ANY)
-            assert expected_op_status == entitlement.operational_status()
-
-        # Use getuid as a proxy for the correct code path being taken
-        assert 1 == m_getuid.call_count
-
 
 class TestProcessContractDeltas:
 
@@ -296,33 +280,3 @@ class TestRepoEnable:
             '/usr/share/keyrings/test.gpg')] == m_apt_add.call_args_list
         stdout, _ = capsys.readouterr()
         assert expected_output == stdout
-
-    @mock.patch.object(RepoTestEntitlement, 'setup_apt_config',
-                       return_value=True)
-    @mock.patch.object(RepoTestEntitlement, 'can_enable', return_value=True)
-    def test_enable_sets_public_local_enabled(
-            self, _m_can_enable, _m_setup_apt_config, entitlement):
-        # We patch the type of entitlement because packages is a property; we
-        # want no packages to reduce the surface that this test covers
-        with mock.patch.object(type(entitlement), 'packages', []):
-            entitlement.enable()
-
-        assert entitlement.cfg.local_enabled_manager.get(entitlement.name)
-
-
-class TestRepoDisable:
-
-    @mock.patch(M_PATH + 'util.subp')
-    @mock.patch.object(RepoTestEntitlement, 'remove_apt_config')
-    @mock.patch.object(RepoTestEntitlement, 'can_disable', return_value=True)
-    def test_disable_sets_public_local_disabled(
-            self, _m_can_disable, _m_remove_apt_config, _m_subp, entitlement):
-        entitlement.cfg.local_enabled_manager.set(entitlement.name, True)
-        assert entitlement.cfg.local_enabled_manager.get(entitlement.name)
-
-        # We patch the type of entitlement because packages is a property; we
-        # want no packages to reduce the surface that this test covers
-        with mock.patch.object(type(entitlement), 'packages', []):
-            entitlement.disable()
-
-        assert not entitlement.cfg.local_enabled_manager.get(entitlement.name)

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -59,7 +59,7 @@ class FakeConfig(UAConfig):
             'machine-token': {
                 'machineToken': 'not-null',
                 'machineTokenInfo': {
-                    'contractInfo': {'id': 'cid',
+                    'contractInfo': {'id': 'cid', 'name': 'test_contract',
                                      'resourceEntitlements': []}}}
         }
         if machine_token:

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -1,0 +1,32 @@
+import mock
+import pytest
+
+from uaclient.cli import action_disable
+
+
+class TestDisable:
+
+    @pytest.mark.parametrize('disable_return,return_code',
+                             ((True, 0), (False, 1)))
+    @mock.patch('uaclient.cli.entitlements')
+    @mock.patch('uaclient.cli.os.getuid', return_value=0)
+    def test_entitlement_instantiated_and_disabled(
+            self, _m_getuid, m_entitlements, disable_return, return_code):
+        m_entitlement_cls = mock.Mock()
+        m_entitlement = m_entitlement_cls.return_value
+        m_entitlement.disable.return_value = disable_return
+        m_cfg = mock.Mock()
+        m_entitlements.ENTITLEMENT_CLASS_BY_NAME = {
+            'testitlement': m_entitlement_cls,
+        }
+
+        args_mock = mock.Mock()
+        args_mock.name = 'testitlement'
+
+        ret = action_disable(args_mock, m_cfg)
+
+        assert [mock.call(m_cfg)] == m_entitlement_cls.call_args_list
+
+        expected_disable_call = mock.call()
+        assert [expected_disable_call] == m_entitlement.disable.call_args_list
+        assert return_code == ret

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -30,3 +30,5 @@ class TestDisable:
         expected_disable_call = mock.call()
         assert [expected_disable_call] == m_entitlement.disable.call_args_list
         assert return_code == ret
+
+        assert 1 == m_cfg.status.call_count

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -43,3 +43,5 @@ class TestPerformEnable:
             expected_enable_call = mock.call(silent_if_inapplicable=False)
         assert [expected_enable_call] == m_entitlement.enable.call_args_list
         assert ret == m_entitlement.enable.return_value
+
+        assert 1 == m_cfg.status.call_count

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -98,14 +98,6 @@ class TestDataPath:
         cfg = UAConfig({'data_dir': '/my/d'})
         assert '/my/d/%s/%s' % (PRIVATE_SUBDIR, key) == cfg.data_path(key=key)
 
-    @pytest.mark.parametrize('key,path_basename', (
-        ('notHere', 'notHere'), ('anything', 'anything')))
-    def test_data_path_returns_file_path_with_public_data_paths(
-            self, key, path_basename):
-        """When private is False Config.data_paths return a public path."""
-        cfg = UAConfig({'data_dir': '/my/d'})
-        assert '/my/d/%s' % key == cfg.data_path(key=key, private=False)
-
 
 class TestWriteCache:
 
@@ -149,16 +141,6 @@ class TestWriteCache:
         with open(tmpdir.join(PRIVATE_SUBDIR, key).strpath, 'r') as stream:
             assert expected_json_content == stream.read()
         assert value == cfg.read_cache(key)
-
-    def test_write_cache_writes_non_private_dir_when_private_is_false(
-            self, tmpdir):
-        """When content is not a string, write a json string."""
-        cfg = UAConfig({'data_dir': tmpdir.strpath})
-
-        assert None is cfg.write_cache('key', 'value', private=False)
-        with open(tmpdir.join('key').strpath, 'r') as stream:
-            assert 'value' == stream.read()
-        assert 'value' == cfg.read_cache('key')
 
 
 class TestReadCache:

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import stat
 
 import pytest
 
@@ -146,6 +147,17 @@ class TestWriteCache:
         with open(tmpdir.join(PRIVATE_SUBDIR, key).strpath, 'r') as stream:
             assert expected_json_content == stream.read()
         assert value == cfg.read_cache(key)
+
+    @pytest.mark.parametrize('datapath,mode', (
+        (DataPath('path', False), 0o644),
+        (DataPath('path', True), 0o600),
+    ))
+    def test_permissions(self, tmpdir, datapath, mode):
+        cfg = UAConfig({'data_dir': tmpdir.strpath})
+        cfg.data_paths = {'path': datapath}
+        cfg.write_cache('path', '')
+        assert mode == stat.S_IMODE(
+            os.lstat(cfg.data_path('path')).st_mode)
 
 
 class TestReadCache:

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from uaclient.config import PRIVATE_SUBDIR, UAConfig
+from uaclient.config import DataPath, PRIVATE_SUBDIR, UAConfig
 
 
 KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
@@ -97,6 +97,11 @@ class TestDataPath:
         """When key is not in Config.data_paths the key is used to data_dir"""
         cfg = UAConfig({'data_dir': '/my/d'})
         assert '/my/d/%s/%s' % (PRIVATE_SUBDIR, key) == cfg.data_path(key=key)
+
+    def test_data_path_returns_public_path_for_public_datapath(self):
+        cfg = UAConfig({'data_dir': '/my/d'})
+        cfg.data_paths['test_path'] = DataPath('test_path', False)
+        assert '/my/d/test_path' == cfg.data_path('test_path')
 
 
 class TestWriteCache:

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -307,10 +307,17 @@ class TestStatus:
         }
         assert expected == cfg.status()
 
-    @mock.patch('uaclient.config.os.getuid', return_value=1000)
-    def test_nonroot_without_cache(self, _m_getuid):
+    @mock.patch('uaclient.config.os.getuid')
+    def test_nonroot_without_cache_is_same_as_unattached_root(self, m_getuid):
+        m_getuid.return_value = 1000
         cfg = FakeConfig()
-        assert None is cfg.status()
+
+        nonroot_status = cfg.status()
+
+        m_getuid.return_value = 0
+        root_unattached_status = cfg.status()
+
+        assert root_unattached_status == nonroot_status
 
     @mock.patch('uaclient.config.os.getuid')
     def test_root_followed_by_nonroot(self, m_getuid, tmpdir):

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from uaclient.config import LocalEnabledManager, PRIVATE_SUBDIR, UAConfig
+from uaclient.config import PRIVATE_SUBDIR, UAConfig
 
 
 KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
@@ -266,55 +266,3 @@ class TestDeleteCache:
         cfg.delete_cache()
         assert [os.path.basename(t_file.strpath)] == os.listdir(
             tmpdir.join(PRIVATE_SUBDIR).strpath)
-
-
-class TestLocalEnabledManager:
-
-    @pytest.fixture(params=['direct', 'via_cfg'])
-    def manager(self, request, tmpdir):
-        cfg = UAConfig({'data_dir': tmpdir.strpath})
-
-        if request.param == 'direct':
-            return LocalEnabledManager(cfg)
-        elif request.param == 'via_cfg':
-            return cfg.local_enabled_manager
-        raise Exception('unknown param: {}'.format(request.param))
-
-    def test_no_local_access_returns_false(self, manager):
-        assert not manager.get('unknown')
-
-    def test_unknown_entitlement_returns_false(self, manager):
-        manager.set('test', True)
-
-        assert not manager.get('unknown')
-
-    @pytest.mark.parametrize('entitlements', [
-        {'a': True},
-        {'a': False},
-        {'a': True, 'b': True},
-        {'a': True, 'b': False, 'c': True},
-    ])
-    def test_round_trip(self, manager, entitlements):
-        for entitlement_name, value in entitlements.items():
-            manager.set(entitlement_name, value)
-
-        out = {entitlement_name: manager.get(entitlement_name)
-               for entitlement_name in entitlements}
-
-        assert entitlements == out
-
-    @pytest.mark.parametrize('non_bool_value', ('', 'a', None, {}, object()))
-    def test_set_non_bool(self, manager, non_bool_value):
-        with pytest.raises(Exception) as excinfo:
-            manager.set('test', non_bool_value)
-
-        expected_msg = 'LocalEnabledManager.set passed non-bool value'
-        assert expected_msg == str(excinfo.value)
-
-    def test_local_access_written_public(self, manager):
-        manager.set('test', True)
-
-        assert os.path.exists(
-            manager._cfg.data_path('local-access', private=False))
-        assert not os.path.exists(
-            manager._cfg.data_path('local-access', private=True))

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import os
 import stat
@@ -249,10 +250,12 @@ class TestDeleteCache:
         for odd_key in odd_keys:
             cfg.write_cache(odd_key, odd_key)
 
-        private_cachedir = tmpdir.join(PRIVATE_SUBDIR).strpath
-        assert len(odd_keys) == len(os.listdir(private_cachedir))
+        present_files = list(itertools.chain(
+            *[walk_entry[2] for walk_entry in os.walk(tmpdir.strpath)]))
+        assert len(odd_keys) == len(present_files)
         cfg.delete_cache()
-        dirty_files = os.listdir(private_cachedir)
+        dirty_files = list(itertools.chain(
+            *[walk_entry[2] for walk_entry in os.walk(tmpdir.strpath)]))
         assert 0 == len(dirty_files), '%d files not deleted' % len(dirty_files)
 
     def test_delete_cache_ignores_files_not_defined_in_data_paths(

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -110,10 +110,6 @@ class TestRequestUpdatedContract:
         cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
         assert True is request_updated_contract(cfg)
         assert machine_token == cfg.read_cache('machine-token')
-        # Redact public content
-        assert (
-            '<REDACTED>' == cfg.read_cache(
-                'public-machine-token')['machineToken'])
 
         # Deltas are processed in a sorted fashion so that if enableByDefault
         # is true, the order of enablement operations is the same regardless


### PR DESCRIPTION
Instead of redacting all of our data and storing it in the public directory, this pull request moves us to only store a JSON representation of the current status which is updated whenever root runs attach/enable/disable. This substantially reduces the footprint of world-readable data, and also means that new data coming from the contract server won't be automatically world-readable.

Fixes #494.