### PR TITLE
Replace operational_status with other APIs

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -328,7 +328,7 @@ def action_status(args, cfg):
         cfg = config.UAConfig()
     if args and args.format == 'json':
         status = cfg.status()
-        if status['expires'] != ua_status.INAPPLICABLE:
+        if status['expires'] != ua_status.UserFacingStatus.INAPPLICABLE.value:
             status['expires'] = str(status['expires'])
         print(json.dumps(status))
     else:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -236,10 +236,10 @@ class UAConfig:
         for ent_cls in ENTITLEMENT_CLASSES:
             ent = ent_cls(self)
             contract_status = ent.contract_status().value
-            op_status, op_details = ent.operational_status()
+            status, details = ent.user_facing_status()
             service_status = {
                 'name': ent.name, 'entitled': contract_status,
-                'status': op_status, 'statusDetails': op_details}
+                'status': status.value, 'statusDetails': details}
             response['services'].append(service_status)
         support = self.entitlements.get('support', {}).get('entitlement')
         if support:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -19,9 +19,9 @@ except ImportError:
 
 DEFAULT_STATUS = {
     'attached': False,
-    'expires': status.INAPPLICABLE,
+    'expires': status.UserFacingStatus.INAPPLICABLE.value,
     'services': [],
-    'techSupportLevel': status.INAPPLICABLE,
+    'techSupportLevel': status.UserFacingStatus.INAPPLICABLE.value,
 }  # type: Dict[str, Any]
 
 LOG = logging.getLogger(__name__)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -103,15 +103,16 @@ class UAEntitlement(metaclass=abc.ABCMeta):
             if not silent:
                 print(status.MESSAGE_UNENTITLED_TMPL.format(title=self.title))
             return False
-        op_status, op_status_details = self.operational_status()
-        if op_status == status.ACTIVE:
+        application_status, _ = self.application_status()
+        if application_status == status.ApplicationStatus.ENABLED:
             if not silent:
                 print(status.MESSAGE_ALREADY_ENABLED_TMPL.format(
                     title=self.title))
             return False
-        if op_status == status.INAPPLICABLE:
+        applicability_status, details = self.applicability_status()
+        if applicability_status == status.ApplicabilityStatus.INAPPLICABLE:
             if not silent:
-                print(op_status_details)
+                print(details)
             return False
         return True
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -76,16 +76,13 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """
         message = ''
         retval = True
-        op_status, status_details = self.operational_status()
+        application_status, _ = self.application_status()
 
         if not force:
-            if op_status == status.INACTIVE:
+            if application_status == status.ApplicationStatus.DISABLED:
                 message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
                     title=self.title
                 )
-                retval = False
-            elif op_status == status.INAPPLICABLE:
-                message = status_details
                 retval = False
         if message and not silent:
             print(message)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -237,18 +237,16 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 transition_to_unentitled = (
                     delta_entitlement['entitled'] in (False, util.DROPPED_KEY))
         if transition_to_unentitled:
-            op_status, _details = self.operational_status()
-            if op_status == status.ACTIVE:
-                if self.can_disable(silent=True):
-                    logging.info(
-                        "Due to contract refresh, '%s' is now disabled.",
-                        self.name)
-                    self.disable()
-                else:
-                    logging.warning(
-                        "Unable to disable '%s' as recommended during contract"
-                        " refresh. Service is still active. See `ua status`" %
-                        self.name)
+            if self.can_disable(silent=True):
+                logging.info(
+                    "Due to contract refresh, '%s' is now disabled.",
+                    self.name)
+                self.disable()
+            else:
+                logging.warning(
+                    "Unable to disable '%s' as recommended during contract"
+                    " refresh. Service is still active. See `ua status`" %
+                    self.name)
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -90,8 +90,8 @@ class LivepatchEntitlement(base.UAEntitlement):
                     'No specific resourceToken present. Using machine token as'
                     ' %s credentials', self.title)
                 livepatch_token = self.cfg.machine_token['machineToken']
-            op_status, _details = self.operational_status()
-            if op_status == status.ACTIVE:
+            application_status, _details = self.application_status()
+            if application_status == status.ApplicationStatus.ENABLED:
                 logging.info('Disabling %s prior to re-attach with new token',
                              self.title)
                 try:

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -161,8 +161,8 @@ class LivepatchEntitlement(base.UAEntitlement):
         """
         if super().process_contract_deltas(orig_access, deltas, allow_enable):
             return True  # Already processed parent class deltas
-        op_status, _details = self.operational_status()
-        if op_status != status.ACTIVE:
+        application_status, _ = self.application_status()
+        if application_status != status.ApplicationStatus.ENABLED:
             return True  # only operate on changed directives when ACTIVE
         delta_entitlement = deltas.get('entitlement', {})
         delta_directives = delta_entitlement.get('directives', {})

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -146,8 +146,8 @@ class RepoEntitlement(base.UAEntitlement):
         if super().process_contract_deltas(orig_access, deltas, allow_enable):
             return True  # Already processed parent class deltas
 
