### PR TITLE
refresh-keyrings.sh: refuse to run anywhere but trusty

### DIFF
--- a/tools/refresh-keyrings.sh
+++ b/tools/refresh-keyrings.sh
@@ -25,6 +25,11 @@ generate_keyring() {
         --recv-keys $KEYS
 }
 
+if [ $(lsb_release -sc) != "trusty" ]; then
+    echo "ERROR: must run on trusty to ensure compatibility"
+    exit 1
+fi
+
 TARGET_DIR="$1"
 
 KEYRING_ESM="ubuntu-esm-v2-keyring.gpg"


### PR DESCRIPTION
We need to ensure that the keyrings we produce are compatible with trusty; the best way to do this is to generate them on trusty.  (This will help avoid recurrence of #602.)