### PR TITLE
repo: un-comment ESM sources.list lines on repo disable

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -172,6 +172,13 @@ def remove_auth_apt_repo(repo_filename: str, repo_url: str,
     remove_repo_from_apt_auth_file(repo_url)
 
 
+def restore_commented_apt_list_file(filename: str) -> None:
+    """Uncomment commented deb lines in the given file."""
+    file_content = util.load_file(filename)
+    file_content = file_content.replace('# deb ', 'deb ')
+    util.write_file(filename, file_content)
+
+
 def add_ppa_pinning(apt_preference_file, repo_url, origin, priority):
     """Add an apt preferences file and pin for a PPA."""
     series = util.get_platform_info()['series']

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -254,6 +254,7 @@ class RepoEntitlement(base.UAEntitlement):
             # is a special-case: we want to be able to report on the
             # available ESM updates even when it's disabled
             apt.remove_repo_from_apt_auth_file(repo_url)
+            apt.restore_commented_apt_list_file(repo_filename)
         else:
             apt.remove_auth_apt_repo(repo_filename, repo_url, keyring_file)
             apt.remove_apt_list_files(repo_url, series)

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -136,12 +136,14 @@ class TestESMEntitlementDisable:
         assert [mock.call(silent, force)] == m_can_disable.call_args_list
         assert 0 == m_remove_apt.call_count
 
+    @mock.patch('uaclient.apt.restore_commented_apt_list_file')
     @mock.patch('uaclient.apt.remove_repo_from_apt_auth_file')
     @mock.patch('uaclient.util.get_platform_info',
                 return_value={'series': 'trusty'})
     @mock.patch(M_PATH + 'can_disable', return_value=True)
     def test_disable_removes_apt_config(
             self, m_can_disable, m_platform_info, m_rm_repo_from_auth,
+            m_restore_commented_apt_list_file,
             entitlement, tmpdir, caplog_text):
         """When can_disable, disable removes apt configuration when forced."""
 
@@ -158,3 +160,5 @@ class TestESMEntitlementDisable:
         assert [mock.call(True, True)] == m_can_disable.call_args_list
         auth_call = mock.call('http://ESM')
         assert [auth_call] == m_rm_repo_from_auth.call_args_list
+        assert [mock.call('/etc/apt/sources.list.d/ubuntu-esm-trusty.list')
+                ] == m_restore_commented_apt_list_file.call_args_list


### PR DESCRIPTION
ESM has a sources.list.d file whether or not it is enabled, so that
users get reporting on what would be available if they enabled ESM.
When we enable ESM, we comment out the -updates line in that file if
-updates isn't enabled on the system.  This commit ensures that we
un-comment that line on disable.

Fixes #396