-        op_status, _details = self.operational_status()
-        if op_status != status.ACTIVE:
+        application_status, _ = self.application_status()
+        if application_status != status.ApplicationStatus.ENABLED:
             return True
         logging.info(
             "Updating '%s' apt sources list on changed directives." %

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -21,11 +21,13 @@ class ConcreteTestEntitlement(base.UAEntitlement):
     description = 'Entitlement for testing'
 
     def __init__(self, cfg=None, disable=None, enable=None,
-                 application_status=None, operational_status=None):
+                 applicability_status=None, application_status=None,
+                 operational_status=None):
         super().__init__(cfg)
         self._calls = []
         self._disable = disable
         self._enable = enable
+        self._applicability_status = applicability_status
         self._application_status = application_status
         self._operational_status = operational_status
 
@@ -41,6 +43,10 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         self._calls.append(('operational_status', ))
         return self._operational_status
 
+    def applicability_status(self):
+        self._calls.append(('applicability_status', ))
+        return self._applicability_status
+
     def application_status(self):
         self._calls.append(('application_status', ))
         return self._application_status
@@ -53,6 +59,7 @@ class ConcreteTestEntitlement(base.UAEntitlement):
 def concrete_entitlement_factory(tmpdir):
     def factory(
         *, entitled: bool, operational_status: 'Tuple[str, str]' = None,
+        applicability_status: 'Tuple[status.ApplicabilityStatus, str]' = None,
         application_status: 'Tuple[status.ApplicationStatus, str]' = None
     ) -> ConcreteTestEntitlement:
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -24,7 +24,6 @@ class ConcreteTestEntitlement(base.UAEntitlement):
                  applicability_status=None, application_status=None,
                  operational_status=None):
         super().__init__(cfg)
-        self._calls = []
         self._disable = disable
         self._enable = enable
         self._applicability_status = applicability_status
@@ -32,27 +31,19 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         self._operational_status = operational_status
 
     def disable(self):
-        self._calls.append(('disable', ))
         return self._disable
 
     def enable(self, silent_if_inapplicable: bool = False):
-        self._calls.append(('enable', silent_if_inapplicable))
         return self._enable
 
     def operational_status(self):
-        self._calls.append(('operational_status', ))
         return self._operational_status
 
     def applicability_status(self):
-        self._calls.append(('applicability_status', ))
         return self._applicability_status
 
     def application_status(self):
-        self._calls.append(('application_status', ))
         return self._application_status
-
-    def calls(self):  # Validate methods called
-        return self._calls
 
 
 @pytest.fixture

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -74,7 +74,9 @@ def concrete_entitlement_factory(tmpdir):
         cfg.write_cache('machine-access-testconcreteentitlement',
                         {'entitlement': {'entitled': entitled}})
         return ConcreteTestEntitlement(
-            cfg, application_status=application_status,
+            cfg,
+            applicability_status=applicability_status,
+            application_status=application_status,
             operational_status=operational_status)
     return factory
 
@@ -134,8 +136,7 @@ class TestUaEntitlement:
             self, capsys, concrete_entitlement_factory, silent):
         """When entitlement contract is not enabled, can_enable is False."""
 
-        entitlement = concrete_entitlement_factory(
-            entitled=False, operational_status=(status.INACTIVE, ''))
+        entitlement = concrete_entitlement_factory(entitled=False)
 
         kwargs = {}
         if silent is not None:
@@ -153,9 +154,10 @@ class TestUaEntitlement:
     @pytest.mark.parametrize('silent', (True, False, None))
     def test_can_enable_false_on_entitlement_active(
             self, capsys, concrete_entitlement_factory, silent):
-        """When operational status is ACTIVE, can_enable returns False."""
+        """When entitlement is ENABLED, can_enable returns False."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.ACTIVE, ''))
+            entitled=True,
+            application_status=(status.ApplicationStatus.ENABLED, ''))
 
         kwargs = {}
         if silent is not None:
@@ -172,9 +174,12 @@ class TestUaEntitlement:
     @pytest.mark.parametrize('silent', (True, False, None))
     def test_can_enable_false_on_entitlement_inapplicable(
             self, capsys, concrete_entitlement_factory, silent):
-        """When operational status INAPPLICABLE, can_enable returns False."""
+        """When entitlement is INAPPLICABLE, can_enable returns False."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.INAPPLICABLE, 'msg'))
+            entitled=True,
+            applicability_status=(status.ApplicabilityStatus.INAPPLICABLE,
+                                  'msg'),
+            application_status=(status.ApplicationStatus.DISABLED, ''))
 
         kwargs = {}
         if silent is not None:
@@ -190,9 +195,11 @@ class TestUaEntitlement:
     @pytest.mark.parametrize('silent', (True, False, None))
     def test_can_enable_true_on_entitlement_inactive(
             self, capsys, concrete_entitlement_factory, silent):
