### PR TITLE
Be consistent when using Ubuntu release names

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -145,7 +145,7 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         if affordance_series and platform['series'] not in affordance_series:
             return (ApplicabilityStatus.INAPPLICABLE,
                     status.MESSAGE_INAPPLICABLE_SERIES_TMPL.format(
-                        title=self.title, series=platform['series']))
+                        title=self.title, series=platform['version']))
         kernel = platform['kernel']
         affordance_kernels = affordances.get('kernelFlavors', [])
         affordance_min_kernel = affordances.get('minKernelVersion')

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -46,27 +46,31 @@ CC_RESOURCE_ENTITLED = {
 PLATFORM_INFO_SUPPORTED = MappingProxyType({
     'arch': 's390x',
     'series': 'xenial',
-    'kernel': '4.15.0-00-generic'
+    'kernel': '4.15.0-00-generic',
+    'version': '16.04 LTS (Xenial Xerus)',
 })
 
 
 class TestCommonCriteriaEntitlementUserFacingStatus:
 
     @pytest.mark.parametrize(
-        'arch,series,details',
-        (('arm64', 'xenial', 'Canonical Common Criteria EAL2 Provisioning is'
-          ' not available for platform arm64.\nSupported platforms are:'
-          ' x86_64, ppc64le, s390x'),
-         ('s390x', 'trusty', 'Canonical Common Criteria EAL2 Provisioning'
-          ' is not available for Ubuntu trusty.')))
+        'arch,series,version,details',
+        (('arm64', 'xenial', '16.04 LTS (Xenial Xerus)', 'Canonical Common'
+          ' Criteria EAL2 Provisioning is not available for platform arm64.\n'
+          'Supported platforms are: x86_64, ppc64le, s390x'),
+         ('s390x', 'trusty', '14.04 LTS (Trusty Tahr)', 'Canonical Common'
+          ' Criteria EAL2 Provisioning is not available for Ubuntu 14.04 LTS'
+          ' (Trusty Tahr).')))
     @mock.patch('uaclient.entitlements.repo.os.getuid', return_value=0)
     @mock.patch('uaclient.util.get_platform_info')
     def test_inapplicable_on_invalid_affordances(
-            self, m_platform_info, m_getuid, arch, series, details, tmpdir):
+            self, m_platform_info, m_getuid, arch, series, version, details,
+            tmpdir):
         """Test invalid affordances result in inapplicable status."""
         unsupported_info = copy.deepcopy(dict(PLATFORM_INFO_SUPPORTED))
         unsupported_info['arch'] = arch
         unsupported_info['series'] = series
