### PR TITLE
apt-hook: Add missing headers for APT 1.9

### DIFF
--- a/apt-hook/hook.cc
+++ b/apt-hook/hook.cc
@@ -19,6 +19,8 @@
 #include <apt-pkg/cachefile.h>
 #include <apt-pkg/error.h>
 #include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
+#include <apt-pkg/policy.h>
 #include <apt-pkg/strutl.h>
 
 #include <fstream>


### PR DESCRIPTION
APT 1.9 cleans up the APT headers ever so slightly, so we
need to include a few more.