### PR TITLE
d/postinst: adjust logfile permissions

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -51,6 +51,11 @@ case "$1" in
           upgrade_to_status_cache
       fi
       grep -iq trusty /etc/os-release && configure_esm
+      if [ ! -f /var/log/ubuntu-advantage.log ]; then
+          touch /var/log/ubuntu-advantage.log
+      fi
+      chmod 0600 /var/log/ubuntu-advantage.log
+      chown root:root /var/log/ubuntu-advantage.log
       ;;
 esac
 


### PR DESCRIPTION
Create an empty log file if none found, and adjust its permissions and
ownership, also during upgrades.

Fixes issue #591 