### PR TITLE
apt: provide simple error message instead of traceback on dpkg lock

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -1,7 +1,6 @@
 import logging
 
 from uaclient.entitlements import base
-from uaclient.entitlements.repo import APT_RETRIES
 from uaclient import apt, exceptions, status
 from uaclient import util
 from uaclient.status import ApplicationStatus
@@ -50,7 +49,7 @@ class LivepatchEntitlement(base.UAEntitlement):
             if not util.which(SNAP_CMD):
                 print('Installing snapd')
                 util.subp(['apt-get', 'install', '--assume-yes', 'snapd'],
-                          capture=True, retry_sleeps=APT_RETRIES)
+                          capture=True, retry_sleeps=apt.APT_RETRIES)
                 util.subp([SNAP_CMD, 'wait', 'system', 'seed.loaded'],
                           capture=True)
             elif 'snapd' not in apt.get_installed_packages():

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -12,7 +12,6 @@ from uaclient import apt
 from uaclient import config
 from uaclient import status
 from uaclient.entitlements.cc import CC_README, CommonCriteriaEntitlement
-from uaclient.entitlements.repo import APT_RETRIES
 
 
 CC_MACHINE_TOKEN = {
@@ -147,7 +146,9 @@ class TestCommonCriteriaEntitlementEnable:
                       'http://CC', 'TOKEN', ['xenial'],
                       '/usr/share/keyrings/ubuntu-cc-keyring.gpg')]
 
-        subp_apt_cmds = [mock.call(['apt-cache', 'policy'])]
+        subp_apt_cmds = [
+            mock.call(['apt-cache', 'policy'],
+                      capture=True, retry_sleeps=apt.APT_RETRIES)]
 
         prerequisite_pkgs = []
         if apt_transport_https:
@@ -162,16 +163,16 @@ class TestCommonCriteriaEntitlementEnable:
             subp_apt_cmds.append(
                 mock.call(
                     ['apt-get', 'install', '--assume-yes'] + prerequisite_pkgs,
-                    capture=True, retry_sleeps=APT_RETRIES))
+                    capture=True, retry_sleeps=apt.APT_RETRIES))
         else:
             expected_stdout = ''
 
         subp_apt_cmds.extend([
-            mock.call(
-                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
+            mock.call(['apt-get', 'update'],
+                      capture=True, retry_sleeps=apt.APT_RETRIES),
             mock.call(
                 ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
-                capture=True, retry_sleeps=APT_RETRIES)])
+                capture=True, retry_sleeps=apt.APT_RETRIES)])
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -4,9 +4,9 @@ import mock
 
 import pytest
 
+from uaclient import apt
 from uaclient import status
 from uaclient.entitlements.cis import CISEntitlement
-from uaclient.entitlements.repo import APT_RETRIES
 
 
 @pytest.fixture
@@ -61,12 +61,13 @@ class TestCISEntitlementEnable:
                 '/usr/share/keyrings/ubuntu-securitybenchmarks-keyring.gpg')]
 
         subp_apt_cmds = [
-            mock.call(['apt-cache', 'policy']),
-            mock.call(
-                ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES),
+            mock.call(['apt-cache', 'policy'],
+                      capture=True, retry_sleeps=apt.APT_RETRIES),
+            mock.call(['apt-get', 'update'],
+                      capture=True, retry_sleeps=apt.APT_RETRIES),
             mock.call(
                 ['apt-get', 'install', '--assume-yes'] + entitlement.packages,
-                capture=True, retry_sleeps=APT_RETRIES)]
+                capture=True, retry_sleeps=apt.APT_RETRIES)]
 
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cis-audit

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -6,10 +6,10 @@ from types import MappingProxyType
 
 import pytest
 
+from uaclient import apt
 from uaclient import exceptions
 from uaclient.entitlements.livepatch import (
     LivepatchEntitlement, process_config_directives)
-from uaclient.entitlements.repo import APT_RETRIES
 from uaclient.entitlements.tests.conftest import machine_token
 from uaclient import status
 from uaclient.status import ContractStatus
@@ -269,7 +269,7 @@ class TestLivepatchEntitlementEnable:
     mocks_snapd_install = [
         mock.call(
             ['apt-get', 'install', '--assume-yes', 'snapd'], capture=True,
-            retry_sleeps=APT_RETRIES),
+            retry_sleeps=apt.APT_RETRIES),
         mock.call(['/usr/bin/snap', 'wait', 'system', 'seed.loaded'],
                   capture=True),
     ]

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 
 from uaclient import apt
 from uaclient import config
-from uaclient.entitlements.repo import APT_RETRIES, RepoEntitlement
+from uaclient.entitlements.repo import RepoEntitlement
 from uaclient.entitlements.tests.conftest import machine_token
 from uaclient import status
 from uaclient import util
