### PR TITLE
ignore noop cast definitions

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -14,7 +14,7 @@ try:
     from typing import Any, cast, Dict, Optional  # noqa: F401
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
-    def cast(_, x):
+    def cast(_, x):  # type: ignore
         return x
 
 

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -9,7 +9,7 @@ try:
     from typing import cast, Dict, List, Type  # noqa: F401
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
-    def cast(_, x):
+    def cast(_, x):  # type: ignore
         return x
 
 ENTITLEMENT_CLASSES = [


### PR DESCRIPTION
mypy has started warning about them, but the warnings are spurious.