### PR TITLE
util: handle missing target keys when handling series overrides

### DIFF
--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -287,6 +287,18 @@ class TestApplySeriesOverrides:
         util.apply_series_overrides(orig_access)
         assert orig_access == expected
 
+    @mock.patch('uaclient.util.get_platform_info',
+                return_value={'series': 'xenial'})
+    def test_missing_keys_are_handled(self, _):
+        orig_access = {
+            'entitlement': {'series': {'xenial': {'directives': {
+                'suites': ['xenial']}}}}}
+        expected = {'entitlement': {'directives': {'suites': ['xenial']}}}
+
+        util.apply_series_overrides(orig_access)
+
+        assert expected == orig_access
+
 
 class TestGetMachineId:
 

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -393,9 +393,13 @@ def apply_series_overrides(orig_access: 'Dict[str, Any]') -> None:
     orig_entitlement = orig_access.get('entitlement', {})
     overrides = orig_entitlement.pop('series', {}).pop(series_name, {})
     for key, value in overrides.items():
-        try:
-            orig_access['entitlement'][key].update(value)
-        except AttributeError:
+        current = orig_access['entitlement'].get(key)
+        if isinstance(current, dict):
+            # If the key already exists and is a dict, update that dict using
+            # the override
+            current.update(value)
+        else:
+            # Otherwise, replace it wholesale
             orig_access['entitlement'][key] = value
 
 


### PR DESCRIPTION
Fixes #664