### PR TITLE
apt: refactor migrate_apt_sources to clean_apt_sources

### DIFF
--- a/debian/prerm
+++ b/debian/prerm
@@ -5,9 +5,9 @@ set -e
 
 remove_apt_files() {
     python3 -c '
-from uaclient.apt import migrate_apt_sources
+from uaclient.apt import clean_apt_sources
 
-migrate_apt_sources(clean=True)
+clean_apt_sources()
 '
 
 }


### PR DESCRIPTION
migrate_apt_sources was only called with clean=True, so refactor it to remove the non-clean code path.

(`migrate_apt_sources` used `operational_status` within the unused code path; instead of refactoring the unused code path to the new APIs, it makes more sense to just drop it and reduce our ongoing maintenance burden.)