### PR TITLE
uaclient: introduce ApplicationStatus.PENDING

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -105,7 +105,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 print(status.MESSAGE_UNENTITLED_TMPL.format(title=self.title))
             return False
         application_status, _ = self.application_status()
-        if application_status == status.ApplicationStatus.ENABLED:
+        if application_status != status.ApplicationStatus.DISABLED:
             if not silent:
                 print(status.MESSAGE_ALREADY_ENABLED_TMPL.format(
                     title=self.title))
@@ -292,6 +292,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         user_facing_status = {
             status.ApplicationStatus.ENABLED: UserFacingStatus.ACTIVE,
             status.ApplicationStatus.DISABLED: UserFacingStatus.INACTIVE,
+            status.ApplicationStatus.PENDING: UserFacingStatus.PENDING,
         }[application_status]
         return user_facing_status, explanation
 

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -91,7 +91,7 @@ class LivepatchEntitlement(base.UAEntitlement):
                     ' %s credentials', self.title)
                 livepatch_token = self.cfg.machine_token['machineToken']
             application_status, _details = self.application_status()
-            if application_status == status.ApplicationStatus.ENABLED:
+            if application_status != status.ApplicationStatus.DISABLED:
                 logging.info('Disabling %s prior to re-attach with new token',
                              self.title)
                 try:
@@ -162,7 +162,7 @@ class LivepatchEntitlement(base.UAEntitlement):
         if super().process_contract_deltas(orig_access, deltas, allow_enable):
             return True  # Already processed parent class deltas
         application_status, _ = self.application_status()
-        if application_status != status.ApplicationStatus.ENABLED:
+        if application_status == status.ApplicationStatus.DISABLED:
             return True  # only operate on changed directives when ACTIVE
         delta_entitlement = deltas.get('entitlement', {})
         delta_directives = delta_entitlement.get('directives', {})

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -143,7 +143,7 @@ class RepoEntitlement(base.UAEntitlement):
             return True  # Already processed parent class deltas
 
         application_status, _ = self.application_status()
-        if application_status != status.ApplicationStatus.ENABLED:
+        if application_status == status.ApplicationStatus.DISABLED:
             return True
         logging.info(
             "Updating '%s' apt sources list on changed directives." %

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -137,12 +137,14 @@ class TestUaEntitlement:
         assert expected_stdout == stdout
 
     @pytest.mark.parametrize('silent', (True, False, None))
+    @pytest.mark.parametrize('application_status', (
+        status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING))
     def test_can_enable_false_on_entitlement_active(
-            self, capsys, concrete_entitlement_factory, silent):
-        """When entitlement is ENABLED, can_enable returns False."""
+            self, capsys, concrete_entitlement_factory, silent,
+            application_status):
+        """When entitlement is ENABLED or PENDING, can_enable returns False."""
         entitlement = concrete_entitlement_factory(
-            entitled=True,
-            application_status=(status.ApplicationStatus.ENABLED, ''))
+            entitled=True, application_status=(application_status, ''))
 
         kwargs = {}
         if silent is not None:
@@ -327,6 +329,7 @@ class TestUaEntitlementUserFacingStatus:
     @pytest.mark.parametrize('application_status,expected_uf_status', (
         (status.ApplicationStatus.ENABLED, status.UserFacingStatus.ACTIVE),
         (status.ApplicationStatus.DISABLED, status.UserFacingStatus.INACTIVE),
+        (status.ApplicationStatus.PENDING, status.UserFacingStatus.PENDING),
     ))
     def test_application_status_used_if_not_inapplicable(
             self, concrete_entitlement_factory, application_status,

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -15,6 +15,7 @@ class ApplicationStatus(enum.Enum):
     """
     ENABLED = object()
     DISABLED = object()
+    PENDING = object()
 
 
 @enum.unique
@@ -49,6 +50,7 @@ class UserFacingStatus(enum.Enum):
     ACTIVE = 'active'
     INACTIVE = 'inactive'
     INAPPLICABLE = 'n/a'
+    PENDING = 'pending'
 
 
 ESSENTIAL = 'essential'
@@ -59,6 +61,8 @@ ADVANCED = 'advanced'
 STATUS_COLOR = {
     UserFacingStatus.ACTIVE.value: (
         TxtColor.OKGREEN + UserFacingStatus.ACTIVE.value + TxtColor.ENDC),
+    UserFacingStatus.PENDING.value: (
+        TxtColor.DISABLEGREY + UserFacingStatus.PENDING.value + TxtColor.ENDC),
     UserFacingStatus.INACTIVE.value: (
         TxtColor.FAIL + UserFacingStatus.INACTIVE.value + TxtColor.ENDC),
     UserFacingStatus.INAPPLICABLE.value: (


### PR DESCRIPTION
This is a third ApplicationStatus that represents "enabled but not yet
fully operational".  This commit updates the code paths that deal with
ApplicationStatus to treat ApplicationStatus.PENDING as equivalent to
ApplicationStatus.ENABLED; we don't yet have any code paths that diverge
based on it.

(The first examples of this will be FIPS/FIPS Updates; they aren't fully
enabled until you have rebooted into the linux-fips kernel.)