+        unsupported_info['version'] = version
         m_platform_info.return_value = unsupported_info
         cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
         cfg.write_cache('machine-token', CC_MACHINE_TOKEN)

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -46,7 +46,8 @@ LIVEPATCH_RESOURCE_ENTITLED = MappingProxyType({
 PLATFORM_INFO_SUPPORTED = MappingProxyType({
     'arch': 'x86_64',
     'kernel': '4.4.0-00-generic',
-    'series': 'xenial'
+    'series': 'xenial',
+    'version': '16.04 LTS (Xenial Xerus)',
 })
 
 M_PATH = 'uaclient.entitlements.livepatch.'  # mock path
@@ -94,7 +95,9 @@ class TestLivepatchUserFacingStatus:
             m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
             uf_status, details = entitlement.user_facing_status()
         assert uf_status == status.UserFacingStatus.INAPPLICABLE
-        assert 'Livepatch is not available for Ubuntu xenial.' == details
+        expected_details = ('Livepatch is not available for Ubuntu 16.04 LTS'
+                            ' (Xenial Xerus).')
+        assert expected_details == details
 
     def test_user_facing_status_inapplicable_on_unentitled(
             self, entitlement):

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -42,7 +42,8 @@ REPO_RESOURCE_ENTITLED = {
 PLATFORM_INFO_SUPPORTED = MappingProxyType({
     'arch': 'x86_64',
     'kernel': '4.4.0-00-generic',
-    'series': 'xenial'
+    'series': 'xenial',
+    'version': '16.04 LTS (Xenial Xerus)',
 })
 
 
@@ -76,10 +77,13 @@ class TestUserFacingStatus:
         """When applicability_status is INAPPLICABLE, return INAPPLICABLE."""
         platform_unsupported = copy.deepcopy(dict(PLATFORM_INFO_SUPPORTED))
         platform_unsupported['series'] = 'trusty'
+        platform_unsupported['version'] = '14.04 LTS (Trusty Tahr)'
         m_platform_info.return_value = platform_unsupported
         applicability, details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.INAPPLICABLE == applicability
-        assert 'Repo Test Class is not available for Ubuntu trusty.' == details
+        expected_details = ('Repo Test Class is not available for Ubuntu 14.04'
+                            ' LTS (Trusty Tahr).')
+        assert expected_details == details
         uf_status, _ = entitlement.user_facing_status()
         assert status.UserFacingStatus.INAPPLICABLE == uf_status
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -221,7 +221,7 @@ class TestGetPlatformInfo:
         assert expected_msg == str(excinfo.value)
 
     @pytest.mark.parametrize('series,release,version,os_release_content', [
-        ('trusty', '14.04', '14.04.5 LTS, Trusty Tahr', OS_RELEASE_TRUSTY),
+        ('trusty', '14.04', '14.04.5 LTS (Trusty Tahr)', OS_RELEASE_TRUSTY),
         ('xenial', '16.04', '16.04.5 LTS (Xenial Xerus)', OS_RELEASE_XENIAL),
         ('bionic', '18.04', '18.04.1 LTS (Bionic Beaver)', OS_RELEASE_BIONIC),
         ('disco', '19.04', '19.04 (Disco Dingo)', OS_RELEASE_DISCO),

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -221,9 +221,9 @@ class TestGetPlatformInfo:
         assert expected_msg == str(excinfo.value)
 
     @pytest.mark.parametrize('series,release,version,os_release_content', [
-        ('trusty', '14.04', '14.04.5 LTS (Trusty Tahr)', OS_RELEASE_TRUSTY),
-        ('xenial', '16.04', '16.04.5 LTS (Xenial Xerus)', OS_RELEASE_XENIAL),
-        ('bionic', '18.04', '18.04.1 LTS (Bionic Beaver)', OS_RELEASE_BIONIC),
+        ('trusty', '14.04', '14.04 LTS (Trusty Tahr)', OS_RELEASE_TRUSTY),
+        ('xenial', '16.04', '16.04 LTS (Xenial Xerus)', OS_RELEASE_XENIAL),
+        ('bionic', '18.04', '18.04 LTS (Bionic Beaver)', OS_RELEASE_BIONIC),
         ('disco', '19.04', '19.04 (Disco Dingo)', OS_RELEASE_DISCO),
     ])
     def test_get_platform_info_with_version(

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -217,7 +217,8 @@ class TestGetPlatformInfo:
         m_parse.return_value = {'VERSION': 'junk'}
         with pytest.raises(RuntimeError) as excinfo:
             util.get_platform_info()
-        expected_msg = 'Could not parse /etc/os-release VERSION: junk'
+        expected_msg = (
+            'Could not parse /etc/os-release VERSION: junk (modified to junk)')
         assert expected_msg == str(excinfo.value)
 
     @pytest.mark.parametrize('series,release,version,os_release_content', [

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -220,21 +220,21 @@ class TestGetPlatformInfo:
         expected_msg = 'Could not parse /etc/os-release VERSION: junk'
         assert expected_msg == str(excinfo.value)
 
-    @pytest.mark.parametrize('series,release,os_release_content', [
-        ('trusty', '14.04', OS_RELEASE_TRUSTY),
-        ('xenial', '16.04', OS_RELEASE_XENIAL),
-        ('bionic', '18.04', OS_RELEASE_BIONIC),
-        ('disco', '19.04', OS_RELEASE_DISCO),
+    @pytest.mark.parametrize('series,release,version,os_release_content', [
+        ('trusty', '14.04', '14.04.5 LTS, Trusty Tahr', OS_RELEASE_TRUSTY),
+        ('xenial', '16.04', '16.04.5 LTS (Xenial Xerus)', OS_RELEASE_XENIAL),
+        ('bionic', '18.04', '18.04.1 LTS (Bionic Beaver)', OS_RELEASE_BIONIC),
+        ('disco', '19.04', '19.04 (Disco Dingo)', OS_RELEASE_DISCO),
     ])
     def test_get_platform_info_with_version(
-            self, series, release, os_release_content, tmpdir):
+            self, series, release, version, os_release_content, tmpdir):
         release_file = tmpdir.join('os-release')
         release_file.write(os_release_content)
         parse_dict = util.parse_os_release(release_file.strpath)
 
         expected = {'arch': 'arm64', 'distribution': 'Ubuntu',
                     'kernel': 'kernel-ver', 'release': release,
-                    'series': series, 'type': 'Linux'}
+                    'series': series, 'type': 'Linux', 'version': version}
 
         with mock.patch('uaclient.util.parse_os_release') as m_parse:
             with mock.patch('uaclient.util.os.uname') as m_uname:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -324,6 +324,12 @@ REGEX_OS_RELEASE_VERSION = r'(?P<version>\d+\.\d+) (LTS )?\((?P<series>\w+).*'
 
 
 def get_platform_info() -> 'Dict[str, str]':
+    """
+    Returns a dict of platform information.
+
+    N.B. This dict is sent to the contract server, which requires the
+    distribution, type and release keys.
+    """
     os_release = parse_os_release()
     platform_info = {
         'distribution': os_release.get('NAME', 'UNKNOWN'),

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -335,6 +335,8 @@ def get_platform_info() -> 'Dict[str, str]':
     if ', ' in version:
         # Fix up trusty's version formatting
         version = '{} ({})'.format(*version.split(', '))
+    # Strip off an LTS point release (14.04.1 LTS -> 14.04 LTS)
+    version = re.sub(r'\.\d LTS', ' LTS', version)
     platform_info['version'] = version
 
     match = re.match(REGEX_OS_RELEASE_VERSION_1, version)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -332,6 +332,8 @@ def get_platform_info() -> 'Dict[str, str]':
         'type': 'Linux'}
 
     version = os_release['VERSION']
+    platform_info['version'] = version
+
     match = re.match(REGEX_OS_RELEASE_VERSION_1, version)
     if not match:
         match = re.match(REGEX_OS_RELEASE_VERSION_2, version)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -320,7 +320,7 @@ def parse_os_release(release_file: 'Optional[str]' = None) -> 'Dict[str, str]':
 
 
 # N.B. this relies on the version normalisation we perform in get_platform_info
-REGEX_OS_RELEASE_VERSION = r'(?P<version>\d+\.\d+) (LTS )?\((?P<series>\w+).*'
+REGEX_OS_RELEASE_VERSION = r'(?P<release>\d+\.\d+) (LTS )?\((?P<series>\w+).*'
 
 
 def get_platform_info() -> 'Dict[str, str]':
@@ -349,7 +349,7 @@ def get_platform_info() -> 'Dict[str, str]':
             'Could not parse /etc/os-release VERSION: %s (modified to %s)' %
             (os_release['VERSION'], version))
     match_dict = match.groupdict()
-    platform_info.update({'release': match_dict['version'],
+    platform_info.update({'release': match_dict['release'],
                           'series': match_dict['series'].lower()})
 
     uname = os.uname()

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -332,6 +332,9 @@ def get_platform_info() -> 'Dict[str, str]':
         'type': 'Linux'}
 
     version = os_release['VERSION']
+    if ', ' in version:
+        # Fix up trusty's version formatting
+        version = '{} ({})'.format(*version.split(', '))
     platform_info['version'] = version
 
     match = re.match(REGEX_OS_RELEASE_VERSION_1, version)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -321,7 +321,7 @@ def parse_os_release(release_file: 'Optional[str]' = None) -> 'Dict[str, str]':
 
 REGEX_OS_RELEASE_VERSION_1 = (  # Precise, Trusty
     r'(?P<version>\d+\.\d+)(\.\d)? (LTS,?) ?(?P<series>\w+).*')
-REGEX_OS_RELEASE_VERSION_2 = (  # >= Disco
+REGEX_OS_RELEASE_VERSION_2 = (  # >= xenial
     r'(?P<version>\d+\.\d+)(\.\d)? (LTS )?\((?P<series>\w+).*')
 
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -319,10 +319,8 @@ def parse_os_release(release_file: 'Optional[str]' = None) -> 'Dict[str, str]':
     return data
 
 
-REGEX_OS_RELEASE_VERSION_1 = (  # Precise, Trusty
-    r'(?P<version>\d+\.\d+)(\.\d)? (LTS,?) ?(?P<series>\w+).*')
-REGEX_OS_RELEASE_VERSION_2 = (  # >= xenial
-    r'(?P<version>\d+\.\d+)(\.\d)? (LTS )?\((?P<series>\w+).*')
+# N.B. this relies on the version normalisation we perform in get_platform_info
+REGEX_OS_RELEASE_VERSION = r'(?P<version>\d+\.\d+) (LTS )?\((?P<series>\w+).*'
 
 
 def get_platform_info() -> 'Dict[str, str]':
@@ -339,13 +337,11 @@ def get_platform_info() -> 'Dict[str, str]':
     version = re.sub(r'\.\d LTS', ' LTS', version)
     platform_info['version'] = version
 
-    match = re.match(REGEX_OS_RELEASE_VERSION_1, version)
-    if not match:
-        match = re.match(REGEX_OS_RELEASE_VERSION_2, version)
+    match = re.match(REGEX_OS_RELEASE_VERSION, version)
     if not match:
         raise RuntimeError(
-            'Could not parse /etc/os-release VERSION: %s' %
-            os_release['VERSION'])
+            'Could not parse /etc/os-release VERSION: %s (modified to %s)' %
+            (os_release['VERSION'], version))
     match_dict = match.groupdict()
     platform_info.update({'release': match_dict['version'],
                           'series': match_dict['series'].lower()})

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -320,9 +320,9 @@ def parse_os_release(release_file: 'Optional[str]' = None) -> 'Dict[str, str]':
 
 
 REGEX_OS_RELEASE_VERSION_1 = (  # Precise, Trusty
-    r'(?P<version>\d+\.\d+)(\.\d)? (?P<lts>LTS,?) ?(?P<series>\w+).*')
+    r'(?P<version>\d+\.\d+)(\.\d)? (LTS,?) ?(?P<series>\w+).*')
 REGEX_OS_RELEASE_VERSION_2 = (  # >= Disco
-    r'(?P<version>\d+\.\d+)(\.\d)? (?P<lts>LTS )?\((?P<series>\w+).*')
+    r'(?P<version>\d+\.\d+)(\.\d)? (LTS )?\((?P<series>\w+).*')
 
 
 def get_platform_info() -> 'Dict[str, str]':


### PR DESCRIPTION
This does the following:

* remove some unused members from the return value of `get_platform_info` and cleans up its regexes
* adds determination of the user-facing version string for our current platform as 'version' to the return value of `get_platform_info`
    * The normalisation performed to get a consistent user-facing string also means we can simplify down to just having a single regex which operates against the normalised version
* uses that value when informing users that their current Ubuntu release is unsupported

Fixes #314 