### PR TITLE
output: clean up strings

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -240,9 +240,7 @@ def request_updated_contract(cfg, contract_token=None, allow_enable=False):
         try:
             new_token = contract_client.request_contract_machine_attach(
                 contract_token=contract_token)
-        except util.UrlError as e:
-            logging.error(
-                'Could not obtain machine token. %s', str(e))
+        except util.UrlError:
             return False
     else:
         machine_token = orig_token['machineToken']
@@ -250,9 +248,7 @@ def request_updated_contract(cfg, contract_token=None, allow_enable=False):
         try:
             new_token = contract_client.request_machine_token_refresh(
                 machine_token=machine_token, contract_id=contract_id)
-        except util.UrlError as e:
-            logging.error(
-                'Could not refresh machine token. %s', str(e))
+        except util.UrlError:
             return False
     try:
         for name, entitlement in sorted(cfg.entitlements.items()):

--- a/uaclient/sso.py
+++ b/uaclient/sso.py
@@ -191,7 +191,8 @@ def prompt_request_macaroon(cfg: UAConfig, caveat_id: str) -> dict:
                 # 2-factor.
                 if '2-factor' in e[API_ERROR_INVALID_CREDENTIALS]:
                     if twofactor_retries < TWOFACTOR_RETRIES:
-                        args['otp'] = input('Re-enter second-factor auth: ')
+                        args['otp'] = input(
+                            'Invalid second-factor auth, try again: ')
                         twofactor_retries += 1
                         continue
             raise exceptions.UserFacingError(str(e))

--- a/uaclient/tests/test_sso.py
+++ b/uaclient/tests/test_sso.py
@@ -161,7 +161,7 @@ class TestPromptRequestMacaroon:
             sso.prompt_request_macaroon(config_mock, 'caveat_id')
         expected_calls = [
             mock.call('Email: '),
-            mock.call('Re-enter second-factor auth: ')]
+            mock.call('Invalid second-factor auth, try again: ')]
         assert expected_calls == m_input.call_args_list
 
     @pytest.mark.parametrize(
@@ -187,7 +187,7 @@ class TestPromptRequestMacaroon:
             sso.prompt_request_macaroon(config_mock, 'caveat_id')
             expected_calls = [
                 mock.call('Email: '),
-                mock.call('Re-enter second-factor auth: ')]
+                mock.call('Invalid second-factor auth, try again: ')]
         else:
             with pytest.raises(exceptions.UserFacingError):
                 sso.prompt_request_macaroon(config_mock, 'caveat_id')


### PR DESCRIPTION
This makes two changes:

1) When 2fa fails and asks for 2fa again it updates the message.
Currently the message makes it sound like the individual needs to
re-enter the exact same 2fa. Similar to how signing up for a website
asks you to 're-enter' your email and password.

2) This hides some of the detail of failures to attach from the user.
These messages are noisy and we should point the user at the logs.