### PR TITLE
cli: check for root before checking for attach in assert_attached_root

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -52,11 +52,11 @@ STATUS_FORMATS = ['tabular', 'json']
 def assert_attached_root(func):
     """Decorator asserting root user and attached config."""
     def wrapper(args, cfg):
-        if not cfg.is_attached:
-            print(ua_status.MESSAGE_UNATTACHED)
-            return 1
         if os.getuid() != 0:
             print(ua_status.MESSAGE_NONROOT_USER)
+            return 1
+        if not cfg.is_attached:
+            print(ua_status.MESSAGE_UNATTACHED)
             return 1
         return func(args, cfg)
     return wrapper

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -1,0 +1,40 @@
+import mock
+
+import pytest
+
+from uaclient import status
+from uaclient.cli import assert_attached_root
+from uaclient.testing.fakes import FakeConfig
+
+
+class TestAssertAttachedRoot:
+
+    @pytest.mark.parametrize('attached,uid,expected_message', (
+        (True, 0, None),
+        (True, 1000, status.MESSAGE_NONROOT_USER),
+        (False, 1000, status.MESSAGE_UNATTACHED),
+        (False, 0, status.MESSAGE_UNATTACHED),
+    ))
+    def test_assert_attached_root(
+            self, attached, uid, expected_message, capsys):
+
+        @assert_attached_root
+        def test_function(args, cfg):
+            return mock.sentinel.success
+
+        if attached:
+            cfg = FakeConfig.for_attached_machine()
+        else:
+            cfg = FakeConfig()
+
+        with mock.patch('uaclient.cli.os.getuid', return_value=uid):
+            ret = test_function(mock.Mock(), cfg)
+
+        if expected_message is None:
+            assert mock.sentinel.success == ret
+            expected_message = ''
+        else:
+            assert 1 == ret
+
+        out, _err = capsys.readouterr()
+        assert expected_message == out.strip()

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -12,7 +12,7 @@ class TestAssertAttachedRoot:
     @pytest.mark.parametrize('attached,uid,expected_message', (
         (True, 0, None),
         (True, 1000, status.MESSAGE_NONROOT_USER),
-        (False, 1000, status.MESSAGE_UNATTACHED),
+        (False, 1000, status.MESSAGE_NONROOT_USER),
         (False, 0, status.MESSAGE_UNATTACHED),
     ))
     def test_assert_attached_root(


### PR DESCRIPTION
`UAConfig.is_attached` relies on access to non-world-readable data, so this guards against calling it when we aren't root.

Fixes #533