### PR TITLE
Refactor internal status to be stored across three axes

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -249,8 +249,8 @@ def migrate_apt_sources(clean=False, cfg=None, platform_info=None):
         op_status, _details = entitlement.operational_status()
         if op_status != status.ACTIVE:
             continue
-        pass_affordances, details = entitlement.check_affordances()
-        if not pass_affordances:
+        applicability, details = entitlement.check_affordances()
+        if applicability != status.ApplicabilityStatus.APPLICABLE:
             logging.info(
                 'Disabled %s after package upgrade/downgrade. %s',
                 entitlement.title, details)

--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -249,7 +249,7 @@ def migrate_apt_sources(clean=False, cfg=None, platform_info=None):
         op_status, _details = entitlement.operational_status()
         if op_status != status.ACTIVE:
             continue
-        applicability, details = entitlement.check_affordances()
+        applicability, details = entitlement.applicability_status()
         if applicability != status.ApplicabilityStatus.APPLICABLE:
             logging.info(
                 'Disabled %s after package upgrade/downgrade. %s',

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -248,7 +248,7 @@ class UAConfig:
                 contractInfo['effectiveTo'], '%Y-%m-%dT%H:%M:%SZ')
         for ent_cls in ENTITLEMENT_CLASSES:
             ent = ent_cls(self)
