### PR TITLE
packaging: trusty postinst upgrade old client to new client clean status

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -24,7 +24,7 @@ EOF
 
 upgrade_to_status_cache() {
     # Remove all publicly-readable files
-    find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f | xargs rm
+    find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f -delete
     # Regenerate the status.json cache
     ua status 2>&1 > /dev/null
 }


### PR DESCRIPTION
When upgrading ubuntu-advantage-tools from version < 18 on trusty, there
are no files in /var/lib/ubuntu-advantage. Fix xargs call to not run rm
if there are no files to remove.

Fixes: #541