### PR TITLE
Remove the old CACHE_DIR in postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -50,6 +50,10 @@ case "$1" in
       if dpkg --compare-versions "$2" lt-nl "19.5~"; then
           upgrade_to_status_cache
       fi
+
+      # CACHE_DIR is no longer present or used since 19.1
+      rm -rf /var/cache/ubuntu-advantage-tools
+
       grep -iq trusty /etc/os-release && configure_esm
       if [ ! -f /var/log/ubuntu-advantage.log ]; then
           touch /var/log/ubuntu-advantage.log

--- a/debian/preinst
+++ b/debian/preinst
@@ -20,16 +20,7 @@ case "$1" in
     install)
     ;;
     upgrade)
-        # CACHE_DIR is no longer present or used since 19.1
-        # dpkg will take care of removing CACHE_DIR, as long
-        # as it's empty
-        if dpkg --compare-versions "$2" lt-nl "19.1~"; then
-            if [ -f "$CACHE_DIR/$CACHE_FILE" ]; then
-                rm -f $CACHE_DIR/$CACHE_FILE || true
-            fi
-        fi
     ;;
-
     abort-upgrade)
     ;;
 


### PR DESCRIPTION
We can just rm -rf the directory, it's quicker and simpler.

`d/preinst` had only this content, and is no longer necessary.

I was trying to remember why I was so careful with `dpkg --compare-versions`, but couldn't come up with a reasonable explanation. Maybe because it was in `preinst`, or I wanted to avoid a useless `rm -rf` on every upgrade, but `dpkg --compare-versions` doesn't look cheaper. Feel free to point out flaws in this thinking.

Note that `d/preinst` is still needed because of `d/ubuntu-advantage-tools.maintscript`, which adds code to the `#DEBHELPER#` marker all over the place.

Fixes issue #352 