### PR TITLE
cli: handle KeyboardInterrupts gracefully

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -382,6 +382,17 @@ def setup_logging(console_level, log_level, log_file=None):
         root.addHandler(filehandler)
 
 
+def main_error_handler(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except KeyboardInterrupt:
+            print('Interrupt received; exiting.', file=sys.stderr)
+            sys.exit(1)
+    return wrapper
+
+
+@main_error_handler
 def main(sys_argv=None):
     if not sys_argv:
         sys_argv = sys.argv

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -3,7 +3,7 @@ import mock
 import pytest
 
 from uaclient import status
-from uaclient.cli import assert_attached_root
+from uaclient.cli import assert_attached_root, main
 from uaclient.testing.fakes import FakeConfig
 
 
@@ -38,3 +38,21 @@ class TestAssertAttachedRoot:
 
         out, _err = capsys.readouterr()
         assert expected_message == out.strip()
+
+
+class TestMain:
+
+    @mock.patch('uaclient.cli.get_parser')
+    def test_keyboard_interrupt_handled_gracefully(self, m_get_parser, capsys):
+        m_args = m_get_parser.return_value.parse_args.return_value
+        m_args.action.side_effect = KeyboardInterrupt
+
+        with pytest.raises(SystemExit) as excinfo:
+            main(['some', 'args'])
+
+        exc = excinfo.value
+        assert 1 == exc.code
+
+        out, err = capsys.readouterr()
+        assert '' == out
+        assert 'Interrupt received; exiting.\n' == err


### PR DESCRIPTION
This introduces a wrapper around main() which handles
KeyboardInterrupts.  This could also be used in future for sanitising
other exceptions that bubble all the way out to the console.

Fixes #535