### PR TITLE
Remove the force parameter from .disable()

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -68,23 +68,20 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         """
         pass
 
-    def can_disable(self, silent: bool = False, force: bool = False) -> bool:
+    def can_disable(self, silent: bool = False) -> bool:
         """Report whether or not disabling is possible for the entitlement.
 
         @param silent: Boolean set True to silence printed messages/warnings.
-        @param force: Boolean set True to allow disable even if entitlement
-            doesn't appear 'enabled'.
         """
         message = ''
         retval = True
         application_status, _ = self.application_status()
 
-        if not force:
-            if application_status == status.ApplicationStatus.DISABLED:
-                message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
-                    title=self.title
-                )
-                retval = False
+        if application_status == status.ApplicationStatus.DISABLED:
+            message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
+                title=self.title
+            )
+            retval = False
         if message and not silent:
             print(message)
         return retval

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -73,18 +73,14 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         @param silent: Boolean set True to silence printed messages/warnings.
         """
-        message = ''
-        retval = True
         application_status, _ = self.application_status()
 
         if application_status == status.ApplicationStatus.DISABLED:
-            message = status.MESSAGE_ALREADY_DISABLED_TMPL.format(
-                title=self.title
-            )
-            retval = False
-        if message and not silent:
-            print(message)
-        return retval
+            if not silent:
+                print(status.MESSAGE_ALREADY_DISABLED_TMPL.format(
+                    title=self.title))
+            return False
+        return True
 
     def can_enable(self, silent: bool = False) -> bool:
         """

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -181,12 +181,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         return ApplicabilityStatus.APPLICABLE, ''
 
     @abc.abstractmethod
-    def disable(self, silent: bool = False, force: bool = False) -> bool:
+    def disable(self, silent: bool = False) -> bool:
         """Disable specific entitlement
 
         @param silent: Boolean set True to silence print/log of messages
