### PR TITLE
util: simplify get_platform_info and improve performance 

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -66,7 +66,7 @@ def add_auth_apt_repo(repo_filename: str, repo_url: str, credentials: str,
     except ValueError:  # Then we have a bearer token
         username = 'bearer'
         password = credentials
-    series = util.get_platform_info('series')
+    series = util.get_platform_info()['series']
     if repo_url.endswith('/'):
         repo_url = repo_url[:-1]
     if not valid_apt_credentials(repo_url, username, password):
@@ -163,7 +163,7 @@ def remove_auth_apt_repo(repo_filename: str, repo_url: str,
 
 def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
     """Add an apt preferences file and pin for a PPA."""
-    series = util.get_platform_info('series')
+    series = util.get_platform_info()['series']
     _protocol, repo_path = repo_url.split('://')
     if repo_path.endswith('/'):  # strip trailing slash
         repo_path = repo_path[:-1]

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -29,7 +29,7 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
         """
         if not self.can_disable(silent, force):
             return False
-        series = util.get_platform_info('series')
+        series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -23,7 +23,7 @@ class CISEntitlement(repo.RepoEntitlement):
         """
         if not self.can_disable(silent, force):
             return False
-        series = util.get_platform_info('series')
+        series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -162,7 +162,7 @@ class RepoEntitlement(base.UAEntitlement):
             old_url = orig_entitlement.get('directives', {}).get('aptURL')
             if old_url:
                 # Remove original aptURL and auth and rewrite
-                series = util.get_platform_info('series')
+                series = util.get_platform_info()['series']
                 repo_filename = self.repo_list_file_tmpl.format(
                     name=self.name, series=series)
                 apt.remove_auth_apt_repo(repo_filename, old_url)
@@ -171,7 +171,7 @@ class RepoEntitlement(base.UAEntitlement):
         return True
 
     def setup_apt_config(self):
-        series = util.get_platform_info('series')
+        series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         resource_cfg = self.cfg.entitlements.get(self.name)
@@ -242,7 +242,7 @@ class RepoEntitlement(base.UAEntitlement):
 
     def remove_apt_config(self):
         """Remove any repository apt configuration files."""
-        series = util.get_platform_info('series')
+        series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series)
         keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -37,7 +37,6 @@ ESM_RESOURCE_ENTITLED = {
 
 M_PATH = 'uaclient.entitlements.esm.ESMEntitlement.'
 M_REPOPATH = 'uaclient.entitlements.repo.'
-M_GETPLATFORM = M_REPOPATH + 'util.get_platform_info'
 
 
 @pytest.fixture
@@ -71,7 +70,8 @@ class TestESMEntitlementDisable:
         assert 0 == m_remove_apt.call_count
 
     @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     @mock.patch(M_PATH + 'can_disable', return_value=True)
     def test_disable_removes_apt_config(
             self, m_can_disable, m_platform_info, m_rm_repo_from_auth,

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -95,7 +95,7 @@ class TestFIPSEntitlementEnable:
             m_can_enable = stack.enter_context(
                 mock.patch.object(entitlement, 'can_enable'))
             stack.enter_context(
-                mock.patch(M_GETPLATFORM, return_value='xenial'))
+                mock.patch(M_GETPLATFORM, return_value={'series': 'xenial'}))
             stack.enter_context(mock.patch(M_REPOPATH + 'os.path.exists'))
             # Note that this patch uses a PropertyMock and happens on the
             # entitlement's type because packages is a property
@@ -132,7 +132,7 @@ class TestFIPSEntitlementEnable:
         assert subp_calls == m_subp.call_args_list
 
     @mock.patch(
-        'uaclient.util.get_platform_info', return_value='xenial')
+        'uaclient.util.get_platform_info', return_value={'series': 'xenial'})
     def test_enable_returns_false_on_can_enable_false(
             self, m_platform_info, entitlement):
         """When can_enable is false enable returns false and noops."""
@@ -142,7 +142,7 @@ class TestFIPSEntitlementEnable:
 
     @mock.patch('uaclient.apt.add_auth_apt_repo')
     @mock.patch(
-        'uaclient.util.get_platform_info', return_value='xenial')
+        'uaclient.util.get_platform_info', return_value={'series': 'xenial'})
     def test_enable_returns_false_on_missing_suites_directive(
             self, m_platform_info, m_add_apt, entitlement):
         """When directives do not contain suites returns false."""
