### PR TITLE
postrm: remove the ESM pinning file on purge

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -23,6 +23,7 @@ remove_esm(){
     rm -f /etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg
     rm -f /etc/apt/sources.list.d/ubuntu-esm-trusty.list
     rm -f /etc/apt/apt.conf.d/51ubuntu-advantage-esm
+    rm -f /etc/apt/preferences.d/ubuntu-esm-trusty
 }
 
 case "$1" in


### PR DESCRIPTION
If purging the package, also remove the pinning file that was created in postinst.

Fixes #584 