### PR TITLE
entitlements/tests: refactor to a shared entitlement_factory fixture

### DIFF
--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -1,0 +1,68 @@
+import pytest
+
+from uaclient import config
+
+try:
+    from typing import Any, Dict, List  # noqa
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
+
+def machine_token(entitlement_type: str) -> 'Dict[str, Any]':
+    return {
+        'machineToken': 'blah',
+        'machineTokenInfo': {
+            'contractInfo': {
+                'resourceEntitlements': [
+                    {'type': entitlement_type, 'entitled': True}]}}}
+
+
+def machine_access(entitlement_type: str, *,
+                   affordances: 'Dict[str, Any]' = None,
+                   directives: 'Dict[str, Any]' = None,
+                   suites: 'List[str]' = None) -> 'Dict[str, Any]':
+    if affordances is None:
+        affordances = {'series': []}  # Will match all series
+    if suites is None:
+        suites = ['xenial']
+    if directives is None:
+        directives = {
+            'aptURL': 'http://{}'.format(entitlement_type.upper()),
+            'aptKey': 'APTKEY',
+            'suites': suites,
+        }
+    return {
+        'resourceToken': 'TOKEN',
+        'entitlement': {
+            'obligations': {
+                'enableByDefault': True
+            },
+            'type': entitlement_type,
+            'entitled': True,
+            'directives': directives,
+            'affordances': affordances,
+        }
+    }
+
+
+@pytest.fixture
+def entitlement_factory(tmpdir):
+    """
+    A pytest fixture that returns a function that instantiates an entitlement
+
+    The function requires an entitlement class as its first argument, and takes
+    keyword arguments for affordances, directives and suites which, if given,
+    replace the default values in the machine-access-*.json file for the
+    entitlement.
+    """
+
+    def factory_func(cls, *, affordances=None, directives=None, suites=None):
+        cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
+        cfg.write_cache('machine-token', machine_token(cls.name))
+        cfg.write_cache('machine-access-{}'.format(cls.name),
+                        machine_access(cls.name, affordances=affordances,
+                                       directives=directives, suites=suites))
+        return cls(cfg)
+
+    return factory_func

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -5,37 +5,8 @@ import os.path
 import pytest
 
 from uaclient import apt
-from uaclient import config
 from uaclient.entitlements.esm import ESMEntitlement
 from uaclient.entitlements.repo import APT_RETRIES
-
-
-ESM_MACHINE_TOKEN = {
-    'machineToken': 'blah',
-    'machineTokenInfo': {
-        'contractInfo': {
-            'resourceEntitlements': [
-                {'type': 'esm', 'entitled': True}]}}}
-
-
-ESM_RESOURCE_ENTITLED = {
-    'resourceToken': 'TOKEN',
-    'entitlement': {
-        'obligations': {
-            'enableByDefault': True
-        },
-        'type': 'esm',
-        'entitled': True,
-        'directives': {
-            'aptURL': 'http://ESM',
-            'aptKey': 'APTKEY',
-            'suites': ['trusty']
-        },
-        'affordances': {
-            'series': []   # Will match all series
-        }
-    }
-}
 
 M_PATH = 'uaclient.entitlements.esm.ESMEntitlement.'
 M_REPOPATH = 'uaclient.entitlements.repo.'
@@ -43,16 +14,8 @@ M_GETPLATFORM = M_REPOPATH + 'util.get_platform_info'
 
 
 @pytest.fixture
-def entitlement(tmpdir):
-    """
-    A pytest fixture to create a ESMEntitlement with some default config
-
-    (Uses the tmpdir fixture for the underlying config cache.)
-    """
-    cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
-    cfg.write_cache('machine-token', dict(ESM_MACHINE_TOKEN))
-    cfg.write_cache('machine-access-esm', dict(ESM_RESOURCE_ENTITLED))
-    return ESMEntitlement(cfg)
+def entitlement(entitlement_factory):
+    return entitlement_factory(ESMEntitlement, suites=['trusty'])
 
 
 class TestESMEntitlementEnable:

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -8,36 +8,12 @@ from types import MappingProxyType
 from uaclient import apt
 from uaclient import config
 from uaclient.entitlements.repo import APT_RETRIES, RepoEntitlement
+from uaclient.entitlements.tests.conftest import machine_token
 from uaclient import status
 from uaclient import util
 
 
 M_PATH = 'uaclient.entitlements.repo.'
-
-REPO_MACHINE_TOKEN = {
-    'machineToken': 'blah',
-    'machineTokenInfo': {
-        'contractInfo': {
-            'resourceEntitlements': [
-                {'type': 'repotest', 'entitled': True}]}}}
-REPO_RESOURCE_ENTITLED = {
-    'resourceToken': 'TOKEN',
-    'entitlement': {
-        'obligations': {
-            'enableByDefault': True
-        },
-        'type': 'repotest',
-        'entitled': True,
-        'directives': {
-            'aptURL': 'http://REPOTEST',
-            'aptKey': 'APTKEY',
-            'suites': ['xenial']
-        },
-        'affordances': {
-            'series': ['xenial']
-        }
-    }
-}
 
 PLATFORM_INFO_SUPPORTED = MappingProxyType({
     'arch': 'x86_64',
@@ -57,16 +33,9 @@ class RepoTestEntitlement(RepoEntitlement):
 
 
 @pytest.fixture
-def entitlement(tmpdir):
-    """
-    A pytest fixture to create a RepoTestEntitlement with some default config
-
-    (Uses the tmpdir fixture for the underlying config cache.)
-    """
-    cfg = config.UAConfig(cfg={'data_dir': tmpdir.strpath})
-    cfg.write_cache('machine-token', dict(REPO_MACHINE_TOKEN))
-    cfg.write_cache('machine-access-repotest', dict(REPO_RESOURCE_ENTITLED))
-    return RepoTestEntitlement(cfg)
+def entitlement(entitlement_factory):
+    return entitlement_factory(RepoTestEntitlement,
+                               affordances={'series': ['xenial']})
 
 
 class TestUserFacingStatus:
@@ -91,7 +60,7 @@ class TestUserFacingStatus:
     def test_inapplicable_on_unentitled(
             self, m_platform_info, entitlement):
         """When unentitled raises a failure, return INAPPLICABLE."""
-        no_entitlements = copy.deepcopy(dict(REPO_MACHINE_TOKEN))
+        no_entitlements = copy.deepcopy(machine_token(RepoTestEntitlement))
         # delete all enttlements
         no_entitlements[
             'machineTokenInfo']['contractInfo']['resourceEntitlements'].pop()


### PR DESCRIPTION
This reduces a lot of re-definition of common data structures, making it
clearer what actually differs between different test cases.