@@ -170,7 +170,7 @@ class TestFIPSEntitlementEnable:
                 mock.patch('uaclient.apt.add_ppa_pinning'))
             stack.enter_context(mock.patch.object(entitlement, 'can_enable'))
             stack.enter_context(
-                mock.patch(M_GETPLATFORM, return_value='xenial'))
+                mock.patch(M_GETPLATFORM, return_value={'series': 'xenial'}))
             stack.enter_context(mock.patch(M_REPOPATH + 'os.path.exists'))
 
             assert False is entitlement.enable()
@@ -262,7 +262,7 @@ class TestFIPSEntitlementDisable:
     @mock.patch('uaclient.apt.remove_apt_list_files')
     @mock.patch('uaclient.apt.remove_auth_apt_repo')
     @mock.patch(
-        'uaclient.util.get_platform_info', return_value='xenial')
+        'uaclient.util.get_platform_info', return_value={'series': 'xenial'})
     def test_disable_returns_false_and_removes_apt_config_on_force(
             self, m_platform_info, m_rm_auth, m_rm_list,
             entitlement, caplog_text):

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -204,7 +204,8 @@ class TestProcessContractDeltas:
         assert [mock.call()] == m_setup_apt_config.call_args_list
         assert [] == m_remove_auth_apt_repo.call_args_list
 
-    @mock.patch(M_PATH + 'util.get_platform_info', return_value='trusty')
+    @mock.patch(M_PATH + 'util.get_platform_info',
+                return_value={'series': 'trusty'})
     @mock.patch(M_PATH + 'apt.remove_auth_apt_repo')
     @mock.patch.object(RepoTestEntitlement, 'setup_apt_config')
     @mock.patch.object(RepoTestEntitlement, 'remove_apt_config')
@@ -261,7 +262,7 @@ class TestRepoEnable:
             self, m_can_enable, m_platform, m_exists, m_apt_add, m_subp,
             entitlement, capsys, caplog_text, tmpdir, packages):
         """On enable add authenticated apt repo and refresh package lists."""