-        """When operational status is INACTIVE, can_enable returns True."""
+        """When an entitlement is applicable and disabled, we can_enable"""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.INACTIVE, ''))
+            entitled=True,
+            applicability_status=(status.ApplicabilityStatus.APPLICABLE, ''),
+            application_status=(status.ApplicationStatus.DISABLED, ''))
 
         kwargs = {}
         if silent is not None:
@@ -218,7 +225,9 @@ class TestUaEntitlement:
             self, concrete_entitlement_factory, orig_access, delta):
         """When orig_acccess dict is empty perform no work."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.INACTIVE, ''))
+            entitled=True,
+            applicability_status=(status.ApplicabilityStatus.APPLICABLE, ''),
+            application_status=(status.ApplicationStatus.DISABLED, ''))
         expected = {'entitlement': {'entitled': True}}
         assert expected == entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
@@ -237,7 +246,9 @@ class TestUaEntitlement:
             self, concrete_entitlement_factory, orig_access, delta):
         """If deltas do not represent transition to unentitled, do nothing."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.INACTIVE, ''))
+            entitled=True,
+            applicability_status=(status.ApplicabilityStatus.APPLICABLE, ''),
+            application_status=(status.ApplicationStatus.DISABLED, ''))
         expected = {'entitlement': {'entitled': True}}
         assert expected == entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -21,23 +21,18 @@ class ConcreteTestEntitlement(base.UAEntitlement):
     description = 'Entitlement for testing'
 
     def __init__(self, cfg=None, disable=None, enable=None,
-                 applicability_status=None, application_status=None,
-                 operational_status=None):
+                 applicability_status=None, application_status=None):
         super().__init__(cfg)
         self._disable = disable
         self._enable = enable
         self._applicability_status = applicability_status
         self._application_status = application_status
-        self._operational_status = operational_status
 
     def disable(self):
         return self._disable
 
     def enable(self, silent_if_inapplicable: bool = False):
         return self._enable
-
-    def operational_status(self):
-        return self._operational_status
 
     def applicability_status(self):
         return self._applicability_status
@@ -49,7 +44,7 @@ class ConcreteTestEntitlement(base.UAEntitlement):
 @pytest.fixture
 def concrete_entitlement_factory(tmpdir):
     def factory(
-        *, entitled: bool, operational_status: 'Tuple[str, str]' = None,
+        *, entitled: bool,
         applicability_status: 'Tuple[status.ApplicabilityStatus, str]' = None,
         application_status: 'Tuple[status.ApplicationStatus, str]' = None
     ) -> ConcreteTestEntitlement:
@@ -67,8 +62,7 @@ def concrete_entitlement_factory(tmpdir):
         return ConcreteTestEntitlement(
             cfg,
             applicability_status=applicability_status,
-            application_status=application_status,
-            operational_status=operational_status)
+            application_status=application_status)
     return factory
 
 

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -21,11 +21,12 @@ class ConcreteTestEntitlement(base.UAEntitlement):
     description = 'Entitlement for testing'
 
     def __init__(self, cfg=None, disable=None, enable=None,
-                 operational_status=None):
+                 application_status=None, operational_status=None):
         super().__init__(cfg)
         self._calls = []
         self._disable = disable
         self._enable = enable
+        self._application_status = application_status
         self._operational_status = operational_status
 
     def disable(self):
@@ -41,7 +42,8 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         return self._operational_status
 
     def application_status(self):
-        pass
+        self._calls.append(('application_status', ))
+        return self._application_status
 
     def calls(self):  # Validate methods called
         return self._calls
