### PR TITLE
WIP: status: add upstart and systemd scripts to update status per boot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,8 @@ Build-Depends: bash-completion,
                python3-mock,
                python3-pytest,
                python3-setuptools,
-               python3-yaml
+               python3-yaml,
+               dh-systemd,
 Standards-Version: 4.3.0
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.8.1)"
 endif
 
 %:
-	dh $@ --with python3,bash-completion --buildsystem=pybuild
+	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild
 
 override_dh_auto_build:
 	dh_auto_build

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import glob
 import setuptools
 
-from uaclient import defaults, version
+from uaclient import defaults, util, version
 
 NAME = 'ubuntu-advantage-tools'
 
@@ -20,18 +20,27 @@ def _get_version():
     return major_minor
 
 
+def _get_data_files():
+    data_files = [
+        ('/etc/apt/apt.conf.d', ['apt.conf.d/51ubuntu-advantage-esm']),
+        ('/etc/ubuntu-advantage', ['uaclient.conf']),
+        ('/usr/share/keyrings', glob.glob('keyrings/*')),
+        (defaults.CONFIG_DEFAULTS['data_dir'], [])]
+    rel_major, _rel_minor = util.get_platform_info()['release'].split('.')
+    if rel_major == '14':
+        data_files.append(('/etc/init', glob.glob('upstart/*')))
+    else:
+        data_files.append(('/lib/systemd/system', glob.glob('systemd/*')))
+    return data_files
+
+
 setuptools.setup(
     name=NAME,
     version=_get_version(),
     packages=setuptools.find_packages(
         exclude=['*.testing', 'tests.*', '*.tests', 'tests']
     ),
-    data_files=[
-        ('/etc/apt/apt.conf.d', ['apt.conf.d/51ubuntu-advantage-esm']),
-        ('/etc/ubuntu-advantage', ['uaclient.conf']),
-        ('/usr/share/keyrings', glob.glob('keyrings/*')),
-        (defaults.CONFIG_DEFAULTS['data_dir'], [])
-    ],
+    data_files=_get_data_files(),
     install_requires=INSTALL_REQUIRES,
     extras_require=dict(test=TEST_REQUIRES),
     author='Ubuntu Server Team',

--- a/systemd/ua-status.service
+++ b/systemd/ua-status.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ubuntu Advantage status refresh
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ua status
+TimeoutSec=5
+
+[Install]
+WantedBy=multi-user.target
+After=network-online.target
+Want=network-online.target

--- a/upstart/ua-status.conf
+++ b/upstart/ua-status.conf
@@ -1,0 +1,14 @@
+# ua-status - Update status cache on reboot
+
+# This task is run on reboot to adapt to potential change in
+# kernels/environment across boot and update Ubuntu Advantage status
+# information.
+
+description	"Ubuntu Advantage status update"
+
+start on runlevel [2345]
+
+task
+# Refresh the status of all Ubuntu Advantage services
+exec ua status
+


### PR DESCRIPTION
WIP: needs discussion on whether we want this every boot
====

Two use cases need discussion:
  1.  Trusty switch to unsupported livepatch kernel
     A. (trusty) ua enable livepatch (on hwe kernel) 
     B. reboot to non hwe kernel
     C. (non-root) ua status will still report livepatch active
     D. (root) ua status will properly update livepatch inactive
     
  2. Xenial, Bionic FIPS*
     A. sudo ua enable fips
     B. (non-root) ua status fips pending   # requires reboot to fips kernel
     C. sudo reboot # to fips kernel
     D. (non-root) ua status fips pending    # status only updated by root
     E: (root) ua status   fips active
     
1 may be a specific corner case we don't really care about. If we are concerned about hitting ua-contracts service every boot unnecessarily, we could limit the scope of this update check to only do this on systems where services are in 'pending' status on an LTS series. Because pending is generally an interim state that we expect to leave post a reboot, this would certainly limit us to systems where FIPS was activated, and have a potential to transition 

Fixes: #622


To test:
```
# launch and connect to vm on your preferred series
sudo make deps
dpkg-buildpackage -us -uc
dpkg -i ../ubuntu-advantage-tools*deb
sleep 60
sudo reboot 
# check timestamp on status,json to make sure it was written again
ls -ltr /var/lib/ubuntu-advantage/status.json  
```