### PR TITLE
attach: add --no-auto-enable option

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -88,6 +88,9 @@ def attach_parser(parser=None):
         '--otp', action='store',
         help=('Optional one-time password for login to Ubuntu Advantage'
               ' Dashboard'))
+    parser.add_argument(
+        '--no-auto-enable', action='store_false', dest='auto_enable',
+        help='Do not enable any recommended services automatically')
     return parser
 
 
@@ -265,7 +268,7 @@ def action_attach(args, cfg):
         print('No valid contract token available')
         return 1
     if not contract.request_updated_contract(
-            cfg, contract_token, allow_enable=True):
+            cfg, contract_token, allow_enable=args.auto_enable):
         print(
             ua_status.MESSAGE_ATTACH_FAILURE_TMPL.format(url=cfg.contract_url))
         return 1

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -9,6 +9,10 @@ from uaclient.exceptions import NonRootUserError
 
 M_PATH = 'uaclient.cli.'
 
+BASIC_MACHINE_TOKEN = {
+    'machineTokenInfo': {'contractInfo': {'name': 'mycontract',
+                                          'resourceEntitlements': []}}}
+
 
 @mock.patch(M_PATH + 'os.getuid')
 def test_non_root_users_are_rejected(getuid):
@@ -50,12 +54,9 @@ class TestActionAttach:
         discharge_root_macaroon.return_value = bound_macaroon
         args = mock.MagicMock(token=None)
         cfg = FakeConfig.with_account()
-        machine_token = {
-            'machineTokenInfo': {'contractInfo': {'name': 'mycontract',
-                                                  'resourceEntitlements': []}}}
 
         def fake_contract_updates(cfg, contract_token, allow_enable):
-            cfg.write_cache('machine-token', machine_token)
+            cfg.write_cache('machine-token', BASIC_MACHINE_TOKEN)
             return True
 
         request_updated_contract.side_effect = fake_contract_updates
@@ -79,13 +80,10 @@ class TestActionAttach:
         token = 'contract-token'
         args = mock.MagicMock(token=token)
         cfg = FakeConfig.with_account()
-        machine_token = {
-            'machineTokenInfo': {'contractInfo': {'name': 'mycontract',
-                                                  'resourceEntitlements': []}}}
 
         def fake_contract_attach(contract_token):
-            cfg.write_cache('machine-token', machine_token)
-            return machine_token
+            cfg.write_cache('machine-token', BASIC_MACHINE_TOKEN)
+            return BASIC_MACHINE_TOKEN
 
         contract_machine_attach.side_effect = fake_contract_attach
 


### PR DESCRIPTION
This will skip enabling any services that are marked as autoEnable.

Fixes #366