### PR TITLE
uaclient-devel.conf: use /var/tmp for data_dir

### DIFF
--- a/uaclient-devel.conf
+++ b/uaclient-devel.conf
@@ -1,6 +1,6 @@
 # Development UA Client config file. YAML
 sso_auth_url: 'https://login.ubuntu.com'
 contract_url: 'https://contracts.staging.canonical.com'
-data_dir: /tmp/uaclient
+data_dir: /var/tmp/uaclient
 log_level: debug
 log_file: ubuntu-advantage-devel.log


### PR DESCRIPTION
/tmp doesn't persist over reboots, by design, so use /var/tmp which
does.