### PR TITLE
Start improving discharge_root_macaroon error handling

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -363,12 +363,14 @@ def setup_logging(console_level, log_level, log_file=None):
             if handler.stream.name == '<stderr>':
                 handler.setLevel(console_level)
                 handler.setFormatter(console_formatter)
+                handler.set_name('console')  # Used to disable console logging
                 stderr_found = True
                 break
     if not stderr_found:
         console = logging.StreamHandler(sys.stderr)
         console.setFormatter(console_formatter)
         console.setLevel(console_level)
+        console.set_name('console')  # Used to disable console logging
         root.addHandler(console)
     if os.getuid() == 0:
         # Setup debug file logging for root user as non-root is read-only

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -241,7 +241,8 @@ def action_attach(args, cfg):
         raise exceptions.NonRootUserError()
     contract_client = contract.UAContractClient(cfg)
     if not args.token:
-        bound_macaroon_bytes = sso.discharge_root_macaroon(contract_client)
+        with util.disable_log_to_console():
+            bound_macaroon_bytes = sso.discharge_root_macaroon(contract_client)
         if bound_macaroon_bytes is None:
             print('Could not attach machine. Unable to obtain authenticated'
                   ' user token')

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -388,6 +388,8 @@ def main_error_handler(func):
             print('Interrupt received; exiting.', file=sys.stderr)
             sys.exit(1)
         except exceptions.UserFacingError as exc:
+            with util.disable_log_to_console():
+                logging.exception(exc.msg)
             print('ERROR: {}'.format(exc.msg), file=sys.stderr)
             sys.exit(1)
     return wrapper

--- a/uaclient/conftest.py
+++ b/uaclient/conftest.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import mock
 
 import pytest
 
@@ -48,3 +49,16 @@ def caplog_text(request):
 
         request.addfinalizer(lambda: root.removeHandler(handler))
     return _func
+
+
+@pytest.yield_fixture
+def logging_sandbox():
+    # Monkeypatch a replacement root logger, so that our changes to logging
+    # configuration don't persist outside of the test
+    root_logger = logging.RootLogger(logging.WARNING)
+
+    with mock.patch.object(logging, 'root', root_logger):
+        with mock.patch.object(logging.Logger, 'root', root_logger):
+            with mock.patch.object(logging.Logger, 'manager',
+                                   logging.Manager(root_logger)):
+                yield

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -2,6 +2,7 @@ import base64
 import getpass
 import json
 import logging
+
 import pymacaroons
 
 from uaclient import serviceclient

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -131,7 +131,7 @@ def extract_macaroon_caveat_id(macaroon):
             (c.location, c.caveat_id)
             for c in root_macaroon.third_party_caveats())
     except Exception as e:
-        raise InvalidRootMacaroonError("Invalid root macaroon. %s" % e)
+        raise InvalidRootMacaroonError(str(e))
     if 'login.ubuntu.com' in caveat_id_by_location:
         return caveat_id_by_location['login.ubuntu.com']
     raise NoThirdPartySSOCaveatFoundError(

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -203,7 +203,7 @@ def discharge_root_macaroon(contract_client):
         raise exceptions.UserFacingError(
             'Could not reach URL {} to authenticate'.format(e.url))
     except (MacaroonFormatError) as e:
-        logging.error("Invalid root macaroon: %s", str(e))
+        raise exceptions.UserFacingError('Invalid root macaroon: {}'.format(e))
 
     if not discharge_macaroon:
         return None

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -5,6 +5,7 @@ import logging
 
 import pymacaroons
 
+from uaclient import exceptions
 from uaclient import serviceclient
 from uaclient import util
 
@@ -199,8 +200,8 @@ def discharge_root_macaroon(contract_client):
         caveat_id = extract_macaroon_caveat_id(root_macaroon['macaroon'])
         discharge_macaroon = prompt_request_macaroon(cfg, caveat_id)
     except (util.UrlError) as e:
-        logging.error("Could not reach url '%s' to authenticate.", e.url)
-        return None
+        raise exceptions.UserFacingError(
+            'Could not reach URL {} to authenticate'.format(e.url))
     except (MacaroonFormatError) as e:
         logging.error("Invalid root macaroon: %s", str(e))
 

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -1,3 +1,4 @@
+import logging
 import mock
 
 import pytest
@@ -67,10 +68,12 @@ class TestMain:
         assert '' == out
         assert 'Interrupt received; exiting.\n' == err
 
+    @pytest.mark.parametrize('caplog_text', [logging.ERROR], indirect=True)
     @mock.patch('uaclient.cli.setup_logging')
     @mock.patch('uaclient.cli.get_parser')
     def test_user_facing_error_handled_gracefully(
-            self, m_get_parser, _m_setup_logging, capsys):
+            self, m_get_parser, _m_setup_logging, capsys, logging_sandbox,
+            caplog_text):
         msg = 'You need to know about this.'
 
         m_args = m_get_parser.return_value.parse_args.return_value
