### PR TITLE
packaging: depend on libapt-pkg4.12 version to use pin-priority never

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,8 @@ Architecture: any
 Depends: ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
-         python3-pkg-resources
+         python3-pkg-resources,
+         ${extra:Depends},
 Description: management tools for Ubuntu Advantage
  Ubuntu Advantage is the professional package of tooling, technology
  and expertise from Canonical, helping organisations around the world

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,19 @@ export DH_VERBOSE=1
 include /usr/share/dpkg/pkg-info.mk
 FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
+include /etc/os-release
+ifeq (${VERSION_ID},"14.04")
+LIBAPT_PKG_DEP="libapt-pkg4.12 (>= 1.0.1ubuntu2.23)"
+else ifeq (${VERSION_ID},"16.04")
+LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.2.31)"
+else ifeq (${VERSION_ID},"18.04")
+LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.6.9)"
+else ifeq (${VERSION_ID},"18.10")
+LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.7.4)"
+else
+LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.8.1)"
+endif
+
 %:
 	dh $@ --with python3,bash-completion --buildsystem=pybuild
 
@@ -22,6 +35,10 @@ else
 	python3 -m flake8 uaclient
 endif
 endif
+
+override_dh_gencontrol:
+	echo extra:Depends=$(LIBAPT_PKG_DEP) >> debian/ubuntu-advantage-tools.substvars
+	dh_gencontrol
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools


### PR DESCRIPTION
Bug #1821308 fix is required to honor pin-priority: never in apt
preferences files. This fix comes in different libapt-pkg<abi> versions on trusty, xenial, bionic and disco.
- trusty: libapt-pkg4.12 version 1.0.1ubuntu2.23 
- xenial: libapt-pkg5.0 version 1.2.30
- bionic: ibapt-pkg5.0 (>= 1.6.9)
- cosmic: libapt-pkg5.0 (>= 1.7.3)
- disco: libapt-pkg5.0 (>= 1.8.0~rc1)
- eoan ++ libapt-pkg5.0 (>= 1.8.1)

UA client depends on this version to prevent installing packages from esm repositories until esm is enabled.