### PR TITLE
cli: log traceback when KeyboardInterrupt is handled

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -387,6 +387,8 @@ def main_error_handler(func):
         try:
             return func(*args, **kwargs)
         except KeyboardInterrupt:
+            with util.disable_log_to_console():
+                logging.exception('KeyboardInterrupt')
             print('Interrupt received; exiting.', file=sys.stderr)
             sys.exit(1)
         except exceptions.UserFacingError as exc:

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -54,7 +54,8 @@ class TestMain:
     @mock.patch('uaclient.cli.setup_logging')
     @mock.patch('uaclient.cli.get_parser')
     def test_keyboard_interrupt_handled_gracefully(
-            self, m_get_parser, _m_setup_logging, capsys):
+            self, m_get_parser, _m_setup_logging, capsys, logging_sandbox,
+            caplog_text):
         m_args = m_get_parser.return_value.parse_args.return_value
         m_args.action.side_effect = KeyboardInterrupt
 
@@ -67,6 +68,8 @@ class TestMain:
         out, err = capsys.readouterr()
         assert '' == out
         assert 'Interrupt received; exiting.\n' == err
+        error_log = caplog_text()
+        assert "Traceback (most recent call last):" in error_log
 
     @pytest.mark.parametrize('caplog_text', [logging.ERROR], indirect=True)
     @mock.patch('uaclient.cli.setup_logging')


### PR DESCRIPTION
This information makes it much easier to determine what is happening
when the client is apparently stuck, because you can just Ctrl-C to get
a good idea of what's going on.