@@ -50,7 +52,8 @@ class ConcreteTestEntitlement(base.UAEntitlement):
 @pytest.fixture
 def concrete_entitlement_factory(tmpdir):
     def factory(
-        *, entitled: bool, operational_status: 'Tuple[str, str]' = None
+        *, entitled: bool, operational_status: 'Tuple[str, str]' = None,
+        application_status: 'Tuple[status.ApplicationStatus, str]' = None
     ) -> ConcreteTestEntitlement:
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         machineToken = {
@@ -64,7 +67,8 @@ def concrete_entitlement_factory(tmpdir):
         cfg.write_cache('machine-access-testconcreteentitlement',
                         {'entitlement': {'entitled': entitled}})
         return ConcreteTestEntitlement(
-            cfg, operational_status=operational_status)
+            cfg, application_status=application_status,
+            operational_status=operational_status)
     return factory
 
 

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -268,7 +268,8 @@ class TestUaEntitlement:
             self, concrete_entitlement_factory, orig_access, delta):
         """Only clear cache when deltas transition inactive to unentitled."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.INACTIVE, ''))
+            entitled=True,
+            application_status=(status.ApplicationStatus.DISABLED, ''))
         expected = {'entitlement': {'entitled': True}}
         assert expected == entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
@@ -276,7 +277,6 @@ class TestUaEntitlement:
         # Cache was cleaned
         assert None is entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
-        assert [('operational_status', )] == entitlement.calls()
 
     @pytest.mark.parametrize(
         'orig_access,delta',
@@ -289,7 +289,7 @@ class TestUaEntitlement:
             self, concrete_entitlement_factory, orig_access, delta):
         """Disable and clear cache when transition active to unentitled."""
         entitlement = concrete_entitlement_factory(
-            entitled=True, operational_status=(status.ACTIVE, ''),
+            entitled=True,
             application_status=(status.ApplicationStatus.ENABLED, ''))
         expected = {'entitlement': {'entitled': True}}
         assert expected == entitlement.cfg.read_cache(
@@ -298,7 +298,3 @@ class TestUaEntitlement:
         # Cache was cleaned
         assert None is entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
-        expected_calls = [
-            ('operational_status', ), ('application_status', ),
-            ('disable', )]
-        assert expected_calls == entitlement.calls()

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -51,7 +51,7 @@ PLATFORM_INFO_SUPPORTED = MappingProxyType({
 })
 
 
-class TestCommonCriteriaEntitlementOperationalStatus:
+class TestCommonCriteriaEntitlementUserFacingStatus:
 
     @pytest.mark.parametrize(
         'arch,series,details',
@@ -73,9 +73,9 @@ class TestCommonCriteriaEntitlementOperationalStatus:
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
         cfg.write_cache('machine-access-cc-eal', CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
-        op_status, op_status_details = entitlement.operational_status()
-        assert status.INAPPLICABLE == op_status
-        assert details == op_status_details
+        uf_status, uf_status_details = entitlement.user_facing_status()
+        assert status.UserFacingStatus.INAPPLICABLE == uf_status
+        assert details == uf_status_details
 
 
 class TestCommonCriteriaEntitlementCanEnable:
@@ -84,16 +84,16 @@ class TestCommonCriteriaEntitlementCanEnable:
     @mock.patch('uaclient.util.get_platform_info')
     def test_can_enable_true_on_entitlement_inactive(
             self, m_platform_info, _m_subp, tmpdir):
-        """When operational status is INACTIVE, can_enable returns True."""
+        """When entitlement is INACTIVE, can_enable returns True."""
         m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)
         cfg.write_cache('machine-access-cc-eal', CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
-        op_status, op_status_details = entitlement.operational_status()
-        assert status.INACTIVE == op_status
+        uf_status, uf_status_details = entitlement.user_facing_status()
+        assert status.UserFacingStatus.INACTIVE == uf_status
         details = '%s is not configured' % entitlement.title
-        assert details == op_status_details
+        assert details == uf_status_details
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert True is entitlement.can_enable()
         assert '' == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -39,15 +39,16 @@ CIS_RESOURCE_ENTITLED = {
 class TestCISEntitlementCanEnable:
 
     def test_can_enable_true_on_entitlement_inactive(self, tmpdir):
-        """When operational status is INACTIVE, can_enable returns True."""
+        """When entitlement is INACTIVE, can_enable returns True."""
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CIS_MACHINE_TOKEN)
         cfg.write_cache('machine-access-cis-audit', CIS_RESOURCE_ENTITLED)
         entitlement = CISEntitlement(cfg)
         # Unset static affordance container check
         entitlement.static_affordances = ()
-        with mock.patch.object(entitlement, 'operational_status',
-                               return_value=(status.INACTIVE, '')):
+        with mock.patch.object(
+                entitlement, 'application_status',
+                return_value=(status.ApplicationStatus.DISABLED, '')):
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
                 assert entitlement.can_enable()
         assert '' == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -74,9 +74,10 @@ def entitlement(request, tmpdir):
 class TestFIPSEntitlementCanEnable:
 
     def test_can_enable_true_on_entitlement_inactive(self, entitlement):
-        """When operational status is INACTIVE, can_enable returns True."""
-        with mock.patch.object(entitlement, 'operational_status',
-                               return_value=(status.INACTIVE, '')):
+        """When entitlement is disabled, can_enable returns True."""
+        with mock.patch.object(
+                entitlement, 'application_status',
+                return_value=(status.ApplicationStatus.DISABLED, '')):
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
                 assert True is entitlement.can_enable()
         assert '' == m_stdout.getvalue()

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -251,12 +251,13 @@ class TestLivepatchProcessContractDeltas:
             ({'remoteServer': 'new'}, True, False),
             ({'unhandledKey': 'new'}, False, False)))
     @mock.patch(M_PATH + 'LivepatchEntitlement.setup_livepatch_config')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     def test_setup_performed_when_active_and_supported_deltas(
-            self, m_op_status, m_setup_livepatch_config, entitlement,
+            self, m_application_status, m_setup_livepatch_config, entitlement,
             directives, process_directives, process_token):
         """Run setup when livepatch ACTIVE and deltas are supported keys."""
-        m_op_status.return_value = status.ACTIVE, 'fake active'
+        m_application_status.return_value = (
+            status.ApplicationStatus.ENABLED, '')
         deltas = {'entitlement': {'directives': directives}}
         assert entitlement.process_contract_deltas({}, deltas, False)
         if any([process_directives, process_token]):
@@ -272,12 +273,13 @@ class TestLivepatchProcessContractDeltas:
             ({'entitlement': {'something': 1}}, False, False),
             ({'resourceToken': 'new'}, False, True)))
     @mock.patch(M_PATH + 'LivepatchEntitlement.setup_livepatch_config')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     def test_livepatch_disable_and_setup_performed_when_resource_token_changes(
-            self, m_op_status, m_setup_livepatch_config, entitlement,
+            self, m_application_status, m_setup_livepatch_config, entitlement,
             deltas, process_directives, process_token):
         """Run livepatch calls setup when resourceToken changes."""
-        m_op_status.return_value = status.ACTIVE, 'fake active'
+        m_application_status.return_value = (
+            status.ApplicationStatus.ENABLED, '')
         entitlement.process_contract_deltas({}, deltas, False)
         if any([process_directives, process_token]):
             setup_calls = [

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -337,12 +337,12 @@ class TestLivepatchEntitlementEnable:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.which', return_value=False)
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     @mock.patch(M_PATH + 'LivepatchEntitlement.can_enable', return_value=True)
     def test_enable_installs_snapd_and_livepatch_snap_when_absent(
-            self, m_can_enable, m_op_status, m_which, m_subp, entitlement):
+            self, m_can_enable, m_app_status, m_which, m_subp, entitlement):
         """Install snapd and canonical-livepatch snap when not on system."""
-        m_op_status.return_value = status.ACTIVE, 'fake active'
+        m_app_status.return_value = status.ApplicationStatus.ENABLED, 'enabled'
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert entitlement.enable()
         assert self.mocks_install + self.mocks_config in m_subp.call_args_list
@@ -356,12 +356,12 @@ class TestLivepatchEntitlementEnable:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.which', side_effect=lambda cmd: cmd == 'snap')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     @mock.patch(M_PATH + 'LivepatchEntitlement.can_enable', return_value=True)
     def test_enable_installs_only_livepatch_snap_when_absent_but_snapd_present(
-            self, m_can_enable, m_op_status, m_which, m_subp, entitlement):
+            self, m_can_enable, m_app_status, m_which, m_subp, entitlement):
         """Install canonical-livepatch snap when not present on the system."""
-        m_op_status.return_value = status.ACTIVE, 'fake active'
+        m_app_status.return_value = status.ApplicationStatus.ENABLED, 'enabled'
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert entitlement.enable()
         assert (self.mocks_livepatch_install + self.mocks_config
@@ -375,12 +375,12 @@ class TestLivepatchEntitlementEnable:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.which', return_value='/found/livepatch')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     @mock.patch(M_PATH + 'LivepatchEntitlement.can_enable', return_value=True)
     def test_enable_does_not_install_livepatch_snap_when_present(
-            self, m_can_enable, m_op_status, m_which, m_subp, entitlement):
+            self, m_can_enable, m_app_status, m_which, m_subp, entitlement):
         """Do not attempt to install livepatch snap when it is present."""
-        m_op_status.return_value = status.ACTIVE, 'fake active'
+        m_app_status.return_value = status.ApplicationStatus.ENABLED, 'enabled'
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert entitlement.enable()
         assert self.mocks_config == m_subp.call_args_list
@@ -388,13 +388,13 @@ class TestLivepatchEntitlementEnable:
 
     @mock.patch('uaclient.util.subp')
     @mock.patch('uaclient.util.which', return_value='/found/livepatch')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     @mock.patch(M_PATH + 'LivepatchEntitlement.can_enable', return_value=True)
     def test_enable_does_not_disable_inactive_livepatch_snap_when_present(
-            self, m_can_enable, m_op_status, m_which, m_subp, entitlement):
+            self, m_can_enable, m_app_status, m_which, m_subp, entitlement):
         """Do not attempt to disable livepatch snap when it is inactive."""
 
-        m_op_status.return_value = status.INACTIVE, 'fake inactive'
+        m_app_status.return_value = status.ApplicationStatus.DISABLED, 'nope'
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             assert entitlement.enable()
         subp_no_livepatch_disable = [

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -81,11 +81,11 @@ class TestLivepatchContractStatus:
         assert ContractStatus.UNENTITLED == entitlement.contract_status()
 
 
-class TestLivepatchOperationalStatus:
+class TestLivepatchUserFacingStatus:
 
-    def test_operational_status_inapplicable_on_inapplicable_status(
+    def test_user_facing_status_inapplicable_on_inapplicable_status(
             self, entitlement):
-        """The operational_status details INAPPLICABLE applicability_status"""
+        """The user-facing details INAPPLICABLE applicability_status"""
         livepatch_bionic = copy.deepcopy(dict(LIVEPATCH_RESOURCE_ENTITLED))
         livepatch_bionic['entitlement']['affordances']['series'] = ['bionic']
         entitlement.cfg.write_cache(
@@ -93,11 +93,11 @@ class TestLivepatchOperationalStatus:
 
         with mock.patch('uaclient.util.get_platform_info') as m_platform_info:
             m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
-            op_status, details = entitlement.operational_status()
-        assert op_status == status.INAPPLICABLE
+            uf_status, details = entitlement.user_facing_status()
+        assert uf_status == status.UserFacingStatus.INAPPLICABLE
         assert 'Livepatch is not available for Ubuntu xenial.' == details
 
-    def test_operational_status_inapplicable_on_unentitled(
+    def test_user_facing_status_inapplicable_on_unentitled(
             self, entitlement):
         """Status inapplicable on absent entitlement contract status."""
         no_entitlements = copy.deepcopy(dict(LIVEPATCH_MACHINE_TOKEN))
@@ -108,8 +108,8 @@ class TestLivepatchOperationalStatus:
 
         with mock.patch('uaclient.util.get_platform_info') as m_platform_info:
             m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
-            op_status, details = entitlement.operational_status()
-        assert op_status == status.INAPPLICABLE
+            uf_status, details = entitlement.user_facing_status()
+        assert uf_status == status.UserFacingStatus.INAPPLICABLE
         assert 'Livepatch is not entitled' == details
 
 
@@ -156,7 +156,7 @@ class TestLivepatchProcessConfigDirectives:
 class TestLivepatchEntitlementCanEnable:
 
     def test_can_enable_true_on_entitlement_inactive(self, entitlement):
-        """When operational status is INACTIVE, can_enable returns True."""
+        """When entitlement is INACTIVE, can_enable returns True."""
         with mock.patch('uaclient.util.get_platform_info') as m_platform:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
                 with mock.patch('uaclient.util.is_container') as m_container:

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -231,14 +231,18 @@ class TestLivepatchProcessContractDeltas:
         assert [] == m_setup_livepatch_config.call_args_list
 
     @mock.patch(M_PATH + 'LivepatchEntitlement.setup_livepatch_config')
-    @mock.patch(M_PATH + 'LivepatchEntitlement.operational_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
+    @mock.patch(M_PATH + 'LivepatchEntitlement.applicability_status')
     def test_true_on_inactive_livepatch_service(
-            self, m_op_status, m_setup_livepatch_config, entitlement):
+            self, m_applicability_status, m_application_status,
+            m_setup_livepatch_config, entitlement):
         """When livepatch is INACTIVE return True and do no setup."""
-        m_op_status.return_value = status.INACTIVE, 'fake inactive'
+        m_applicability_status.return_value = (
+            status.ApplicabilityStatus.APPLICABLE, '')
+        m_application_status.return_value = (
+            status.ApplicationStatus.DISABLED, '')
         deltas = {'entitlement': {'directives': {'caCerts': 'new'}}}
         assert entitlement.process_contract_deltas({}, deltas, False)
-        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         assert [] == m_setup_livepatch_config.call_args_list
 
     @pytest.mark.parametrize(
@@ -255,7 +259,6 @@ class TestLivepatchProcessContractDeltas:
         m_op_status.return_value = status.ACTIVE, 'fake active'
         deltas = {'entitlement': {'directives': directives}}
         assert entitlement.process_contract_deltas({}, deltas, False)
-        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         if any([process_directives, process_token]):
             setup_calls = [
                 mock.call(process_directives=process_directives,
@@ -276,7 +279,6 @@ class TestLivepatchProcessContractDeltas:
         """Run livepatch calls setup when resourceToken changes."""
         m_op_status.return_value = status.ACTIVE, 'fake active'
         entitlement.process_contract_deltas({}, deltas, False)
-        assert [mock.call(), mock.call()] == m_op_status.call_args_list
         if any([process_directives, process_token]):
             setup_calls = [
                 mock.call(process_directives=process_directives,

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -123,7 +123,6 @@ class TestProcessContractDeltas:
         assert entitlement.process_contract_deltas(
             {'entitlement': {'entitled': True}},
             {'entitlement': {'entitled': entitled}})
-        assert [mock.call()] == m_op_status.call_args_list
         assert [mock.call()] == m_disable.call_args_list
 
     @mock.patch.object(RepoTestEntitlement, 'remove_apt_config')

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -68,7 +68,7 @@ def entitlement(tmpdir):
     return RepoTestEntitlement(cfg)
 
 
-class TestOperationalStatus:
+class TestUserFacingStatus:
 
     @mock.patch(M_PATH + 'util.get_platform_info')
     def test_inapplicable_on_inapplicable_applicability_status(
@@ -80,8 +80,8 @@ class TestOperationalStatus:
         applicability, details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.INAPPLICABLE == applicability
         assert 'Repo Test Class is not available for Ubuntu trusty.' == details
-        op_status, op_details = entitlement.operational_status()
-        assert status.INAPPLICABLE == op_status
+        uf_status, _ = entitlement.user_facing_status()
+        assert status.UserFacingStatus.INAPPLICABLE == uf_status
 
     @mock.patch(M_PATH + 'util.get_platform_info')
     def test_inapplicable_on_unentitled(
@@ -96,9 +96,9 @@ class TestOperationalStatus:
         m_platform_info.return_value = dict(PLATFORM_INFO_SUPPORTED)
         applicability, _details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.APPLICABLE == applicability
-        op_status, op_details = entitlement.operational_status()
-        assert status.INAPPLICABLE == op_status
-        assert 'Repo Test Class is not entitled' == op_details
+        uf_status, uf_details = entitlement.user_facing_status()
+        assert status.UserFacingStatus.INAPPLICABLE == uf_status
+        assert 'Repo Test Class is not entitled' == uf_details
 
 
 class TestProcessContractDeltas:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -51,22 +51,22 @@ class UserFacingStatus(enum.Enum):
     INAPPLICABLE = 'n/a'
 
 
-ACTIVE = 'active'
-INACTIVE = 'inactive'
-INAPPLICABLE = 'n/a'
-NONE = 'none'
 ESSENTIAL = 'essential'
 STANDARD = 'standard'
 ADVANCED = 'advanced'
 
 # Colorized status output for terminal
 STATUS_COLOR = {
-    ACTIVE: TxtColor.OKGREEN + ACTIVE + TxtColor.ENDC,
-    INACTIVE: TxtColor.FAIL + INACTIVE + TxtColor.ENDC,
-    INAPPLICABLE: TxtColor.DISABLEGREY + INAPPLICABLE + TxtColor.ENDC,
+    UserFacingStatus.ACTIVE.value: (
+        TxtColor.OKGREEN + UserFacingStatus.ACTIVE.value + TxtColor.ENDC),
+    UserFacingStatus.INACTIVE.value: (
+        TxtColor.FAIL + UserFacingStatus.INACTIVE.value + TxtColor.ENDC),
+    UserFacingStatus.INAPPLICABLE.value: (
+        TxtColor.DISABLEGREY + UserFacingStatus.INAPPLICABLE.value + TxtColor.ENDC),  # noqa: E501
     ContractStatus.ENTITLED.value: (
         TxtColor.OKGREEN + ContractStatus.ENTITLED.value + TxtColor.ENDC),
-    NONE: TxtColor.DISABLEGREY + NONE + TxtColor.ENDC,
+    ContractStatus.UNENTITLED.value: (
+        TxtColor.DISABLEGREY + ContractStatus.UNENTITLED.value + TxtColor.ENDC),  # noqa: E501
     ESSENTIAL: TxtColor.OKGREEN + ESSENTIAL + TxtColor.ENDC,
     STANDARD: TxtColor.OKGREEN + STANDARD + TxtColor.ENDC,
     ADVANCED: TxtColor.OKGREEN + ADVANCED + TxtColor.ENDC

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -16,13 +16,6 @@ class ApplicationStatus(enum.Enum):
     ENABLED = object()
     DISABLED = object()
 
-    def to_operational_status(self) -> str:
-        mapping = {
-            ApplicationStatus.ENABLED: ACTIVE,
-            ApplicationStatus.DISABLED: INACTIVE,
-        }
-        return mapping[self]
-
 
 @enum.unique
 class ContractStatus(enum.Enum):
@@ -43,6 +36,19 @@ class ApplicabilityStatus(enum.Enum):
     """
     APPLICABLE = object()
     INAPPLICABLE = object()
