### PR TITLE
contract: apply_series_overrides before computing deltas

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -198,6 +198,7 @@ def process_entitlement_delta(orig_access, new_access, allow_enable=False):
     """
     from uaclient.entitlements import ENTITLEMENT_CLASS_BY_NAME
 
+    util.apply_series_overrides(new_access)
     deltas = util.get_dict_deltas(orig_access, new_access)
     if deltas:
         name = orig_access.get('entitlement', {}).get('type')


### PR DESCRIPTION
Our orig_access has already had the series overrides applied, which
means it will never be equal to the contract server's response.  As a
result, we would _always_ determine that there was a delta, and apply
it.

This is simply fixed by applying the series overrides to the new access
dict before we determine if there are any deltas.

Fixes #666