### PR TITLE
livepatch: use /usr/bin/snap directly and raise an error if snapd is not installed

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -2,7 +2,7 @@ import logging
 
 from uaclient.entitlements import base
 from uaclient.entitlements.repo import APT_RETRIES
-from uaclient import status
+from uaclient import apt, exceptions, status
 from uaclient import util
 from uaclient.status import ApplicationStatus
 
@@ -53,6 +53,10 @@ class LivepatchEntitlement(base.UAEntitlement):
                           capture=True, retry_sleeps=APT_RETRIES)
                 util.subp([SNAP_CMD, 'wait', 'system', 'seed.loaded'],
                           capture=True)
+            elif 'snapd' not in apt.get_installed_packages():
+                raise exceptions.UserFacingError(
+                    '/usr/bin/snap is present but snapd is not installed;'
+                    ' cannot enable {}'.format(self.title))
             print('Installing canonical-livepatch snap')
             try:
                 util.subp([SNAP_CMD, 'install', 'canonical-livepatch'],

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -6,6 +6,7 @@ from uaclient import status
 from uaclient import util
 from uaclient.status import ApplicationStatus
 
+SNAP_CMD = '/usr/bin/snap'
 SNAP_INSTALL_RETRIES = [0.5, 1.0, 5.0]
 
 try:
@@ -46,15 +47,15 @@ class LivepatchEntitlement(base.UAEntitlement):
         if not self.can_enable(silent=silent_if_inapplicable):
             return False
         if not util.which('/snap/bin/canonical-livepatch'):
-            if not util.which('snap'):
+            if not util.which(SNAP_CMD):
                 print('Installing snapd')
                 util.subp(['apt-get', 'install', '--assume-yes', 'snapd'],
                           capture=True, retry_sleeps=APT_RETRIES)
-                util.subp(['snap', 'wait', 'system', 'seed.loaded'],
+                util.subp([SNAP_CMD, 'wait', 'system', 'seed.loaded'],
                           capture=True)
             print('Installing canonical-livepatch snap')
             try:
-                util.subp(['snap', 'install', 'canonical-livepatch'],
+                util.subp([SNAP_CMD, 'install', 'canonical-livepatch'],
                           capture=True, retry_sleeps=SNAP_INSTALL_RETRIES)
             except util.ProcessExecutionError as e:
                 msg = 'Unable to install Livepatch client: ' + str(e)
@@ -129,7 +130,8 @@ class LivepatchEntitlement(base.UAEntitlement):
         logging.debug('Removing canonical-livepatch snap')
         if not silent:
             print('Removing canonical-livepatch snap')
-        util.subp(['snap', 'remove', 'canonical-livepatch'], capture=True)
+        util.subp([SNAP_CMD, 'remove', 'canonical-livepatch'],
+                  capture=True)
         if not silent:
             print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -295,11 +295,12 @@ class TestLivepatchEntitlementEnable:
         mock.call(
             ['apt-get', 'install', '--assume-yes', 'snapd'], capture=True,
             retry_sleeps=APT_RETRIES),
-        mock.call(['snap', 'wait', 'system', 'seed.loaded'], capture=True),
+        mock.call(['/usr/bin/snap', 'wait', 'system', 'seed.loaded'],
+                  capture=True),
     ]
     mocks_livepatch_install = [
-        mock.call(['snap', 'install', 'canonical-livepatch'], capture=True,
-                  retry_sleeps=[0.5, 1, 5]),
+        mock.call(['/usr/bin/snap', 'install', 'canonical-livepatch'],
+                  capture=True, retry_sleeps=[0.5, 1, 5]),
     ]
     mocks_install = mocks_snapd_install + mocks_livepatch_install
     mocks_config = [
@@ -353,13 +354,14 @@ class TestLivepatchEntitlementEnable:
                'Canonical livepatch enabled.\n')
         assert (msg, '') == capsys.readouterr()
         expected_calls = [mock.call('/snap/bin/canonical-livepatch'),
-                          mock.call('snap')]
+                          mock.call('/usr/bin/snap')]
         assert expected_calls == m_which.call_args_list
 
     @pytest.mark.parametrize('application_status', (
         status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING))
     @mock.patch('uaclient.util.subp')
-    @mock.patch('uaclient.util.which', side_effect=lambda cmd: cmd == 'snap')
+    @mock.patch('uaclient.util.which',
+                side_effect=lambda cmd: cmd == '/usr/bin/snap')
     @mock.patch(M_PATH + 'LivepatchEntitlement.application_status')
     @mock.patch(M_PATH + 'LivepatchEntitlement.can_enable', return_value=True)
     def test_enable_installs_only_livepatch_snap_when_absent_but_snapd_present(
@@ -374,7 +376,7 @@ class TestLivepatchEntitlementEnable:
                'Canonical livepatch enabled.\n')
         assert (msg, '') == capsys.readouterr()
         expected_calls = [mock.call('/snap/bin/canonical-livepatch'),
-                          mock.call('snap')]
+                          mock.call('/usr/bin/snap')]
         assert expected_calls == m_which.call_args_list
 
     @pytest.mark.parametrize('application_status', (


### PR DESCRIPTION
This uses the full path to `/usr/bin/snap` to ensure that we don't end up using some other binary named `snap` that happens to be in the PATH on a system. And, as there is more than one package in trusty that installs `/usr/bin/snap`, we ensure that `snapd` is installed before using `/usr/bin/snap`.

Fixes #356 