+
+
+@enum.unique
+class UserFacingStatus(enum.Enum):
+    """
+    An enum representing the states we will display in status output.
+
+    This enum should only be used in display code, it should not be used in
+    business logic.
+    """
+    ACTIVE = 'active'
+    INACTIVE = 'inactive'
+    INAPPLICABLE = 'n/a'
 
 
 ACTIVE = 'active'

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -359,14 +359,16 @@ class TestStatus:
         [{'type': 'support', 'entitled': True,
           'affordances': {'supportLevel': 'anything'}}]))
     @mock.patch('uaclient.config.os.getuid', return_value=0)
-    @mock.patch(M_PATH + 'livepatch.LivepatchEntitlement.operational_status')
-    @mock.patch(M_PATH + 'repo.RepoEntitlement.operational_status')
+    @mock.patch(M_PATH + 'livepatch.LivepatchEntitlement.user_facing_status')
+    @mock.patch(M_PATH + 'repo.RepoEntitlement.user_facing_status')
     def test_attached_reports_contract_and_service_status(
-            self, m_repo_op_status, m_livepatch_op_status, _m_getuid, tmpdir,
+            self, m_repo_uf_status, m_livepatch_uf_status, _m_getuid, tmpdir,
             entitlements):
-        """When attached, return contract and service operational status."""
-        m_repo_op_status.return_value = status.INAPPLICABLE, 'repo details'
-        m_livepatch_op_status.return_value = status.ACTIVE, 'livepatch details'
+        """When attached, return contract and service user-facing status."""
+        m_repo_uf_status.return_value = (
+            status.UserFacingStatus.INAPPLICABLE, 'repo details')
+        m_livepatch_uf_status.return_value = (
+            status.UserFacingStatus.ACTIVE, 'livepatch details')
         token = {
             'machineTokenInfo': {
                 'accountInfo': {'id': '1', 'name': 'accountname'},
@@ -384,14 +386,14 @@ class TestStatus:
             'techSupportLevel': support_level, 'services': []}
         for cls in ENTITLEMENT_CLASSES:
             if cls.name == 'livepatch':
-                op_status = status.ACTIVE
-                op_details = 'livepatch details'
+                expected_status = status.UserFacingStatus.ACTIVE.value
+                details = 'livepatch details'
             else:
-                op_status = status.INAPPLICABLE
-                op_details = 'repo details'
+                expected_status = status.UserFacingStatus.INAPPLICABLE.value
+                details = 'repo details'
             expected['services'].append(
                 {'name': cls.name, 'entitled': status.NONE,
-                 'status': op_status, 'statusDetails': op_details})
+                 'status': expected_status, 'statusDetails': details})
         assert expected == cfg.status()
