### PR TITLE
test_livepatch: remove unnecessary log level workaround

### DIFF
--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -24,11 +24,6 @@ def caplog_text(request):
     log_level = getattr(request, 'param', logging.INFO)
     try:
         try:
-            # TODO pyest 3.4 is funky and logs debug level by default
-            # https://docs.pytest.org/en/features/logging.html#\
-            #            incompatible-changes-in-pytest-3-4
-            # write_cache debug logs are seen on Bionic in test_livepatch:
-            # test_enable_false_when_can_enable_false
             caplog = request.getfixturevalue('caplog')
         except AttributeError:
             # Older versions of pytest only have getfuncargvalue, which is now

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -316,10 +316,7 @@ class TestLivepatchEntitlementEnable:
         """When can_enable returns False enable returns False."""
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert not entitlement.enable()
-        info_level_logs = [  # see uaclient/conftest.py
-            line for line in caplog_text().splitlines()
-            if 'DEBUG' not in line]
-        assert [] == info_level_logs
+        assert '' == caplog_text()
         assert '' == m_stdout.getvalue()  # No additional prints
         assert [mock.call(silent=mock.ANY)] == m_can_enable.call_args_list
 


### PR DESCRIPTION
caplog_text now logs at INFO by default, so we no longer need to filter
out debug log messages.

(Also remove the TODO that this addresses.)