### PR TITLE
.travis.yml: don't ignore mypy failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,3 @@ matrix:
   allow_failures:
     - python: 3.8-dev
       env: TOXENV=py3,flake8
-    - python: 3.7
-      env: TOXENV=mypy


### PR DESCRIPTION
It's passing, and has been for a while. I'm pretty sure this is a holdover from when we were first introducing it.