### PR TITLE
config: drop unused UAConfig.contracts property

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -39,7 +39,6 @@ class UAConfig:
     data_paths = {
         'bound-macaroon': DataPath('bound-macaroon', True),
         'accounts': DataPath('accounts.json', True),
-        'account-contracts': DataPath('account-contracts.json', True),
         'account-users': DataPath('account-users.json', True),
         'contract-token': DataPath('contract-token.json', True),
         'local-access': DataPath('local-access', True),
@@ -65,7 +64,6 @@ class UAConfig:
         'oauth': DataPath('sso-oauth.json', True)
     }  # type: Dict[str, DataPath]
 
-    _contracts = None  # caching to avoid repetitive file reads
     _entitlements = None  # caching to avoid repetitive file reads
     _machine_token = None  # caching to avoid repetitive file reading
 
@@ -127,13 +125,6 @@ class UAConfig:
         return self.cfg['sso_auth_url']
 
     @property
-    def contracts(self):
-        """Return the list of contracts that apply to this account."""
-        if not self._contracts:
-            self._contracts = self.read_cache('account-contracts')
-        return self._contracts or []
-
-    @property
     def entitlements(self):
         """Return a dictionary of entitlements keyed by entitlement name.
 
@@ -193,8 +184,6 @@ class UAConfig:
         if key.startswith('machine-access') or key == 'machine-token':
             self._entitlements = None
             self._machine_token = None
-        elif key == 'account-contracts':
-            self._contracts = None
         cache_path = self.data_path(key)
         if os.path.exists(cache_path):
             os.unlink(cache_path)
@@ -223,8 +212,6 @@ class UAConfig:
         if key.startswith('machine-access') or key == 'machine-token':
             self._machine_token = None
             self._entitlements = None
-        elif key == 'account-contracts':
-            self._contracts = None
         if not isinstance(content, str):
             content = json.dumps(content)
         mode = 0o600

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -84,7 +84,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         headers = self.headers()
         headers.update({'Authorization': 'Macaroon %s' % macaroon_token})
         account_contracts, _headers = self.request_url(url, headers=headers)
-        self.cfg.write_cache('account-contracts', account_contracts)
         return account_contracts
 
     def request_add_contract_token(self, macaroon_token, contract_id):

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -206,7 +206,7 @@ class TestDeleteCache:
     @pytest.mark.parametrize(
         'property_name,data_path_name,expected_null_value', (
             ('machine_token', 'machine-token', None),
-            ('contracts', 'account-contracts', [])))
+        ))
     def test_delete_cache_properly_clears_all_caches_simple(
             self, tmpdir, property_name, data_path_name, expected_null_value):
         """


### PR DESCRIPTION
We never actually read the account-contracts cached file (as we only
need it when we're performing an attach, at which point we obviously
won't have it cached), so we can drop it entirely.

(In 3fd37d3 we switched to using the contract information in the machine
token, and in 9cf48da we dropped the last of the MOTD support; that was
the point at which we stopped using it.)