### PR TITLE
Handle encoding/decoding datetimes to/from JSON when using the cache

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -173,7 +173,7 @@ class UAConfig:
                 logging.debug('File does not exist: %s', cache_path)
             return None
         try:
-            return json.loads(content)
+            return json.loads(content, cls=util.DatetimeAwareJSONDecoder)
         except ValueError:
             return content
 

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -186,7 +186,7 @@ class UAConfig:
             self._machine_token = None
             self._entitlements = None
         if not isinstance(content, str):
-            content = json.dumps(content)
+            content = json.dumps(content, cls=util.DatetimeAwareJSONEncoder)
         mode = 0o600
         if key in self.data_paths:
             if not self.data_paths[key].private:

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -172,8 +172,10 @@ class UAConfig:
             if not os.path.exists(cache_path) and not silent:
                 logging.debug('File does not exist: %s', cache_path)
             return None
-        json_content = util.maybe_parse_json(content)
-        return json_content if json_content else content
+        try:
+            return json.loads(content)
+        except ValueError:
+            return content
 
     def write_cache(self, key: str, content: 'Any') -> None:
         filepath = self.data_path(key)

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -50,10 +50,9 @@ class UAServiceClient(metaclass=abc.ABCMeta):
             response, headers = util.readurl(
                 url=url, data=data, headers=headers, method=method)
         except error.URLError as e:
-            code = e.errno
             if hasattr(e, 'read'):
                 error_details = util.maybe_parse_json(e.read().decode('utf-8'))
                 if error_details:
                     raise self.api_error_cls(e, error_details)
-            raise util.UrlError(e, code=code, headers=headers, url=url)
+            raise util.UrlError(e, code=e.code, headers=headers, url=url)
         return response, headers

--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -51,7 +51,10 @@ class UAServiceClient(metaclass=abc.ABCMeta):
                 url=url, data=data, headers=headers, method=method)
         except error.URLError as e:
             if hasattr(e, 'read'):
-                error_details = util.maybe_parse_json(e.read().decode('utf-8'))
+                try:
+                    error_details = json.loads(e.read().decode('utf-8'))
+                except ValueError:
+                    error_details = None
                 if error_details:
                     raise self.api_error_cls(e, error_details)
             raise util.UrlError(e, code=e.code, headers=headers, url=url)

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -2,6 +2,7 @@ import json
 
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
+from uaclient.util import DatetimeAwareJSONEncoder
 
 try:
     from typing import Any, Dict, Optional  # noqa: F401
@@ -34,7 +35,8 @@ class FakeConfig(UAConfig):
         self._cache_contents = {}
         if cache_contents:
             self._cache_contents = {
-                k: json.dumps(v) for k, v in cache_contents.items()}
+                k: json.dumps(v, cls=DatetimeAwareJSONEncoder)
+                for k, v in cache_contents.items()}
 
         super().__init__({})
 
@@ -46,7 +48,7 @@ class FakeConfig(UAConfig):
 
     def write_cache(
             self, key: str, content: 'Any', private: bool = True) -> None:
-        content = json.dumps(content)
+        content = json.dumps(content, cls=DatetimeAwareJSONEncoder)
         if private:
             self._cache_contents[key] = content
         else:

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,3 +1,5 @@
+import json
+
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
 
@@ -29,15 +31,22 @@ class FakeContractClient(UAContractClient):
 class FakeConfig(UAConfig):
 
     def __init__(self, cache_contents: 'Dict[str, Any]' = None) -> None:
-        self._cache_contents = (
-            cache_contents if cache_contents is not None else {})
+        self._cache_contents = {}
+        if cache_contents:
+            self._cache_contents = {
+                k: json.dumps(v) for k, v in cache_contents.items()}
+
         super().__init__({})
 
     def read_cache(self, key: str, silent: bool = False) -> 'Optional[str]':
-        return self._cache_contents.get(key)
+        value = self._cache_contents.get(key)
+        if value:
+            value = json.loads(value)
+        return value
 
     def write_cache(
             self, key: str, content: 'Any', private: bool = True) -> None:
+        content = json.dumps(content)
         if private:
             self._cache_contents[key] = content
         else:

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -2,7 +2,7 @@ import json
 
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
-from uaclient.util import DatetimeAwareJSONEncoder
+from uaclient.util import DatetimeAwareJSONDecoder, DatetimeAwareJSONEncoder
 
 try:
     from typing import Any, Dict, Optional  # noqa: F401
@@ -43,7 +43,7 @@ class FakeConfig(UAConfig):
     def read_cache(self, key: str, silent: bool = False) -> 'Optional[str]':
         value = self._cache_contents.get(key)
         if value:
