### PR TITLE
enable: exit non-zero on contract refresh failure

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -213,7 +213,8 @@ def action_enable(args, cfg):
     """
     logging.debug(ua_status.MESSAGE_REFRESH_ENABLE)
     if not contract.request_updated_contract(cfg):
-        logging.debug(ua_status.MESSAGE_REFRESH_FAILURE)
+        logging.error(ua_status.MESSAGE_REFRESH_FAILURE)
+        return 1
     return 0 if _perform_enable(args.name, cfg) else 1
 
 

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -1,8 +1,13 @@
 import mock
 
+from uaclient.testing.fakes import FakeConfig
+
+import logging
 import pytest
 
-from uaclient.cli import _perform_enable
+from uaclient.cli import _perform_enable, action_enable
+
+M_PATH = 'uaclient.cli.'
 
 
 class TestPerformEnable:
@@ -45,3 +50,42 @@ class TestPerformEnable:
         assert ret == m_entitlement.enable.return_value
 
         assert 1 == m_cfg.status.call_count
+
+
+class TestActionEnable:
+
+    @pytest.mark.parametrize('caplog_text', [logging.DEBUG], indirect=True)
+    @mock.patch(M_PATH + '_perform_enable')
+    @mock.patch(M_PATH + 'contract.request_updated_contract')
+    @mock.patch(M_PATH + 'os.getuid', return_value=0)
+    def test_exits_nonzero_on_failed_contract_refresh(
+            self, _, m_request_updated_contract, m_perform_enable,
+            caplog_text):
+        m_request_updated_contract.return_value = False  # failure to refresh
+        account_name = 'test_account'
+        cfg = FakeConfig.for_attached_machine(account_name=account_name)
+        args = mock.MagicMock(name='livepatch')
+        ret = action_enable(args, cfg)
+        assert ret == 1
+        expected_messages = [
+            'DEBUG    Refreshing contracts prior to enable',
+            'ERROR    Failure to refresh Ubuntu Advantage contracts.']
+        for msg in expected_messages:
+            assert msg in caplog_text()
+        assert 0 == m_perform_enable.call_count
+
+    @pytest.mark.parametrize('perform_enable_return', (True, False))
+    @mock.patch(M_PATH + '_perform_enable')
+    @mock.patch(M_PATH + 'contract.request_updated_contract')
+    @mock.patch(M_PATH + 'os.getuid', return_value=0)
+    def test_exit_code_based_on_success_of_perform_enable(
+            self, _, m_request_updated_contract, m_perform_enable,
+            perform_enable_return):
+        m_perform_enable.return_value = perform_enable_return
+        m_request_updated_contract.return_value = True  # successful refresh
+        account_name = 'test_account'
+        cfg = FakeConfig.for_attached_machine(account_name=account_name)
+        args = mock.MagicMock(name='livepatch')
+        ret = action_enable(args, cfg)
+        exit_code = 0 if perform_enable_return else 1
+        assert ret == exit_code


### PR DESCRIPTION
We don't want to attempt enabling if we get a failure that contracts
service is unavailable for a couple reasons:
 - stale contract information from ua-contracts service which could have
disabled our services
 - network is down for the whole system which would result in failure to
   enable both the repo-based or livepatch services

Fixes: #492