-        @param force: Boolean set True to perform disable logic even if
-            entitlement doesn't appear fully configured.
 
         @return: True on success, False otherwise.
         """

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -25,12 +25,12 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
         'post_enable': [
             'Please follow instructions in %s to configure EAL2' % CC_README]}
 
-    def disable(self, silent=False, force=False):
+    def disable(self, silent=False):
         """Disable specific entitlement
 
         @return: True on success, False otherwise.
         """
-        if not self.can_disable(silent, force):
+        if not self.can_disable(silent):
             return False
         series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -16,12 +16,12 @@ class CISEntitlement(repo.RepoEntitlement):
     repo_key_file = 'ubuntu-securitybenchmarks-keyring.gpg'
     packages = ['ubuntu-cisbenchmark-16.04']
 
-    def disable(self, silent=False, force=False):
+    def disable(self, silent=False):
         """Disable specific entitlement
 
         @return: True on success, False otherwise.
         """
-        if not self.can_disable(silent, force):
+        if not self.can_disable(silent):
             return False
         series = util.get_platform_info()['series']
         repo_filename = self.repo_list_file_tmpl.format(

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -46,6 +46,10 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             print('Warning: no option to disable {}'.format(self.title))
         return False
 
+    def _cleanup(self) -> None:
+        """FIPS can't be cleaned up automatically, so don't do anything"""
+        pass
+
 
 class FIPSEntitlement(FIPSCommonEntitlement):
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -41,6 +41,12 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         return (
             status.ApplicationStatus.PENDING, 'Reboot to FIPS kernel required')
 
+    def disable(self, silent: bool = False, force: bool = False) -> bool:
+        """FIPS cannot be disabled, so simply display a message to the user"""
+        if not silent:
+            print('Warning: no option to disable {}'.format(self.title))
+        return False
+
 
 class FIPSEntitlement(FIPSCommonEntitlement):
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -19,7 +19,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         'openssl': set(),
         'strongswan': {'strongswan-hmac'},
     }  # type: Dict[str, Set[str]]
-    force_disable = True
 
     @property
     def packages(self) -> 'List[str]':

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -40,7 +40,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         return (
             status.ApplicationStatus.PENDING, 'Reboot to FIPS kernel required')
 
-    def disable(self, silent: bool = False, force: bool = False) -> bool:
+    def disable(self, silent: bool = False) -> bool:
         """FIPS cannot be disabled, so simply display a message to the user"""
         if not silent:
             print('Warning: no option to disable {}'.format(self.title))

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -116,12 +116,12 @@ class LivepatchEntitlement(base.UAEntitlement):
             print('Canonical livepatch enabled.')
         return True
 
-    def disable(self, silent=False, force=False):
+    def disable(self, silent=False):
         """Disable specific entitlement
 
         @return: True on success, False otherwise.
         """
-        if not self.can_disable(silent, force):
+        if not self.can_disable(silent):
             return False
         if not util.which('/snap/bin/canonical-livepatch'):
             return True

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -79,7 +79,7 @@ class RepoEntitlement(base.UAEntitlement):
                     ['apt-get', 'install', '--assume-yes'] + self.packages,
                     capture=True, retry_sleeps=APT_RETRIES)
             except util.ProcessExecutionError:
-                self.disable(silent=True, force=True)
+                self._cleanup()
                 logging.error(
                     status.MESSAGE_ENABLED_FAILED_TMPL.format(
                         title=self.title))

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -92,15 +92,19 @@ class RepoEntitlement(base.UAEntitlement):
     def disable(self, silent=False, force=False):
         if not self.can_disable(silent, force):
             return False
+        self._cleanup()
+        if not silent:
+            print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
+        return True
+
+    def _cleanup(self) -> None:
+        """Clean up the entitlement without checks or messaging"""
         self.remove_apt_config()
         try:
             util.subp(
                 ['apt-get', 'remove', '--assume-yes'] + self.packages)
         except util.ProcessExecutionError:
             pass
-        if not silent:
-            print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
-        return True
 
     def application_status(self) -> 'Tuple[ApplicationStatus, str]':
         entitlement_cfg = self.cfg.entitlements.get(self.name, {})

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -89,8 +89,8 @@ class RepoEntitlement(base.UAEntitlement):
             print(msg)
         return True
 
-    def disable(self, silent=False, force=False):
-        if not self.can_disable(silent, force):
+    def disable(self, silent=False):
+        if not self.can_disable(silent):
             return False
         self._cleanup()
         if not silent:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -34,9 +34,6 @@ class RepoEntitlement(base.UAEntitlement):
     # Optional repo pin priority in subclass
     repo_pin_priority = None  # type: Union[int, str, None]
 
-    # force_disable True if entitlement does not allow disable (fips*)
-    force_disable = False
-
     # disable_apt_auth_only (ESM) to only remove apt auth files on disable
     disable_apt_auth_only = False  # Set True on ESM to only remove apt auth
 
@@ -95,19 +92,12 @@ class RepoEntitlement(base.UAEntitlement):
     def disable(self, silent=False, force=False):
         if not self.can_disable(silent, force):
             return False
-        if any([not self.force_disable, force]):
-            self.remove_apt_config()
-            try:
-                util.subp(
-                    ['apt-get', 'remove', '--assume-yes'] + self.packages)
-            except util.ProcessExecutionError:
-                pass
-        if self.force_disable:
-            if not silent:
-                print('Warning: no option to disable {title}'.format(
-                    title=self.title)
-                )
-            return False
+        self.remove_apt_config()
+        try:
+            util.subp(
+                ['apt-get', 'remove', '--assume-yes'] + self.packages)
+        except util.ProcessExecutionError:
+            pass
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -4,7 +4,6 @@ import contextlib
 import copy
 import itertools
 import mock
-import os
 
 import pytest
 
@@ -255,80 +254,17 @@ class TestFIPSEntitlementDisable:
     @pytest.mark.parametrize(
         'silent,force', itertools.product([False, True], repeat=2))
     @mock.patch('uaclient.util.get_platform_info')
-    def test_disable_returns_false_on_can_disable_false_and_does_nothing(
-            self, m_platform_info, entitlement, silent, force):
+    def test_disable_returns_false_and_does_nothing(
+            self, m_platform_info, entitlement, silent, force, capsys):
         """When can_disable is false disable returns false and noops."""
         with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
-            with mock.patch.object(entitlement, 'can_disable',
-                                   return_value=False) as m_can_disable:
-                assert False is entitlement.disable(silent, force)
-        assert [mock.call(silent, force)] == m_can_disable.call_args_list
+            assert False is entitlement.disable(silent, force)
         assert 0 == m_remove_apt.call_count
 
-    @mock.patch('uaclient.apt.remove_apt_list_files')
-    @mock.patch('uaclient.apt.remove_auth_apt_repo')
-    @mock.patch(
-        'uaclient.util.get_platform_info', return_value={'series': 'xenial'})
-    def test_disable_returns_false_and_removes_apt_config_on_force(
-            self, m_platform_info, m_rm_auth, m_rm_list,
-            entitlement, caplog_text):
-        """When can_disable, disable removes apt configuration when force."""
-
-        original_exists = os.path.exists
-        patched_packages = ['c', 'd']
-        preferences_path = '/etc/apt/preferences.d/ubuntu-{}-xenial'.format(
-            entitlement.name)
-
-        def fake_exists(path):
-            if path == preferences_path:
-                return True
-            return original_exists(path)
-
-        with contextlib.ExitStack() as stack:
-            m_can_disable = stack.enter_context(
-                mock.patch.object(
-                    entitlement, 'can_disable', return_value=True))
-            stack.enter_context(
-                mock.patch('os.path.exists', side_effect=fake_exists))
-            m_unlink = stack.enter_context(
-                mock.patch('uaclient.apt.os.unlink'))
-            m_subp = stack.enter_context(mock.patch('uaclient.util.subp'))
-            # Note that this patch uses a PropertyMock and happens on the
-            # entitlement's type because packages is a property
-            m_packages = mock.PropertyMock(return_value=patched_packages)
-            stack.enter_context(
-                mock.patch.object(type(entitlement), 'packages', m_packages))
-
-            assert False is entitlement.disable(True, True)
-        assert [mock.call(True, True)] == m_can_disable.call_args_list
-        calls = [mock.call(preferences_path)]
-        assert calls == m_unlink.call_args_list
-        auth_call = mock.call(
-            '/etc/apt/sources.list.d/ubuntu-{}-xenial.list'.format(
-                entitlement.name),
-            'http://FIPS',
-            '/etc/apt/trusted.gpg.d/ubuntu-{}-keyring.gpg'.format(
-                entitlement.name)
-        )
-        assert [auth_call] == m_rm_auth.call_args_list
-        assert [mock.call('http://FIPS', 'xenial')] == m_rm_list.call_args_list
-        apt_cmd = mock.call(
-            ['apt-get', 'remove', '--assume-yes'] + patched_packages)
-        assert [apt_cmd] == m_subp.call_args_list
-
-    @mock.patch('uaclient.util.get_platform_info')
-    def test_disable_returns_false_does_nothing_by_default(
-            self, m_platform_info, caplog_text, capsys, entitlement):
-        """When can_disable, disable does nothing without force param."""
-        with mock.patch.object(entitlement, 'can_disable',
-                               return_value=True) as m_can_disable:
-            with mock.patch('uaclient.apt.remove_auth_apt_repo'
-                            ) as m_remove_apt:
-                assert False is entitlement.disable()
-        assert [mock.call(False, False)] == m_can_disable.call_args_list
-        assert 0 == m_remove_apt.call_count
-        expected_stdout = 'Warning: no option to disable {}\n'.format(
-            entitlement.title)
+        expected_stdout = ''
+        if not silent:
+            expected_stdout = 'Warning: no option to disable {}\n'.format(
+                entitlement.title)
         assert (expected_stdout, '') == capsys.readouterr()
 
 

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -250,15 +250,13 @@ class TestFipsEntitlementPackages:
 
 class TestFIPSEntitlementDisable:
 
-    # Paramterize True/False for silent and force
-    @pytest.mark.parametrize(
-        'silent,force', itertools.product([False, True], repeat=2))
+    @pytest.mark.parametrize('silent', [False, True])
     @mock.patch('uaclient.util.get_platform_info')
     def test_disable_returns_false_and_does_nothing(
-            self, m_platform_info, entitlement, silent, force, capsys):
+            self, m_platform_info, entitlement, silent, capsys):
         """When can_disable is false disable returns false and noops."""
         with mock.patch('uaclient.apt.remove_auth_apt_repo') as m_remove_apt:
-            assert False is entitlement.disable(silent, force)
+            assert False is entitlement.disable(silent)
         assert 0 == m_remove_apt.call_count
 
         expected_stdout = ''

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -318,3 +318,31 @@ class TestRepoEnable:
             '/usr/share/keyrings/test.gpg')] == m_apt_add.call_args_list
         stdout, _ = capsys.readouterr()
         assert expected_output == stdout
+
+    @mock.patch(M_PATH + 'util.subp')
+    def test_failed_install_removes_apt_config_and_packages(
+            self, m_subp, entitlement):
+
+        def fake_subp(args, *other_args, **kwargs):
+            if 'install' in args:
+                raise util.ProcessExecutionError(args)
+
+        m_subp.side_effect = fake_subp
+
+        packages = ['fake_pkg', 'and_another']
+        with mock.patch.object(entitlement, 'setup_apt_config',
+                               return_value=True):
+            with mock.patch.object(entitlement, 'can_enable',
+                                   return_value=True):
+                with mock.patch.object(entitlement, 'can_disable',
+                                       return_value=True):
+                    with mock.patch.object(type(entitlement), 'packages',
+                                           packages):
+                        with mock.patch.object(
+                                entitlement, 'remove_apt_config') as m_rac:
+                            entitlement.enable()
+
+        expected_call = mock.call(
+            ['apt-get', 'remove', '--assume-yes'] + packages)
+        assert expected_call in m_subp.call_args_list
+        assert 1 == m_rac.call_count

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -334,13 +334,11 @@ class TestRepoEnable:
                                return_value=True):
             with mock.patch.object(entitlement, 'can_enable',
                                    return_value=True):
-                with mock.patch.object(entitlement, 'can_disable',
-                                       return_value=True):
-                    with mock.patch.object(type(entitlement), 'packages',
-                                           packages):
-                        with mock.patch.object(
-                                entitlement, 'remove_apt_config') as m_rac:
-                            entitlement.enable()
+                with mock.patch.object(type(entitlement), 'packages',
+                                       packages):
+                    with mock.patch.object(
+                            entitlement, 'remove_apt_config') as m_rac:
+                        entitlement.enable()
 
         expected_call = mock.call(
             ['apt-get', 'remove', '--assume-yes'] + packages)


### PR DESCRIPTION
The first commit fixes #434 by not performing any actions on disable of a FIPS entitlement (other than messaging).

This meant that the only place passing `force=True` to a `disable()` call was the exception handler for failed installs in `RepoEntitlement.enable()`. As this is happening _during_ enable, it can't logically be a "disable" because we aren't enabled yet. So to clean up the logic, I then refactored the cleanup code to a `_cleanup()` method which both the exception handler and `.disable()` call. (I stopped short of introducing `.cleanup()` on `UAEntitlement` because at the moment we only have one caller of it, in a sub-class.)

This then meant that nothing was calling `.disable()` with `force=True`, so we could remove it from the definition of `disable()`.

This, in turn, meant that nothing was calling `can_disable()` with `force=True`, so we could also remove it from there (and then simplify the implementation).

(This also fixes #371, because `False` is now the appropriate thing to return at all time.)