-            value = json.loads(value)
+            value = json.loads(value, cls=DatetimeAwareJSONDecoder)
         return value
 
     def write_cache(

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -203,6 +203,16 @@ class TestReadCache:
 
         assert expected == cfg.read_cache(key)
 
+    def test_datetimes_are_unserialised(self, tmpdir):
+        cfg = UAConfig({'data_dir': tmpdir.strpath})
+        os.makedirs(tmpdir.join(PRIVATE_SUBDIR).strpath)
+        data_path = tmpdir.join(PRIVATE_SUBDIR, 'dt_test')
+        with open(data_path.strpath, 'w') as f:
+            f.write('{"dt": "2019-07-25T14:35:51"}')
+
+        actual = cfg.read_cache('dt_test')
+        assert {'dt': datetime.datetime(2019, 7, 25, 14, 35, 51)} == actual
+
 
 class TestDeleteCache:
 
@@ -406,6 +416,27 @@ class TestStatus:
         assert expected == cfg.status()
         assert len(ENTITLEMENT_CLASSES) - 1 == m_repo_uf_status.call_count
         assert 1 == m_livepatch_uf_status.call_count
+
+    @mock.patch('uaclient.config.os.getuid')
+    def test_expires_handled_appropriately(self, m_getuid):
+        token = {
+            'machineTokenInfo': {
+                'accountInfo': {'id': '1', 'name': 'accountname'},
+                'contractInfo': {'name': 'contractname',
+                                 'effectiveTo': '2020-07-18T00:00:00Z',
+                                 'resourceEntitlements': []}}}
+        cfg = FakeConfig.for_attached_machine(
+            account_name='accountname', machine_token=token)
+
+        # Test that root's status works as expected (including the cache write)
+        m_getuid.return_value = 0
+        expected_dt = datetime.datetime(2020, 7, 18, 0, 0, 0)
+        assert expected_dt == cfg.status()['expires']
+
+        # Test that the read from the status cache work properly for non-root
+        # users
+        m_getuid.return_value = 1000
+        assert expected_dt == cfg.status()['expires']
 
 
 class TestParseConfig:

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -359,7 +359,7 @@ class TestStatus:
     @mock.patch(M_PATH + 'livepatch.LivepatchEntitlement.user_facing_status')
     @mock.patch(M_PATH + 'repo.RepoEntitlement.user_facing_status')
     def test_attached_reports_contract_and_service_status(
-            self, m_repo_uf_status, m_livepatch_uf_status, _m_getuid, tmpdir,
+            self, m_repo_uf_status, m_livepatch_uf_status, _m_getuid,
             entitlements):
         """When attached, return contract and service user-facing status."""
         m_repo_uf_status.return_value = (

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 import itertools
 import json
 import os
@@ -159,6 +160,14 @@ class TestWriteCache:
         cfg.write_cache('path', '')
         assert mode == stat.S_IMODE(
             os.lstat(cfg.data_path('path')).st_mode)
+
+    def test_write_datetime(self, tmpdir):
+        cfg = UAConfig({'data_dir': tmpdir.strpath})
+        key = 'test_key'
+        dt = datetime.datetime.now()
+        cfg.write_cache(key, dt)
+        with open(cfg.data_path(key)) as f:
+            assert dt.isoformat() == f.read().strip('"')
 
 
 class TestReadCache:

--- a/uaclient/tests/test_serviceclient.py
+++ b/uaclient/tests/test_serviceclient.py
@@ -1,0 +1,48 @@
+import mock
+from urllib.error import HTTPError
+from io import BytesIO
+
+import pytest
+
+from uaclient import util
+from uaclient.serviceclient import UAServiceClient
+
+
+class OurServiceClientException(Exception):
+
+    def __init__(self, exc, details):
+        self.exc = exc
+        self.details = details
+
+
+class OurServiceClient(UAServiceClient):
+
+    @property
+    def api_error_cls(self):
+        return OurServiceClientException
+
+    @property
+    def cfg_url_base_attr(self):
+        return 'unused'
+
+
+class TestRequestUrl:
+
+    # TODO: Non error-path tests
+
+    @pytest.mark.parametrize('fp,expected_exception,expected_attrs', (
+        (BytesIO(), util.UrlError, {'code': 619}),
+        (BytesIO(b'{"a": "b"}'), OurServiceClientException,
+         {'details': {"a": "b"}}),
+    ))
+    @mock.patch('uaclient.serviceclient.util.readurl')
+    def test_urlerror_with_read(
+            self, m_readurl, fp, expected_exception, expected_attrs):
+        m_readurl.side_effect = HTTPError(None, 619, None, None, fp)
+
+        client = OurServiceClient(cfg=mock.MagicMock())
+        with pytest.raises(expected_exception) as excinfo:
+            client.request_url('/')
+
+        for attr, expected_value in expected_attrs.items():
+            assert expected_value == getattr(excinfo.value, attr)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -1,4 +1,6 @@
 """Tests related to uaclient.util module."""
+import datetime
+import json
 import logging
 import posix
 import subprocess
@@ -428,3 +430,15 @@ class TestDisableLogToConsole:
         combined_output = out + err
         assert 'test error' in combined_output
         assert 'test info' in combined_output
+
+
+class TestDatetimeAwareJSONEncoder:
+
+    @pytest.mark.parametrize('input,out', (
+        ('a', '"a"'),
+        (1, '1'),
+        ({'a': 1}, '{"a": 1}'),
+        (datetime.datetime(2019, 7, 25, 14, 35, 51), '"2019-07-25T14:35:51"'),
+    ))
+    def test_encode(self, input, out):
+        assert out == json.dumps(input, cls=util.DatetimeAwareJSONEncoder)

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -432,13 +432,28 @@ class TestDisableLogToConsole:
         assert 'test info' in combined_output
 
 
+JSON_TEST_PAIRS = (
+    ('a', '"a"'),
+    (1, '1'),
+    ({'a': 1}, '{"a": 1}'),
+    # See the note in DatetimeAwareJSONDecoder for why this datetime is in a
+    # dict
+    ({'dt': datetime.datetime(2019, 7, 25, 14, 35, 51)},
+     '{"dt": "2019-07-25T14:35:51"}'),
+)
+
+
 class TestDatetimeAwareJSONEncoder:
 
-    @pytest.mark.parametrize('input,out', (
-        ('a', '"a"'),
-        (1, '1'),
-        ({'a': 1}, '{"a": 1}'),
-        (datetime.datetime(2019, 7, 25, 14, 35, 51), '"2019-07-25T14:35:51"'),
-    ))
+    @pytest.mark.parametrize('input,out', JSON_TEST_PAIRS)
     def test_encode(self, input, out):
         assert out == json.dumps(input, cls=util.DatetimeAwareJSONEncoder)
+
+
+class TestDatetimeAwareJSONDecoder:
+
+    # Note that the parameter names are flipped from
+    # TestDatetimeAwareJSONEncoder
+    @pytest.mark.parametrize('out,input', JSON_TEST_PAIRS)
+    def test_encode(self, input, out):
+        assert out == json.loads(input, cls=util.DatetimeAwareJSONDecoder)

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -1,4 +1,5 @@
 from errno import ENOENT
+import datetime
 import json
 import logging
 import os
@@ -65,6 +66,15 @@ class ProcessExecutionError(IOError):
                 " Message: {stderr}")
         super().__init__(
             message_tmpl.format(cmd=cmd, stderr=stderr, exit_code=exit_code))
+
+
+class DatetimeAwareJSONEncoder(json.JSONEncoder):
+    """A json.JSONEncoder subclass that writes out isoformat'd datetimes."""
+
+    def default(self, o):
+        if isinstance(o, datetime.datetime):
+            return o.isoformat()
+        return super().default(o)
 
 
 def del_file(path: str) -> None:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -176,17 +176,6 @@ def load_file(filename: str, decode: bool = True) -> str:
     return content.decode('utf-8')
 
 
-def maybe_parse_json(content: str) -> 'Optional[Any]':
-    """Attempt to parse json content.
-
-    @return: Structured content on success and None on failure.
-    """
-    try:
-        return json.loads(content)
-    except ValueError:
-        return None
-
-
 def readurl(url: str, data: 'Optional[bytes]' = None,
             headers: 'Dict[str, str]' = {}, method: 'Optional[str]' = None
             ) -> 'Tuple[Any, Union[HTTPMessage, Mapping[str, str]]]':

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -193,8 +193,6 @@ def readurl(url: str, data: 'Optional[bytes]' = None,
     if data and not method:
         method = 'POST'
     req = request.Request(url, data=data, headers=headers, method=method)
-    if data:
-        data = maybe_parse_json(data.decode('utf-8'))
     logging.debug(
         'URL [%s]: %s, headers: %s, data: %s',
         method or 'GET', url, headers, data)


### PR DESCRIPTION
This adds classes which handle the encoding/decoding of datetimes (to/from an ISO string format) and uses them when writing to/reading from the cache.

This also remove `util.maybe_parse_json`. One of its call sites, in `readurl`, was no longer needed (we used to parse the JSON to mutate it for log redaction, but we no longer redact the logs so we can just log the unparsed string). The remaining two call sites now have different behaviour (one should decodes datetimes transparently from the cache, the other should not decode datetimes transparently from remote services), and it's less code to just inline the try/except in each callsite than to handle that difference in a single function.

This fixes #694 