### PR TITLE
apt: failure to acccess repo url will result in timeout error message

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -217,13 +217,8 @@ class RepoEntitlement(base.UAEntitlement):
             except util.ProcessExecutionError as e:
                 logging.error(str(e))
                 return False
-        try:
-            apt.add_auth_apt_repo(
-                repo_filename, repo_url, token, repo_suites,
-                keyring_file)
-        except apt.InvalidAPTCredentialsError as e:
-            logging.error(str(e))
-            return False
+        apt.add_auth_apt_repo(repo_filename, repo_url, token, repo_suites,
+                              keyring_file)
         # Run apt-update on any repo-entitlement enable because the machine
         # probably wants access to the repo that was just enabled.
         # Side-effect is that apt policy will new report the repo as accessible

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -56,6 +56,7 @@ class ProcessExecutionError(IOError):
                  stdout: str = '', stderr: str = '') -> None:
         self.stdout = stdout
         self.stderr = stderr
+        self.exit_code = exit_code
         if not exit_code:
             message_tmpl = "Invalid command specified '{cmd}'."
         else:
@@ -265,15 +266,13 @@ def subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
             out, err = _subp(args, rcs, capture)
             break
         except ProcessExecutionError as e:
-            message = str(e)
-            if retry_sleeps:
-                logging.debug(
-                    message + " Retrying %d more times.", len(retry_sleeps))
-                time.sleep(retry_sleeps.pop(0))
-            else:
+            if not retry_sleeps:
                 if capture:
                     logging.error(str(e))
                 raise
+            logging.debug(
+                str(e) + " Retrying %d more times.", len(retry_sleeps))
+            time.sleep(retry_sleeps.pop(0))
     return out, err
 
 


### PR DESCRIPTION
Refactor and valid_apt_credentials to assert_valid_apt_credentials.
The new function will raise different UserFacingError messages on
repo url timeout versus credentials/authentication errors.

Fixes: #613