### PR TITLE
CI: add disco to tox/travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - python: 3.6
       env: TOXENV=py3-bionic,flake8-bionic
     - python: 3.7
+      env: TOXENV=py3-disco,flake8-disco
+    - python: 3.7
       env: TOXENV=py3,flake8
     - python: 3.8-dev
       env: TOXENV=py3,flake8

--- a/tools/constraints-disco.txt
+++ b/tools/constraints-disco.txt
@@ -1,0 +1,5 @@
+flake8==3.6.0
+py==1.7.0
+pycodestyle==2.4.0
+pytest==3.10.1
+pytest-cov==2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, flake8, py3-{xenial,bionic}, flake8-{trusty,xenial,bionic},mypy
+envlist = py3, flake8, py3-{xenial,bionic,disco}, flake8-{trusty,xenial,bionic,disco},mypy
 
 [testenv]
 deps =
@@ -8,6 +8,7 @@ deps =
     trusty: -ctools/constraints-trusty.txt
     xenial: -ctools/constraints-xenial.txt
     bionic: -ctools/constraints-bionic.txt
+    disco: -ctools/constraints-disco.txt
     mypy: mypy
 commands =
     py3: py.test --cov uaclient uaclient


### PR DESCRIPTION
This excludes cosmic, because there are incompatibilities between pycodestyle and flake8 that are handled in the distro packaging. (As cosmic is EOL in a couple of months, I didn't investigate any further.)