@@ -232,7 +232,7 @@ class TestRepoEnable:
 
     @pytest.mark.parametrize('with_pre_install_msg', (False, True))
     @pytest.mark.parametrize('packages', (['a'], [], None))
-    @mock.patch(M_PATH + 'util.subp')
+    @mock.patch(M_PATH + 'util.subp', return_value=('', ''))
     @mock.patch(M_PATH + 'apt.add_auth_apt_repo')
     @mock.patch(M_PATH + 'os.path.exists', return_value=True)
     @mock.patch(M_PATH + 'util.get_platform_info')
@@ -252,7 +252,7 @@ class TestRepoEnable:
             messaging_patch = mock.MagicMock()
 
         expected_apt_calls = [mock.call(
-            ['apt-get', 'update'], capture=True, retry_sleeps=APT_RETRIES)]
+            ['apt-get', 'update'], capture=True, retry_sleeps=apt.APT_RETRIES)]
         expected_output = dedent("""\
         Updating package lists
         Repo Test Class enabled.
@@ -263,7 +263,7 @@ class TestRepoEnable:
                     mock.call(
                         ['apt-get', 'install', '--assume-yes',
                          ' '.join(packages)],
-                        capture=True, retry_sleeps=APT_RETRIES))
+                        capture=True, retry_sleeps=apt.APT_RETRIES))
                 expected_output = '\n'.join([
                     'Updating package lists',
                     'Installing Repo Test Class packages',

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -76,6 +76,9 @@ STATUS_COLOR = {
     ADVANCED: TxtColor.OKGREEN + ADVANCED + TxtColor.ENDC
 }
 
+MESSAGE_APT_INSTALL_FAILED = 'APT install failed.'
+MESSAGE_APT_UPDATE_FAILED = 'APT update failed.'
+MESSAGE_APT_POLICY_FAILED = 'Failure checking APT policy.'
 MESSAGE_DISABLED_TMPL = '{title} disabled.'
 MESSAGE_NONROOT_USER = 'This command must be run as root (try using sudo)'
 MESSAGE_ALREADY_DISABLED_TMPL = """\

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -157,7 +157,9 @@ class TestSubp:
         with pytest.raises(util.ProcessExecutionError) as excinfo:
             util.subp(['ls', '--bogus'])
 
-        expected_error = 'Failed running command \'ls --bogus\' [exit(2)]'
+        expected_error = (
+            "Failed running command 'ls --bogus' [exit(2)]."
+            " Message: ls: unrecognized option")
         assert expected_error in str(excinfo.value)
         assert 0 == m_sleep.call_count  # no retries
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -267,9 +267,9 @@ def subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
             out, err = _subp(args, rcs, capture)
             break
         except ProcessExecutionError as e:
+            if capture:
+                logging.debug(str(e))
             if not retry_sleeps:
-                if capture:
-                    logging.error(str(e))
                 raise
             logging.debug(
                 str(e) + " Retrying %d more times.", len(retry_sleeps))

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -231,13 +231,14 @@ def _subp(args: 'Sequence[str]', rcs: 'Optional[List[int]]' = None,
     except OSError:
         try:
             raise ProcessExecutionError(
-                cmd=' '.join(args), exit_code=proc.returncode, stderr=err)
+                cmd=' '.join(args), exit_code=proc.returncode,
+                stdout=out.decode('utf-8'), stderr=err.decode('utf-8'))
         except UnboundLocalError:
             raise ProcessExecutionError(cmd=' '.join(args))
     if proc.returncode not in rcs:
         raise ProcessExecutionError(
-            cmd=' '.join(args), exit_code=proc.returncode, stdout=out,
-            stderr=err)
+            cmd=' '.join(args), exit_code=proc.returncode,
+            stdout=out.decode('utf-8'), stderr=err.decode('utf-8'))
     if capture:
         logging.debug('Ran cmd: %s, rc: %s stderr: %s',
                       ' '.join(args), proc.returncode, err)


### PR DESCRIPTION
When automated updates occur, or apt-get update is run from another
process apt-cache policy and apt-get update from ua client can face
contention on dpkg lock files. Contention time can exceed client's
retries on apt commands.

Present a simple error message about APT contention instead of traceback
so that the user can resolve the apt contention, or await completion
of a long-running apt process.

Also in this branch:
- add cleanup on failure during setup_apt_config to remove any apt auth, pin or sources files
- Add retries to apt-cache policy calls

Fixes: #629
```
To test: 
terminal 1:
# on trusty
sudo ua attach
sudo ua disable esm # because it should be auto-enabled

terminal 2:
# setup a lock 
sudo with-lock-ex -f /var/lib/dpkg/lock sleep 150

terminal 1:
sudo ua enable esm
```