-        m_platform.return_value = 'xenial'  # from 'series' param
+        m_platform.return_value = {'series': 'xenial'}
 
         expected_apt_calls = [mock.call(['apt-get', 'update'], capture=True)]
         expected_output = dedent("""\

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -25,7 +25,7 @@ class TestAddPPAPinning:
     @mock.patch('uaclient.util.get_platform_info')
     def test_write_apt_pin_file_to_apt_preferences(self, m_platform, tmpdir):
         """Write proper apt pin file to specified apt_preference_file."""
-        m_platform.return_value = 'xenial'
+        m_platform.return_value = {'series': 'xenial'}
         pref_file = tmpdir.join('preffile').strpath
         assert None is add_ppa_pinning(
             pref_file, repo_url='http://fakerepo', origin='MYORIG',
@@ -146,7 +146,8 @@ class TestAddAuthAptRepo:
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     def test_add_auth_apt_repo_writes_sources_file(
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
@@ -168,7 +169,8 @@ class TestAddAuthAptRepo:
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     def test_add_auth_apt_repo_ignores_suites_not_matching_series(
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
@@ -195,7 +197,8 @@ class TestAddAuthAptRepo:
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     def test_add_auth_apt_repo_ignores_updates_suites_on_non_update_machine(
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
@@ -220,7 +223,8 @@ class TestAddAuthAptRepo:
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     def test_add_auth_apt_repo_writes_username_password_to_auth_file(
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
@@ -243,7 +247,8 @@ class TestAddAuthAptRepo:
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
     @mock.patch('uaclient.apt.valid_apt_credentials', return_value=True)
-    @mock.patch('uaclient.util.get_platform_info', return_value='xenial')
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
     def test_add_auth_apt_repo_writes_bearer_resource_token_to_auth_file(
             self, m_platform, m_valid_creds, m_get_apt_auth_file, m_subp,
             tmpdir):
@@ -366,14 +371,6 @@ class TestMigrateAptSources:
         glob_files = ['/etc/apt/sources.list.d/ubuntu-cc-eal-trusty.list',
                       '/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list']
 
-        def fake_platform_info(key=None):
-            platform_data = {
-                'arch': 'x86_64', 'series': 'xenial', 'release': '16.04',
-                'kernel': '4.15.0-40-generic'}
-            if key:
-                return platform_data[key]
-            return platform_data
-
         def fake_apt_list_exists(path):
             if path in glob_files:
                 return True
@@ -385,7 +382,10 @@ class TestMigrateAptSources:
             return []
 
         repo_url = CC_RESOURCE_ENTITLED['entitlement']['directives']['aptURL']
-        m_platform_info.side_effect = fake_platform_info
+        m_platform_info.return_value = {
+            'arch': 'x86_64', 'series': 'xenial', 'release': '16.04',
+            'kernel': '4.15.0-40-generic',
+        }
         m_subp.return_value = '500 %s' % repo_url, ''
         with mock.patch('uaclient.apt.glob.glob') as m_glob:
             with mock.patch('uaclient.apt.os.path.exists') as m_exists:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -280,11 +280,9 @@ def get_platform_info(  # noqa: F811
         platform_info.update({'release': match_dict['version'],
                               'series': match_dict['series'].lower()})
     if key in (None, 'kernel'):
-        kernel_ver_out, _err = subp(['uname', '-r'])
-        platform_info['kernel'] = kernel_ver_out.strip()
+        platform_info['kernel'] = os.uname().release
     if key in (None, 'arch'):
-        arch, _err = subp(['uname', '-i'])
-        platform_info['arch'] = arch.strip()
+        platform_info['arch'] = os.uname().machine
     return platform_info if not key else platform_info[key]
 
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -8,10 +8,11 @@ from urllib import request
 import uuid
 
 try:
-    from typing import Any, Optional  # noqa: F401
+    from typing import Any, Dict, Optional, overload, Union  # noqa: F401
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
-    pass
+    def overload(f):
+        return f
 
 
 SENSITIVE_KEYS = ['caveat_id', 'password', 'resourceToken', 'machineToken']
@@ -249,7 +250,18 @@ REGEX_OS_RELEASE_VERSION_2 = (  # >= Disco
     r'(?P<version>\d+\.\d+)(\.\d)? (?P<lts>LTS )?\((?P<series>\w+).*')
 
 
-def get_platform_info(key=None):
+@overload
+def get_platform_info(key: None = None) -> 'Dict[str, str]':
+    pass
+
+
+@overload  # noqa: F811
+def get_platform_info(key: str) -> 'str':
+    pass
+
+
+def get_platform_info(  # noqa: F811
+        key: 'Optional[str]' = None) -> 'Union[Dict[str, str], str]':
     os_release = parse_os_release()
     platform_info = {
         'distribution': os_release.get('NAME', 'UNKNOWN'),


### PR DESCRIPTION
This PR does two things.

Firstly, it replaces shelling out to `uname` with calls to `os.uname()` from the stdlib; this improves the performance of the function (called without arguments) from ~2.5ms per call to ~20µs per call (i.e. over a 100x speed-up).

Secondly, given the substantially improved performance, it simplifies the call signature and implementation (by removing the `key` parameter) to always determine every piece of information, rather than optionally excluding parts of the return dict.