### PR TITLE
 d/postinst: remove public files and generate status cache on upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,12 @@
 ubuntu-advantage-tools (19.5) UNRELEASED; urgency=medium
 
+  [ Andreas Hasenack ]
   * Ship unattended-upgrades configuration for ESM
   * Wait for snapd to initialise before using it
   * Test fixes
+
+  [ Daniel Watkins ]
+  * d/postinst: handle migration to new status cache on upgrade
 
  -- Andreas Hasenack <andreas@canonical.com>  Mon, 15 Apr 2019 10:38:35 -0300
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -30,5 +30,3 @@ esac
 
 #DEBHELPER#
 exit 0
-
-

--- a/debian/postinst
+++ b/debian/postinst
@@ -22,8 +22,20 @@ EOF
     fi
 }
 
+upgrade_to_status_cache() {
+    # Remove all publicly-readable files
+    find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f | xargs rm
+    # Regenerate the status.json cache
+    ua status 2>&1 > /dev/null
+}
+
 case "$1" in
     configure)
+      # We changed the way we store public files in 19.5; transition to the new
+      # status cache for installs of a previous version
+      if dpkg --compare-versions "$2" lt-nl "19.5~"; then
+          upgrade_to_status_cache
+      fi
       grep -iq trusty /etc/os-release && configure_esm
       ;;
 esac


### PR DESCRIPTION
Newer versions of ubuntu-advantage-tools only publicly store in
/var/lib/ubuntu-advantage exactly the data required for `ua status` to
run as a non-root user.  This postinst change removes all files in
/var/lib/ubuntu-advantage (but not in /var/lib/ubuntu-advantage/private,
which is where the non-public files are stored) and then runs `ua
status` to (re-)populate the status cache.

Fixes #522.