### PR TITLE
attach: no tracebacks when ctrl-c is used during email/password prompts

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -244,7 +244,11 @@ def action_attach(args, cfg):
         return 1
     contract_client = contract.UAContractClient(cfg)
     if not args.token:
-        bound_macaroon_bytes = sso.discharge_root_macaroon(contract_client)
+        try:
+            bound_macaroon_bytes = sso.discharge_root_macaroon(contract_client)
+        except KeyboardInterrupt:
+            print('... Cancelled attach')
+            return 2
         if bound_macaroon_bytes is None:
             print('Could not attach machine. Unable to obtain authenticated'
                   ' user token')

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -218,7 +218,6 @@ def discharge_root_macaroon(contract_client):
         return None
     except (MacaroonFormatError) as e:
         logging.error("Invalid root macaroon: %s", str(e))
-
     if not discharge_macaroon:
         return None
     return bind_discharge_macarooon_to_root_macaroon(

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -104,6 +104,19 @@ class TestActionAttach:
         assert expected_calls == contract_machine_attach.call_args_list
         assert 0 == discharge_root_macaroon.call_count
 
+    @mock.patch(M_PATH + 'sso.discharge_root_macaroon')
+    @mock.patch(M_PATH + 'action_status')
+    def test_cancelled_input(self, action_status, discharge_root_macaroon):
+        """User cancelled input does not result in tracebacks."""
+        discharge_root_macaroon.side_effect = KeyboardInterrupt()
+        args = mock.MagicMock(token=None)
+        with mock.patch(M_PATH + 'sys.stdout', new_callable=StringIO) as m_out:
+            ret = action_attach(args, FakeConfig())
+
+        assert 2 == ret
+        assert 0 == action_status.call_count
+        assert '... Cancelled attach\n' == m_out.getvalue()
+
     @mock.patch('uaclient.cli.sys.stdout')
     @mock.patch('uaclient.cli.sso.discharge_root_macaroon')
     @mock.patch('uaclient.cli.contract.UAContractClient')


### PR DESCRIPTION
Fixes: #535