### PR TITLE
packaging: trusty should remove v1 esm key if present after upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -3,9 +3,11 @@
 set -e
 
 ESM_APT_GPG_KEY="/etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg"
+ESM_APT_GPG_KEY_OLD="/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg"
 ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
 
 configure_esm() {
+    rm -f $ESM_APT_GPG_KEY_OLD  # Remove retired key from key list
     if [ ! -f "$ESM_APT_GPG_KEY" ]; then
         cp /usr/share/keyrings/ubuntu-esm-v2-keyring.gpg "$ESM_APT_GPG_KEY"
     fi


### PR DESCRIPTION
v1 was viewed as compromised and has been retired in favor of
ubuntu-esm-v2-keyring.gpg. Remove this from the machines list of
acceptable keys if present as the esm repo is signed with v2.

Fixes: #423