-        assert len(ENTITLEMENT_CLASSES) - 1 == m_repo_op_status.call_count
-        assert 1 == m_livepatch_op_status.call_count
+        assert len(ENTITLEMENT_CLASSES) - 1 == m_repo_uf_status.call_count
+        assert 1 == m_livepatch_uf_status.call_count

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -284,9 +284,9 @@ class TestStatus:
         cfg = FakeConfig({})
         expected = {
             'attached': False,
-            'expires': status.INAPPLICABLE,
+            'expires': status.UserFacingStatus.INAPPLICABLE.value,
             'services': [],
-            'techSupportLevel': status.INAPPLICABLE,
+            'techSupportLevel': status.UserFacingStatus.INAPPLICABLE.value,
         }
         assert expected == cfg.status()
 
@@ -294,18 +294,19 @@ class TestStatus:
     def test_root_attached(self, _m_getuid):
         """Test we get the correct status dict when attached with basic conf"""
         cfg = FakeConfig.for_attached_machine()
-        expected_services = [{'entitled': status.NONE,
-                              'name': cls.name,
-                              'status': status.INAPPLICABLE,
-                              'statusDetails': mock.ANY}
-                             for cls in entitlements.ENTITLEMENT_CLASSES]
+        expected_services = [
+            {'entitled': status.ContractStatus.UNENTITLED.value,
+             'name': cls.name,
+             'status': status.UserFacingStatus.INAPPLICABLE.value,
+             'statusDetails': mock.ANY}
+            for cls in entitlements.ENTITLEMENT_CLASSES]
         expected = {
             'account': 'test_account',
             'attached': True,
-            'expires': status.INAPPLICABLE,
+            'expires': status.UserFacingStatus.INAPPLICABLE.value,
             'services': expected_services,
             'subscription': 'test_contract',
-            'techSupportLevel': status.INAPPLICABLE,
+            'techSupportLevel': status.UserFacingStatus.INAPPLICABLE.value,
         }
         assert expected == cfg.status()
         # cfg.status() idempotent