@@ -85,3 +88,6 @@ class TestMain:
         out, err = capsys.readouterr()
         assert '' == out
         assert 'ERROR: {}\n'.format(msg) == err
+        error_log = caplog_text()
+        assert msg in error_log
+        assert "Traceback (most recent call last):" in error_log

--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -1,0 +1,20 @@
+import mock
+
+import pytest
+
+from uaclient import exceptions, sso, util
+
+
+class TestDischargeRootMacaroon:
+
+    def test_urlerror_converted_to_userfacing_error(self):
+        m_contract_client = mock.Mock()
+        url = 'https://some_url'
+        m_contract_client.request_root_macaroon.side_effect = util.UrlError(
+            mock.Mock(), url=url)
+
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            sso.discharge_root_macaroon(m_contract_client)
+
+        expected_msg = "Could not reach URL {} to authenticate".format(url)
+        assert expected_msg == excinfo.value.msg

--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -19,6 +19,18 @@ class TestDischargeRootMacaroon:
         expected_msg = "Could not reach URL {} to authenticate".format(url)
         assert expected_msg == excinfo.value.msg
 
+    @mock.patch('uaclient.sso.extract_macaroon_caveat_id')
+    def test_macaroon_format_error_converted_to_userfacing_error(self, m_emci):
+        m_contract_client = mock.MagicMock()
+        exception_msg = 'our exception msg'
+        m_emci.side_effect = sso.MacaroonFormatError(exception_msg)
+
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            sso.discharge_root_macaroon(m_contract_client)
+
+        expected_msg = "Invalid root macaroon: {}".format(exception_msg)
+        assert expected_msg == excinfo.value.msg
+
 
 class TestExtractMacaroonCaveatId:
 

--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -31,6 +31,18 @@ class TestDischargeRootMacaroon:
         expected_msg = "Invalid root macaroon: {}".format(exception_msg)
         assert expected_msg == excinfo.value.msg
 
+    @mock.patch('uaclient.sso.prompt_request_macaroon')
+    @mock.patch('uaclient.sso.extract_macaroon_caveat_id')
+    def test_userfacingerror_untouched(self, m_emci, m_prompt):
+        m_contract_client = mock.MagicMock()
+        exception_msg = 'our exception msg'
+        m_prompt.side_effect = exceptions.UserFacingError(exception_msg)
+
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            sso.discharge_root_macaroon(m_contract_client)
+
+        assert exception_msg == excinfo.value.msg
+
 
 class TestExtractMacaroonCaveatId:
 

--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -18,3 +18,15 @@ class TestDischargeRootMacaroon:
 
         expected_msg = "Could not reach URL {} to authenticate".format(url)
         assert expected_msg == excinfo.value.msg
+
+
+class TestExtractMacaroonCaveatId:
+
+    @mock.patch('uaclient.sso.pymacaroons.Macaroon.deserialize')
+    def test_invalidrootmacaroonerror_message(self, m_deserialize):
+        exception_msg = 'our exception msg'
+        m_deserialize.side_effect = sso.InvalidRootMacaroonError(exception_msg)
+        with pytest.raises(sso.InvalidRootMacaroonError) as excinfo:
+            sso.extract_macaroon_caveat_id('')
+
+        assert exception_msg == str(excinfo.value)


### PR DESCRIPTION
This is the first PR towards addressing #504. It puts the framework in place for the new error reporting, and addresses the errors that are handled in `discharge_root_macaroon`.

(The following PR(s) will update the exceptions produced by the interaction with SSO itself, to directly address #504.)