### PR TITLE
esm: use Pin-Priority never apt preference file to disable esm initially

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -5,6 +5,7 @@ set -e
 ESM_APT_GPG_KEY="/etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg"
 ESM_APT_GPG_KEY_OLD="/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg"
 ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
+ESM_APT_PREF_FILE="/etc/apt/preferences.d/ubuntu-esm-trusty"
 
 configure_esm() {
     rm -f $ESM_APT_GPG_KEY_OLD  # Remove retired key from key list
@@ -22,6 +23,14 @@ deb https://esm.ubuntu.com/ubuntu trusty-updates main
 # deb-src https://esm.ubuntu.com/ubuntu trusty-updates main
 EOF
     fi
+    if [ ! -e "$ESM_APT_PREF_FILE" ]; then
+	cat > $ESM_APT_PREF_FILE <<EOF
+# Written by ubuntu-advantage-tools
+Package: *
+Pin: release o=UbuntuESM, n=trusty
+Pin-Priority: never
+EOF
+   fi
 }
 
 upgrade_to_status_cache() {

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -11,4 +11,5 @@ class ESMEntitlement(repo.RepoEntitlement):
         ' (https://ubuntu.com/esm)')
     repo_url = 'https://esm.ubuntu.com'
     repo_key_file = 'ubuntu-esm-v2-keyring.gpg'
+    repo_pin_priority = 'never'
     disable_apt_auth_only = True  # Only remove apt auth files when disabling

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -1,11 +1,14 @@
+import contextlib
 import itertools
 import mock
 import os.path
 
 import pytest
 
+from uaclient import apt
 from uaclient import config
 from uaclient.entitlements.esm import ESMEntitlement
