### PR TITLE
base: don't message about disabling already-disabled entitlements

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -239,10 +239,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                     delta_entitlement['entitled'] in (False, util.DROPPED_KEY))
         if transition_to_unentitled:
             if self.can_disable(silent=True):
+                self.disable()
                 logging.info(
                     "Due to contract refresh, '%s' is now disabled.",
                     self.name)
-                self.disable()
             else:
                 logging.warning(
                     "Unable to disable '%s' as recommended during contract"

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -238,16 +238,18 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 transition_to_unentitled = (
                     delta_entitlement['entitled'] in (False, util.DROPPED_KEY))
         if transition_to_unentitled:
-            if self.can_disable(silent=True):
-                self.disable()
-                logging.info(
-                    "Due to contract refresh, '%s' is now disabled.",
-                    self.name)
-            else:
-                logging.warning(
-                    "Unable to disable '%s' as recommended during contract"
-                    " refresh. Service is still active. See `ua status`" %
-                    self.name)
+            application_status, _ = self.application_status()
+            if application_status != status.ApplicationStatus.DISABLED:
+                if self.can_disable(silent=True):
+                    self.disable()
+                    logging.info(
+                        "Due to contract refresh, '%s' is now disabled.",
+                        self.name)
+                else:
+                    logging.warning(
+                        "Unable to disable '%s' as recommended during contract"
+                        " refresh. Service is still active. See `ua status`" %
+                        self.name)
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -255,7 +255,8 @@ class TestUaEntitlement:
           {'entitlement': {'entitled': False}})  # transition to unentitled
          ))
     def test_process_contract_deltas_clean_cache_on_inactive_unentitled(
-            self, concrete_entitlement_factory, orig_access, delta):
+            self, concrete_entitlement_factory, orig_access, delta,
+            caplog_text):
         """Only clear cache when deltas transition inactive to unentitled."""
         entitlement = concrete_entitlement_factory(
             entitled=True,
@@ -267,6 +268,12 @@ class TestUaEntitlement:
         # Cache was cleaned
         assert None is entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
+        # If an entitlement is disabled, we don't need to tell the user
+        # anything about it becoming unentitled
+        # (FIXME: Something on bionic means that DEBUG log lines are being
+        # picked up by caplog_text(), so work around that here)
+        assert [] == [line for line in caplog_text().splitlines()
+                      if 'DEBUG' not in line]
 
     @pytest.mark.parametrize(
         'orig_access,delta',

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -1,4 +1,5 @@
 """Tests related to uaclient.entitlement.base module."""
+import mock
 
 import pytest
 
@@ -29,6 +30,8 @@ class ConcreteTestEntitlement(base.UAEntitlement):
         self._application_status = application_status
 
     def disable(self):
+        self._application_status = (
+            status.ApplicationStatus.DISABLED, 'disable() called')
         return self._disable
 
     def enable(self, silent_if_inapplicable: bool = False):
@@ -285,6 +288,8 @@ class TestUaEntitlement:
         # Cache was cleaned
         assert None is entitlement.cfg.read_cache(
             'machine-access-testconcreteentitlement')
+        assert (status.ApplicationStatus.DISABLED,
+                mock.ANY) == entitlement.application_status()
 
 
 class TestUaEntitlementUserFacingStatus:


### PR DESCRIPTION
This is inaccurate and confusing.

Fixes #599