-            contract_status = ent.contract_status()
+            contract_status = ent.contract_status().value
             op_status, op_details = ent.operational_status()
             service_status = {
                 'name': ent.name, 'entitled': contract_status,

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -14,6 +14,7 @@ from uaclient import config
 from uaclient import contract
 from uaclient import status
 from uaclient import util
+from uaclient.status import ContractStatus
 
 RE_KERNEL_UNAME = (
     r'(?P<major>[\d]+)[.-](?P<minor>[\d]+)[.-](?P<patch>[\d]+\-[\d]+)'
@@ -101,7 +102,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             contract_client = contract.UAContractClient(self.cfg)
             contract_client.request_resource_machine_access(
                 token, self.name)
-        if not self.contract_status() == status.ENTITLED:
+        if not self.contract_status() == ContractStatus.ENTITLED:
             if not silent:
                 print(status.MESSAGE_UNENTITLED_TMPL.format(title=self.title))
             return False
@@ -188,14 +189,14 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """
         pass
 
-    def contract_status(self) -> str:
-        """Return whether contract entitlement is ENTITLED or NONE."""
+    def contract_status(self) -> ContractStatus:
+        """Return whether the user is entitled to the entitlement or not"""
         if not self.cfg.is_attached:
-            return status.NONE
+            return ContractStatus.UNENTITLED
         entitlement_cfg = self.cfg.entitlements.get(self.name, {})
         if entitlement_cfg and entitlement_cfg['entitlement'].get('entitled'):
-            return status.ENTITLED
-        return status.NONE
+            return ContractStatus.ENTITLED
+        return ContractStatus.UNENTITLED
 
     def is_access_expired(self) -> bool:
         """Return entitlement access info as stale and needing refresh."""

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -118,16 +118,17 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             return False
         return True
 
-    def check_affordances(self) -> 'Tuple[ApplicabilityStatus, str]':
+    def applicability_status(self) -> 'Tuple[ApplicabilityStatus, str]':
         """Check all contract affordances to vet current platform
 
         Affordances are a list of support constraints for the entitlement.
         Examples include a list of supported series, architectures for kernel
         revisions.
 
-        @return: Tuple (ApplicabilityStatus, detailed_message).  APPLICABLE if
-        platform passes all defined affordances, INAPPLICABLE if it doesn't
-        meet all of the provided constraints.
+        :return:
+            tuple of (ApplicabilityStatus, detailed_message).  APPLICABLE if
+            platform passes all defined affordances, INAPPLICABLE if it doesn't
+            meet all of the provided constraints.
         """
         entitlement_cfg = self.cfg.entitlements.get(self.name)
         if not entitlement_cfg:
@@ -279,7 +280,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
     def operational_status(self) -> 'Tuple[str, str]':
         """Return whether entitlement is ACTIVE, INACTIVE or UNAVAILABLE"""
-        applicability, details = self.check_affordances()
+        applicability, details = self.applicability_status()
         if applicability != ApplicabilityStatus.APPLICABLE:
             return status.INAPPLICABLE, details
         entitlement_cfg = self.cfg.entitlements.get(self.name)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -273,7 +273,26 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         return False
 
-    @abc.abstractmethod
     def operational_status(self) -> 'Tuple[str, str]':
         """Return whether entitlement is ACTIVE, INACTIVE or UNAVAILABLE"""
+        passed_affordances, details = self.check_affordances()
+        if not passed_affordances:
+            return status.INAPPLICABLE, details
+        entitlement_cfg = self.cfg.entitlements.get(self.name)
+        if not entitlement_cfg:
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
+        elif entitlement_cfg['entitlement'].get('entitled', False) is False:
+            return status.INAPPLICABLE, '%s is not entitled' % self.title
+
+        application_status, explanation = self.application_status()
+        return application_status.to_operational_status(), explanation
+
+    @abc.abstractmethod
+    def application_status(self) -> 'Tuple[status.ApplicationStatus, str]':
+        """
+        The current status of application of this entitlement
+
+        :return:
+            A tuple of (ApplicationStatus, human-friendly reason)
+        """
         pass

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -6,6 +6,7 @@ from uaclient import config
 from uaclient.entitlements import base
 from uaclient import status
 from uaclient import util
+from uaclient.status import ContractStatus
 
 try:
     from typing import Tuple  # noqa
@@ -215,12 +216,12 @@ class TestUaEntitlement:
     def test_contract_status_entitled(self, concrete_entitlement_factory):
         """The contract_status returns ENTITLED when entitlement enabled."""
         entitlement = concrete_entitlement_factory(entitled=True)
-        assert status.ENTITLED == entitlement.contract_status()
+        assert ContractStatus.ENTITLED == entitlement.contract_status()
 
     def test_contract_status_unentitled(self, concrete_entitlement_factory):
         """The contract_status returns NONE when entitlement is unentitled."""
         entitlement = concrete_entitlement_factory(entitled=False)
-        assert status.NONE == entitlement.contract_status()
+        assert ContractStatus.UNENTITLED == entitlement.contract_status()
 
     @pytest.mark.parametrize('orig_access,delta', (
         ({}, {}), ({}, {'entitlement': {'entitled': False}})))

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -58,7 +58,7 @@ def concrete_entitlement_factory(tmpdir):
                 'contractInfo': {
                     'resourceEntitlements': [
                         {'type': 'testconcreteentitlement',
-                         'entitled': True}]}}}
+                         'entitled': entitled}]}}}
         cfg.write_cache('machine-token', machineToken)
         cfg.write_cache('machine-access-testconcreteentitlement',
                         {'entitlement': {'entitled': entitled}})

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -39,6 +39,9 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         self._calls.append(('operational_status', ))
         return self._operational_status
 
+    def application_status(self):
+        pass
+
     def calls(self):  # Validate methods called
         return self._calls
 
@@ -72,7 +75,7 @@ class TestUaEntitlement:
             base.UAEntitlement()
         expected_msg = (
             "Can't instantiate abstract class UAEntitlement with abstract"
-            " methods description, disable, enable, name, operational_status,"
+            " methods application_status, description, disable, enable, name,"
             " title")
         assert expected_msg == str(excinfo.value)
 

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -12,6 +12,7 @@ from uaclient.entitlements.livepatch import (
     LivepatchEntitlement, process_config_directives)
 from uaclient.entitlements.repo import APT_RETRIES
 from uaclient import status
+from uaclient.status import ContractStatus
 
 
 LIVEPATCH_MACHINE_TOKEN = MappingProxyType({
@@ -71,13 +72,13 @@ class TestLivepatchContractStatus:
 
     def test_contract_status_entitled(self, entitlement):
         """The contract_status returns ENTITLED when entitled is True."""
-        assert status.ENTITLED == entitlement.contract_status()
+        assert ContractStatus.ENTITLED == entitlement.contract_status()
 
     def test_contract_status_unentitled(self, entitlement):
         """The contract_status returns NONE when entitled is False."""
         entitlement.cfg.write_cache(
             'machine-access-livepatch', {'entitlement': {'entitled': False}})
-        assert status.NONE == entitlement.contract_status()
+        assert ContractStatus.UNENTITLED == entitlement.contract_status()
 
 
 class TestLivepatchOperationalStatus:

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -83,9 +83,9 @@ class TestLivepatchContractStatus:
 
 class TestLivepatchOperationalStatus:
 
-    def test_operational_status_inapplicable_on_checked_affordances(
+    def test_operational_status_inapplicable_on_inapplicable_status(
             self, entitlement):
-        """The operational_status details failed check_affordances."""
+        """The operational_status details INAPPLICABLE applicability_status"""
         livepatch_bionic = copy.deepcopy(dict(LIVEPATCH_RESOURCE_ENTITLED))
         livepatch_bionic['entitlement']['affordances']['series'] = ['bionic']
         entitlement.cfg.write_cache(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -77,8 +77,8 @@ class TestOperationalStatus:
         platform_unsupported = copy.deepcopy(dict(PLATFORM_INFO_SUPPORTED))
         platform_unsupported['series'] = 'trusty'
         m_platform_info.return_value = platform_unsupported
-        passed_affordances, details = entitlement.check_affordances()
-        assert False is passed_affordances
+        applicability, details = entitlement.check_affordances()
+        assert status.ApplicabilityStatus.INAPPLICABLE == applicability
         assert 'Repo Test Class is not available for Ubuntu trusty.' == details
         op_status, op_details = entitlement.operational_status()
         assert status.INAPPLICABLE == op_status
@@ -94,8 +94,8 @@ class TestOperationalStatus:
         entitlement.cfg.write_cache('machine-token', no_entitlements)
         entitlement.cfg.delete_cache_key('machine-access-repotest')
         m_platform_info.return_value = dict(PLATFORM_INFO_SUPPORTED)
-        passed_affordances, _details = entitlement.check_affordances()
-        assert True is passed_affordances
+        applicability, _details = entitlement.check_affordances()
+        assert status.ApplicabilityStatus.APPLICABLE == applicability
         op_status, op_details = entitlement.operational_status()
         assert status.INAPPLICABLE == op_status
         assert 'Repo Test Class is not entitled' == op_details

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -71,13 +71,13 @@ def entitlement(tmpdir):
 class TestOperationalStatus:
 
     @mock.patch(M_PATH + 'util.get_platform_info')
-    def test_inapplicable_on_failed_check_affordances(
+    def test_inapplicable_on_inapplicable_applicability_status(
             self, m_platform_info, entitlement):
-        """When check_affordances raises a failure, return INAPPLICABLE."""
+        """When applicability_status is INAPPLICABLE, return INAPPLICABLE."""
         platform_unsupported = copy.deepcopy(dict(PLATFORM_INFO_SUPPORTED))
         platform_unsupported['series'] = 'trusty'
         m_platform_info.return_value = platform_unsupported
-        applicability, details = entitlement.check_affordances()
+        applicability, details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.INAPPLICABLE == applicability
         assert 'Repo Test Class is not available for Ubuntu trusty.' == details
         op_status, op_details = entitlement.operational_status()
@@ -94,7 +94,7 @@ class TestOperationalStatus:
         entitlement.cfg.write_cache('machine-token', no_entitlements)
         entitlement.cfg.delete_cache_key('machine-access-repotest')
         m_platform_info.return_value = dict(PLATFORM_INFO_SUPPORTED)
-        applicability, _details = entitlement.check_affordances()
+        applicability, _details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.APPLICABLE == applicability
         op_status, op_details = entitlement.operational_status()
         assert status.INAPPLICABLE == op_status

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,8 +1,27 @@
+import enum
+
+
 class TxtColor:
     OKGREEN = '\033[92m'
     DISABLEGREY = '\033[37m'
     FAIL = '\033[91m'
     ENDC = '\033[0m'
+
+
+@enum.unique
+class ApplicationStatus(enum.Enum):
+    """
+    An enum to represent the current application status of an entitlement
+    """
+    ENABLED = object()
+    DISABLED = object()
+
+    def to_operational_status(self) -> str:
+        mapping = {
+            ApplicationStatus.ENABLED: ACTIVE,
+            ApplicationStatus.DISABLED: INACTIVE,
+        }
+        return mapping[self]
 
 
 ACTIVE = 'active'

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -36,6 +36,15 @@ class ContractStatus(enum.Enum):
     UNENTITLED = 'none'
 
 
+@enum.unique
+class ApplicabilityStatus(enum.Enum):
+    """
+    An enum to represent whether an entitlement could apply to this machine
+    """
+    APPLICABLE = object()
+    INAPPLICABLE = object()
+
+
 ACTIVE = 'active'
 INACTIVE = 'inactive'
 INAPPLICABLE = 'n/a'

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -24,10 +24,21 @@ class ApplicationStatus(enum.Enum):
         return mapping[self]
 
 
+@enum.unique
+class ContractStatus(enum.Enum):
+    """
+    An enum to represent whether a user is entitled to an entitlement
+
+    (The value of each member is the string that will be used in status
+    output.)
+    """
+    ENTITLED = 'entitled'
+    UNENTITLED = 'none'
+
+
 ACTIVE = 'active'
 INACTIVE = 'inactive'
 INAPPLICABLE = 'n/a'
-ENTITLED = 'entitled'
 NONE = 'none'
 ESSENTIAL = 'essential'
 STANDARD = 'standard'
@@ -38,7 +49,8 @@ STATUS_COLOR = {
     ACTIVE: TxtColor.OKGREEN + ACTIVE + TxtColor.ENDC,
     INACTIVE: TxtColor.FAIL + INACTIVE + TxtColor.ENDC,
     INAPPLICABLE: TxtColor.DISABLEGREY + INAPPLICABLE + TxtColor.ENDC,
-    ENTITLED: TxtColor.OKGREEN + ENTITLED + TxtColor.ENDC,
+    ContractStatus.ENTITLED.value: (
+        TxtColor.OKGREEN + ContractStatus.ENTITLED.value + TxtColor.ENDC),
     NONE: TxtColor.DISABLEGREY + NONE + TxtColor.ENDC,
     ESSENTIAL: TxtColor.OKGREEN + ESSENTIAL + TxtColor.ENDC,
     STANDARD: TxtColor.OKGREEN + STANDARD + TxtColor.ENDC,


### PR DESCRIPTION
This refactors the internal state of the codebase so that we're passing around three types of enum: `ContractStatus`, `ApplicabilityStatus` and `ApplicationStatus`. Entitlements have methods that match these names, which return the entitlement's status for that axis.

operational_status remains (albeit moved to a shared implementation for all entitlements), but will be removed in favour of direct use of the `contract_status()`, `applicability_status()` and `application_status()` methods in a future PR.