+from uaclient.entitlements.repo import APT_RETRIES
 
 
 ESM_MACHINE_TOKEN = {
@@ -13,7 +16,7 @@ ESM_MACHINE_TOKEN = {
     'machineTokenInfo': {
         'contractInfo': {
             'resourceEntitlements': [
-                {'type': 'esm'}]}}}
+                {'type': 'esm', 'entitled': True}]}}}
 
 
 ESM_RESOURCE_ENTITLED = {
@@ -27,7 +30,7 @@ ESM_RESOURCE_ENTITLED = {
         'directives': {
             'aptURL': 'http://ESM',
             'aptKey': 'APTKEY',
-            'suites': ['xenial']
+            'suites': ['trusty']
         },
         'affordances': {
             'series': []   # Will match all series
@@ -37,6 +40,7 @@ ESM_RESOURCE_ENTITLED = {
 
 M_PATH = 'uaclient.entitlements.esm.ESMEntitlement.'
 M_REPOPATH = 'uaclient.entitlements.repo.'
+M_GETPLATFORM = M_REPOPATH + 'util.get_platform_info'
 
 
 @pytest.fixture
@@ -50,6 +54,69 @@ def entitlement(tmpdir):
     cfg.write_cache('machine-token', dict(ESM_MACHINE_TOKEN))
     cfg.write_cache('machine-access-esm', dict(ESM_RESOURCE_ENTITLED))
     return ESMEntitlement(cfg)
+
+
+class TestESMEntitlementEnable:
+
+    def test_enable_configures_apt_sources_and_auth_files(self, entitlement):
+        """When entitled, configure apt repo auth token, pinning and url."""
+        patched_packages = ['a', 'b']
+        original_exists = os.path.exists
+
+        def fake_exists(path):
+            if path == '/etc/apt/preferences.d/ubuntu-esm-trusty':
+                return True
+            if path in (apt.APT_METHOD_HTTPS_FILE, apt.CA_CERTIFICATES_FILE):
+                return True
+            return original_exists(path)
+
+        with contextlib.ExitStack() as stack:
+            m_add_apt = stack.enter_context(
+                mock.patch('uaclient.apt.add_auth_apt_repo'))
+            m_add_pinning = stack.enter_context(
+                mock.patch('uaclient.apt.add_ppa_pinning'))
+            m_subp = stack.enter_context(mock.patch('uaclient.util.subp'))
+            m_can_enable = stack.enter_context(
+                mock.patch.object(entitlement, 'can_enable'))
+            stack.enter_context(
+                mock.patch(M_GETPLATFORM, return_value={'series': 'trusty'}))
+            stack.enter_context(
+                mock.patch(M_REPOPATH + 'os.path.exists',
+                           side_effect=fake_exists))
+            m_unlink = stack.enter_context(
+                mock.patch('uaclient.apt.os.unlink'))
+            # Note that this patch uses a PropertyMock and happens on the
+            # entitlement's type because packages is a property
+            m_packages = mock.PropertyMock(return_value=patched_packages)
+            stack.enter_context(
+                mock.patch.object(type(entitlement), 'packages', m_packages))
+
+            m_can_enable.return_value = True
+
+            assert True is entitlement.enable()
+
+        add_apt_calls = [
+            mock.call(
+                '/etc/apt/sources.list.d/ubuntu-{}-trusty.list'.format(
+                    entitlement.name),
+                'http://ESM', 'TOKEN', ['trusty'],
+                '/usr/share/keyrings/ubuntu-{}-v2-keyring.gpg'.format(
+                    entitlement.name))]
+        install_cmd = mock.call(
+            ['apt-get', 'install', '--assume-yes'] + patched_packages,
+            capture=True, retry_sleeps=APT_RETRIES)
+
+        subp_calls = [
+            mock.call(
+                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
+            install_cmd]
+
+        assert [mock.call(silent=mock.ANY)] == m_can_enable.call_args_list
+        assert add_apt_calls == m_add_apt.call_args_list
+        assert 0 == m_add_pinning.call_count
+        assert subp_calls == m_subp.call_args_list
+        unlink_calls = [mock.call('/etc/apt/preferences.d/ubuntu-esm-trusty')]
+        assert unlink_calls == m_unlink.call_args_list
 
 
 class TestESMEntitlementDisable:
@@ -71,26 +138,23 @@ class TestESMEntitlementDisable:
 
     @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
     @mock.patch('uaclient.util.get_platform_info',
-                return_value={'series': 'xenial'})
+                return_value={'series': 'trusty'})
     @mock.patch(M_PATH + 'can_disable', return_value=True)
     def test_disable_removes_apt_config(
             self, m_can_disable, m_platform_info, m_rm_repo_from_auth,
             entitlement, tmpdir, caplog_text):
-        """When can_disable, disable removes apt configuration when force."""
+        """When can_disable, disable removes apt configuration when forced."""
 
-        original_exists = os.path.exists
+        with mock.patch('uaclient.util.subp'):
+            with mock.patch('uaclient.util.write_file') as m_write:
+                assert entitlement.disable(True, True)
 
-        def fake_exists(path):
-            if path == '/etc/apt/preferences.d/ubuntu-esm-xenial':
-                return True
-            return original_exists(path)
-
-        with mock.patch('os.path.exists', side_effect=fake_exists):
-            with mock.patch('uaclient.apt.os.unlink') as m_unlink:
-                with mock.patch('uaclient.util.subp'):
-                    assert entitlement.disable(True, True)
-
-        assert 0 == m_unlink.call_count
+        # Disable esm repo again
+        write_calls = [mock.call(
+            '/etc/apt/preferences.d/ubuntu-esm-trusty',
+            'Package: *\nPin: release o=UbuntuESM, n=trusty\n'
+            'Pin-Priority: never\n')]
+        assert write_calls == m_write.call_args_list
         assert [mock.call(True, True)] == m_can_disable.call_args_list
         auth_call = mock.call('http://ESM')
         assert [auth_call] == m_rm_repo_from_auth.call_args_list


### PR DESCRIPTION
Instead of relying on Packages-Require-Authorization header for the ESM
repo, disable the repo initially on package install setting
Pin-Priority: never. Upon enabling, we'll remove that preference file thus
enabling package installs from the repo.
    
Fixes: #520
