### PR TITLE
tox.ini: add mypy to envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{trusty,xenial,bionic}, flake8-{trusty,xenial,bionic}
+envlist = py3, flake8, py3-{trusty,xenial,bionic}, flake8-{trusty,xenial,bionic},mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
This means that developers running tox locally will see any mypy errors
that they introduce.  It _doesn't_ introduce mypy in to our Travis
configuration, so mypy errors will not block merges.