@@ -377,12 +378,13 @@ class TestStatus:
         cfg = FakeConfig.for_attached_machine(
             account_name='accountname', machine_token=token)
         if not entitlements:
-            support_level = status.INAPPLICABLE
+            support_level = status.UserFacingStatus.INAPPLICABLE.value
         else:
             support_level = entitlements[0]['affordances']['supportLevel']
         expected = {
             'attached': True, 'account': 'accountname',
-            'expires': status.INAPPLICABLE, 'subscription': 'contractname',
+            'expires': status.UserFacingStatus.INAPPLICABLE.value,
+            'subscription': 'contractname',
             'techSupportLevel': support_level, 'services': []}
         for cls in ENTITLEMENT_CLASSES:
             if cls.name == 'livepatch':
@@ -392,7 +394,8 @@ class TestStatus:
                 expected_status = status.UserFacingStatus.INAPPLICABLE.value
                 details = 'repo details'
             expected['services'].append(
-                {'name': cls.name, 'entitled': status.NONE,
+                {'name': cls.name,
+                 'entitled': status.ContractStatus.UNENTITLED.value,
                  'status': expected_status, 'statusDetails': details})
         assert expected == cfg.status()
         assert len(ENTITLEMENT_CLASSES) - 1 == m_repo_uf_status.call_count


### PR DESCRIPTION
This renames `operational_status` to `user_facing_status` and modifies the non-display-related call sites of `operational_status` to use `applicability_status`, `application_status`, and `contract_status` instead.