### PR TITLE
travis: use Python 3.7 for mypy runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ matrix:
       env: TOXENV=py3,flake8
     - python: 3.8-dev
       env: TOXENV=py3,flake8
-    - python: 3.8-dev
+    - python: 3.7
       env: TOXENV=mypy
   allow_failures:
     - python: 3.8-dev
       env: TOXENV=py3,flake8
-    - python: 3.8-dev
+    - python: 3.7
       env: TOXENV=mypy


### PR DESCRIPTION
mypy currently fails to install on Python 3.8 (due to it relying on a
version of typed-ast that doesn't yet include this fix:
https://github.com/python/typed_ast/pull/119).  There's no reason to be
running it on 3.8, so just run it on 3.7 instead.