### PR TITLE
livepatch: do not autoenable livepatch on trusty

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -150,6 +150,7 @@ class UAConfig:
             if not entitlement_cfg:
                 # Fallback to machine-token info on unentitled
                 entitlement_cfg = {'entitlement': ent_value}
+            util.apply_series_overrides(entitlement_cfg)
             self._entitlements[entitlement_name] = entitlement_cfg
         return self._entitlements
 

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -225,6 +225,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         delta_entitlement = deltas.get('entitlement', {})
         transition_to_unentitled = bool(delta_entitlement == util.DROPPED_KEY)
         if not transition_to_unentitled:
+            if delta_entitlement:
+                util.apply_series_overrides(deltas)
+                delta_entitlement = deltas['entitlement']
             if orig_access and 'entitled' in delta_entitlement:
                 transition_to_unentitled = (
                     delta_entitlement['entitled'] in (False, util.DROPPED_KEY))

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -230,10 +230,17 @@ class TestUaEntitlement:
         'orig_access,delta',
         (({'entitlement': {'entitled': True}}, {}),  # no deltas
          ({'entitlement': {'entitled': False}},
-          {'entitlement': {'entitled': True}})  # transition to entitled
+          {'entitlement': {'entitled': True}}),  # transition to entitled
+         ({'entitlement': {'entitled': False}},
+             {'entitlement': {
+                 'entitled': False,  # overridden True by series trusty
+                 'series': {'trusty': {'entitled': True}}}})
          ))
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'trusty'})
     def test_process_contract_deltas_does_nothing_when_delta_remains_entitled(
-            self, concrete_entitlement_factory, orig_access, delta):
+            self, m_platform_info, concrete_entitlement_factory, orig_access,
+            delta):
         """If deltas do not represent transition to unentitled, do nothing."""
         entitlement = concrete_entitlement_factory(
             entitled=True,

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -18,6 +18,45 @@ KNOWN_DATA_PATHS = (('bound-macaroon', 'bound-macaroon'),
 M_PATH = 'uaclient.entitlements.'
 
 
+class TestEntitlements:
+
+    def test_entitlements_property_keyed_by_entitlement_name(self, tmpdir):
+        """Return machine_token resourceEntitlements, keyed by name."""
+        cfg = UAConfig({'data_dir': tmpdir.strpath})
+        token = {
+            'machineTokenInfo': {'contractInfo': {'resourceEntitlements': [
+                {'type': 'entitlement1', 'entitled': True},
+                {'type': 'entitlement2', 'entitled': True}]}}}
+        cfg.write_cache('machine-token', token)
+        expected = {
+            'entitlement1': {
+                'entitlement': {'entitled': True, 'type': 'entitlement1'}},
+            'entitlement2': {
+                'entitlement': {'entitled': True, 'type': 'entitlement2'}}}
+        assert expected == cfg.entitlements
+
+    def test_entitlements_use_machine_access_when_present(self, tmpdir):
+        """Return specific machine-access info if present."""
+        cfg = UAConfig({'data_dir': tmpdir.strpath})
+        token = {
+            'machineTokenInfo': {'contractInfo': {'resourceEntitlements': [
+                {'type': 'entitlement1', 'entitled': True},
+                {'type': 'entitlement2', 'entitled': True}]}}}
+        cfg.write_cache('machine-token', token)
+        cfg.write_cache(
+            'machine-access-entitlement1',
+            {'entitlement': {
+                'type': 'entitlement1', 'entitled': True,
+                'more': 'data'}})
+        expected = {
+            'entitlement1': {
+                'entitlement': {'entitled': True, 'type': 'entitlement1',
+                                'more': 'data'}},
+            'entitlement2': {
+                'entitlement': {'entitled': True, 'type': 'entitlement2'}}}
+        assert expected == cfg.entitlements
+
+
 class TestAccounts:
 
     def test_accounts_returns_empty_list_when_no_cached_account_value(

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -246,6 +246,38 @@ class TestGetPlatformInfo:
                 assert expected == util.get_platform_info()
 
 
+class TestApplySeriesOverrides:
+
+    def test_error_on_non_entitlement_dict(self):
+        """Raise a runtime error when seeing invalid dict type."""
+        with pytest.raises(RuntimeError) as exc:
+            util.apply_series_overrides({'some': 'dict'})
+        error = (
+            'Expected entitlement access dict. Missing "entitlement" key:'
+            " {'some': 'dict'}")
+        assert error == str(exc.value)
+
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
+    def test_mutates_orig_access_dict(self, _):
+        """Mutate orig_access dict when called."""
+        orig_access = {
+            'entitlement': {
+                'a': {'a1': 'av1', 'a2': {'aa2': 'aav2'}},
+                'b': 'b1',
+                'c': 'c1',
+                'series': {
+                    'trusty': {'a': 't1'},
+                    'xenial': {'a': {'a2': {'aa2': 'xxv2'}}, 'b': 'bx1'}}}}
+        expected = {
+            'entitlement': {
+                'a': {'a1': 'av1', 'a2': {'aa2': 'xxv2'}},
+                'b': 'bx1',
+                'c': 'c1'}}
+        util.apply_series_overrides(orig_access)
+        assert orig_access == expected
+
+
 class TestGetMachineId:
 
     def test_get_machine_id_from_etc_machine_id(self, tmpdir):

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -358,6 +358,25 @@ def get_platform_info() -> 'Dict[str, str]':
     return platform_info
 
 
+def apply_series_overrides(orig_access: 'Dict[str, Any]') -> None:
+    """Apply series-specific overrides to an entitlement dict.
+
+    :param orig_access: Dict with original entitlement access details
+    """
+    if not all([isinstance(orig_access, dict), 'entitlement' in orig_access]):
+        raise RuntimeError(
+            'Expected entitlement access dict. Missing "entitlement" key: %s'
+            % orig_access)
+    series_name = get_platform_info()['series']
+    orig_entitlement = orig_access.get('entitlement', {})
+    overrides = orig_entitlement.pop('series', {}).pop(series_name, {})
+    for key, value in overrides.items():
+        try:
+            orig_access['entitlement'][key].update(value)
+        except AttributeError:
+            orig_access['entitlement'][key] = value
+
+
 def get_machine_id(data_dir: str) -> str:
     """Get system's unique machine-id or create our own in data_dir."""
     if os.path.exists(ETC_MACHINE_ID):


### PR DESCRIPTION
Due to the memory cost and the cost of also installing
systemd on trusty, livepatch is not auto-enabled.

To obtain series-specific behavior, ua-contracts now provides
a new 'series' key under each entitlement which will contain
any overrides for behavior on a specific series.

UA client now honors overrides via a new util function
apply_series_overrides.

Fixes: #618