### PR TITLE
attach: two-factor auth reprompt only two-factor auth on failed 2fa

### DIFF
--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -85,6 +85,25 @@ class SimpleSSOAuthError(sso.SSOAuthError):
         return self.exception_string
 
 
+class TestSSOAuthError:
+
+    @pytest.mark.parametrize(
+        'error_key,value',
+        (('some-other-error-code', None),
+         (sso.API_ERROR_2FA_REQUIRED, '2FA required'),
+         (sso.API_ERROR_INVALID_CREDENTIALS, 'Invalid pwd')))
+    def test_api_errors_as_dict_keyed_on_error_code(self, error_key, value):
+        api_errors = [{'code': sso.API_ERROR_2FA_REQUIRED,
+                       'message': '2FA required'},
+                      {'code': sso.API_ERROR_INVALID_CREDENTIALS,
+                       'message': 'Invalid pwd'}]
+        exception = SimpleSSOAuthError("Invalid 2fa", api_errors=api_errors)
+        if value is None:
+            assert value is exception[error_key]
+        else:
+            assert value == exception[error_key]
+
+
 class TestPromptRequestMacaroon:
 
     @mock.patch('uaclient.sso.getpass')
@@ -108,7 +127,7 @@ class TestPromptRequestMacaroon:
     @mock.patch('uaclient.sso.getpass')
     @mock.patch('builtins.input')
     @mock.patch('uaclient.sso.UbuntuSSOClient')
-    def test_2fa_errors_dont_raise_and_request_extra_input(
+    def test_2fa_required_prompts_for_second_factor_auth_input(
             self, m_sso_client, m_input, _m_getpass):
         exception = SimpleSSOAuthError(
             api_errors=[{'code': sso.API_ERROR_2FA_REQUIRED}])
@@ -121,6 +140,60 @@ class TestPromptRequestMacaroon:
         sso.prompt_request_macaroon(config_mock, 'caveat_id')
 
         assert mock.call('Second-factor auth: ') in m_input.call_args_list
+
+    @mock.patch('uaclient.sso.getpass')
+    @mock.patch('builtins.input')
+    @mock.patch('uaclient.sso.UbuntuSSOClient')
+    def test_2fa_credential_errors_only_reprompt_once_for_second_factor_auth(
+            self, m_sso_client, m_input, _m_getpass):
+        exception = SimpleSSOAuthError(
+            api_errors=[
+                {'code': sso.API_ERROR_INVALID_CREDENTIALS,
+                 'message': 'The provided 2-factor key is not recognised.'}])
+        m_sso_client.return_value.request_discharge_macaroon.side_effect = [
+            exception, exception]
+
+        config_mock = mock.Mock()
+        config_mock.read_cache.return_value = None
+
+        # First re-prompt is okay, second fails
+        with pytest.raises(exceptions.UserFacingError):
+            sso.prompt_request_macaroon(config_mock, 'caveat_id')
+        expected_calls = [
+            mock.call('Email: '),
+            mock.call('Re-enter second-factor auth: ')]
+        assert expected_calls == m_input.call_args_list
+
+    @pytest.mark.parametrize(
+        'error_message,reprompt',
+        (('The provided 2-factor key is not recognised.', True),
+         ('Invalid email or password', False)))
+    @mock.patch('uaclient.sso.getpass')
+    @mock.patch('builtins.input')
+    @mock.patch('uaclient.sso.UbuntuSSOClient')
+    def test_2fa_credential_errors_reprompt_for_second_factor_auth_input(
+            self, m_sso_client, m_input, _m_getpass, error_message, reprompt):
+        exception = SimpleSSOAuthError(
+            api_errors=[
+                {'code': sso.API_ERROR_INVALID_CREDENTIALS,
+                 'message': error_message}])
+        m_sso_client.return_value.request_discharge_macaroon.side_effect = [
+            exception, "some content"]
+
+        config_mock = mock.Mock()
+        config_mock.read_cache.return_value = None
+
+        if reprompt:
+            sso.prompt_request_macaroon(config_mock, 'caveat_id')
+            expected_calls = [
+                mock.call('Email: '),
+                mock.call('Re-enter second-factor auth: ')]
+        else:
+            with pytest.raises(exceptions.UserFacingError):
+                sso.prompt_request_macaroon(config_mock, 'caveat_id')
+            expected_calls = [mock.call('Email: ')]
+
+        assert expected_calls == m_input.call_args_list
 
     @mock.patch('uaclient.sso.getpass')
     @mock.patch('builtins.input')


### PR DESCRIPTION
Sometimes the 2fa token expires before typing it, or the user mistypes
the 2fa. No longer exit non-zero, forcing the person to re-enter login
and password. Just re-prompt for two factor authentication.

Fixes: #561