### PR TITLE
tox.ini: drop py3-trusty from default list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{trusty,xenial,bionic}, flake8-{trusty,xenial,bionic},mypy
+envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic},mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
It no longer runs successfully on the Ubuntu development release,
meaning developers on eoan (and perhaps disco) can't expect running
`tox` to pass.  This makes tox less useful.

(Note that this _doesn't_ remove py3-trusty from our tox.ini entirely,
and it will still run as appropriate in CI.)