### PR TITLE
uaclient: replace % formatting with .format()

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -51,8 +51,9 @@ def assert_valid_apt_credentials(repo_url, username, password):
             [
                 '/usr/lib/apt/apt-helper',
                 'download-file',
-                '%s://%s:%s@%s/ubuntu/pool/'
-                % (protocol, username, password, repo_path),
+                '{}://{}:{}@{}/ubuntu/pool/'.format(
+                    protocol, username, password, repo_path
+                ),
                 '/tmp/uaclient-apt-test',
             ],
             timeout=APT_HELPER_TIMEOUT,
@@ -62,11 +63,13 @@ def assert_valid_apt_credentials(repo_url, username, password):
             stderr = str(e.stderr).lower()
             if re.search(r'401\s+unauthorized|httperror401', stderr):
                 raise exceptions.UserFacingError(
-                    'Invalid APT credentials provided for %s' % repo_url
+                    'Invalid APT credentials provided for {}'.format(repo_url)
                 )
             elif re.search(r'connection timed out', stderr):
                 raise exceptions.UserFacingError(
-                    'Timeout trying to access APT repository at %s' % repo_url
+                    'Timeout trying to access APT repository at {}'.format(
+                        repo_url
+                    )
                 )
         raise exceptions.UserFacingError(
             'Unexpected APT error. See /var/log/ubuntu-advantage.log'
@@ -74,8 +77,9 @@ def assert_valid_apt_credentials(repo_url, username, password):
     except subprocess.TimeoutExpired:
         raise exceptions.UserFacingError(
             'Cannot validate credentials for APT repo.'
-            ' Timeout after %d seconds trying to reach %s.'
-            % (APT_HELPER_TIMEOUT, repo_path)
+            ' Timeout after {} seconds trying to reach {}.'.format(
+                APT_HELPER_TIMEOUT, repo_path
+            )
         )
     finally:
         if os.path.exists('/tmp/uaclient-apt-test'):
@@ -280,7 +284,9 @@ def find_apt_list_files(repo_url, series):
     aptlist_filename = repo_path.replace('/', '_')
     return sorted(
         glob.glob(
-            os.path.join(lists_dir, aptlist_filename + '_dists_%s*' % series)
+            os.path.join(
+                lists_dir, aptlist_filename + '_dists_{}*'.format(series)
+            )
         )
     )
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -82,8 +82,9 @@ def attach_parser(parser=None):
     parser._optionals.title = 'Flags'
     parser.add_argument(
         'token',
-        help='Token obtained for Ubuntu Advantage authentication:'
-        ' %s' % UA_AUTH_TOKEN_URL,
+        help='Token obtained for Ubuntu Advantage authentication: {}'.format(
+            UA_AUTH_TOKEN_URL
+        ),
     )
     parser.add_argument(
         '--no-auto-enable',
@@ -186,8 +187,9 @@ def status_parser(parser=None):
         choices=STATUS_FORMATS,
         default=STATUS_FORMATS[0],
         help=(
-            'Output status in the request format. Default: %s'
-            % STATUS_FORMATS[0]
+            'Output status in the request format. Default: {}'.format(
+                STATUS_FORMATS[0]
+            )
         ),
     )
     parser._optionals.title = 'Flags'
@@ -266,8 +268,9 @@ def action_detach(args, cfg):
 def action_attach(args, cfg):
     if cfg.is_attached:
         print(
-            "This machine is already attached to '%s'."
-            % cfg.accounts[0]['name']
+            "This machine is already attached to '{}'.".format(
+                cfg.accounts[0]['name']
+            )
         )
         return 0
     if os.getuid() != 0:

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -75,7 +75,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         os = util.get_platform_info()
         arch = os.pop('arch')
         headers = self.headers()
-        headers.update({'Authorization': 'Bearer %s' % contract_token})
+        headers.update({'Authorization': 'Bearer {}'.format(contract_token)})
         data = {'machineId': machine_id, 'architecture': arch, 'os': os}
         machine_token, _headers = self.request_url(
             API_V1_CONTEXT_MACHINE_TOKEN, data=data, headers=headers
@@ -103,14 +103,16 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not machine_id:
             machine_id = util.get_machine_id(self.cfg.data_dir)
         headers = self.headers()
-        headers.update({'Authorization': 'Bearer %s' % machine_token})
+        headers.update({'Authorization': 'Bearer {}'.format(machine_token)})
         url = API_V1_TMPL_RESOURCE_MACHINE_ACCESS.format(
             resource=resource, machine=machine_id
         )
         resource_access, headers = self.request_url(url, headers=headers)
         if headers.get('expires'):
             resource_access['expires'] = headers['expires']
-        self.cfg.write_cache('machine-access-%s' % resource, resource_access)
+        self.cfg.write_cache(
+            'machine-access-{}'.format(resource), resource_access
+        )
         return resource_access
 
     def request_machine_token_refresh(
@@ -129,7 +131,7 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not machine_id:
             machine_id = util.get_machine_id(self.cfg.data_dir)
         headers = self.headers()
-        headers.update({'Authorization': 'Bearer %s' % machine_token})
+        headers.update({'Authorization': 'Bearer {}'.format(machine_token)})
         url = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH.format(
             contract=contract_id, machine=machine_id
         )
@@ -164,8 +166,9 @@ def process_entitlement_delta(orig_access, new_access, allow_enable=False):
             name = deltas.get('entitlement', {}).get('type')
         if not name:
             raise RuntimeError(
-                'Could not determine contract delta service type %s %s'
-                % (orig_access, new_access)
+                'Could not determine contract delta service type {} {}'.format(
+                    orig_access, new_access
+                )
             )
         try:
             ent_cls = ENTITLEMENT_CLASS_BY_NAME[name]

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -278,13 +278,14 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 else:
                     logging.warning(
                         "Unable to disable '%s' as recommended during contract"
-                        " refresh. Service is still active. See `ua status`"
-                        % self.name
+                        " refresh. Service is still active. See"
+                        " `ua status`",
+                        self.name,
                     )
             # Clean up former entitled machine-access-<name> response cache
             # file because uaclient doesn't access machine-access-* routes or
             # responses on unentitled services.
-            self.cfg.delete_cache_key('machine-access-%s' % self.name)
+            self.cfg.delete_cache_key('machine-access-{}'.format(self.name))
             return True
 
         resourceToken = orig_access.get('resourceToken')
@@ -320,12 +321,12 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         if not entitlement_cfg:
             return (
                 UserFacingStatus.INAPPLICABLE,
-                '%s is not entitled' % self.title,
+                '{} is not entitled'.format(self.title),
             )
         elif entitlement_cfg['entitlement'].get('entitled', False) is False:
             return (
                 UserFacingStatus.INAPPLICABLE,
-                '%s is not entitled' % self.title,
+                '{} is not entitled'.format(self.title),
             )
 
         application_status, explanation = self.application_status()

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -196,7 +196,7 @@ class LivepatchEntitlement(base.UAEntitlement):
         )
         process_token = bool(deltas.get('resourceToken', False))
         if any([process_directives, process_token]):
-            logging.info("Updating '%s' on changed directives." % self.name)
+            logging.info("Updating '%s' on changed directives.", self.name)
             return self.setup_livepatch_config(
                 process_directives=process_directives,
                 process_token=process_token,
@@ -223,7 +223,7 @@ def process_config_directives(cfg):
             [
                 '/snap/bin/canonical-livepatch',
                 'config',
-                'ca-certs=%s' % ca_certs,
+                'ca-certs={}'.format(ca_certs),
             ],
             capture=True,
         )
@@ -235,7 +235,7 @@ def process_config_directives(cfg):
             [
                 '/snap/bin/canonical-livepatch',
                 'config',
-                'remote-server=%s' % remote_server,
+                'remote-server={}'.format(remote_server),
             ],
             capture=True,
         )

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -122,10 +122,13 @@ class RepoEntitlement(base.UAEntitlement):
         policy = apt.run_apt_command(
             ['apt-cache', 'policy'], status.MESSAGE_APT_POLICY_FAILED
         )
-        match = re.search(r'(?P<pin>(-)?\d+) %s[^-]' % repo_url, policy)
+        match = re.search(r'(?P<pin>(-)?\d+) {}[^-]'.format(repo_url), policy)
         if match and match.group('pin') != APT_DISABLED_PIN:
-            return ApplicationStatus.ENABLED, '%s is active' % self.title
-        return ApplicationStatus.DISABLED, '%s is not configured' % self.title
+            return ApplicationStatus.ENABLED, '{} is active'.format(self.title)
+        return (
+            ApplicationStatus.DISABLED,
+            '{} is not configured'.format(self.title),
+        )
 
     def process_contract_deltas(
         self,
@@ -152,7 +155,7 @@ class RepoEntitlement(base.UAEntitlement):
         if application_status == status.ApplicationStatus.DISABLED:
             return True
         logging.info(
-            "Updating '%s' apt sources list on changed directives." % self.name
+            "Updating '%s' apt sources list on changed directives.", self.name
         )
         delta_entitlement = deltas.get('entitlement', {})
         if delta_entitlement.get('directives', {}).get('aptURL'):
@@ -192,8 +195,8 @@ class RepoEntitlement(base.UAEntitlement):
         aptKey = directives.get('aptKey')
         if not aptKey:
             raise exceptions.UserFacingError(
-                "Ubuntu Advantage server provided no aptKey directive for %s."
-                % self.name
+                "Ubuntu Advantage server provided no aptKey directive for"
+                " {}.".format(self.name)
             )
         repo_url = directives.get('aptURL')
         if not repo_url:
@@ -201,15 +204,15 @@ class RepoEntitlement(base.UAEntitlement):
         repo_suites = directives.get('suites')
         if not repo_suites:
             raise exceptions.UserFacingError(
-                'Empty %s apt suites directive from %s'
-                % (self.name, self.cfg.contract_url)
+                'Empty {} apt suites directive from {}'.format(
+                    self.name, self.cfg.contract_url
+                )
             )
         if self.repo_pin_priority:
             if not self.origin:
                 raise exceptions.UserFacingError(
-                    "Cannot setup apt pin. Empty apt repo origin value '%s'.\n"
-                    "%s"
-                    % (
+                    "Cannot setup apt pin. Empty apt repo origin value '{}'.\n"
+                    "{}".format(
                         self.origin,
                         status.MESSAGE_ENABLED_FAILED_TMPL.format(
                             title=self.title
@@ -273,9 +276,9 @@ class RepoEntitlement(base.UAEntitlement):
             name=self.name, series=series
         )
         keyring_file = os.path.join(apt.APT_KEYS_DIR, self.repo_key_file)
-        entitlement = self.cfg.read_cache('machine-access-%s' % self.name).get(
-            'entitlement', {}
-        )
+        entitlement = self.cfg.read_cache(
+            'machine-access-{}'.format(self.name)
+        ).get('entitlement', {})
         access_directives = entitlement.get('directives', {})
         repo_url = access_directives.get('aptURL', self.repo_url)
         if not repo_url:

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -109,7 +109,7 @@ class TestCommonCriteriaEntitlementCanEnable:
         entitlement = CommonCriteriaEntitlement(cfg)
         uf_status, uf_status_details = entitlement.user_facing_status()
         assert status.UserFacingStatus.INACTIVE == uf_status
-        details = '%s is not configured' % entitlement.title
+        details = '{} is not configured'.format(entitlement.title)
         assert details == uf_status_details
         assert True is entitlement.can_enable()
         assert ('', '') == capsys.readouterr()
@@ -192,8 +192,8 @@ class TestCommonCriteriaEntitlementEnable:
             prerequisite_pkgs.append('ca-certificates')
 
         if prerequisite_pkgs:
-            expected_stdout = 'Installing prerequisites: %s\n' % ', '.join(
-                prerequisite_pkgs
+            expected_stdout = 'Installing prerequisites: {}\n'.format(
+                ', '.join(prerequisite_pkgs)
             )
             subp_apt_cmds.append(
                 mock.call(
@@ -233,8 +233,9 @@ class TestCommonCriteriaEntitlementEnable:
                 '(This will download more than 500MB of packages, so may take'
                 ' some time.)',
                 'Canonical Common Criteria EAL2 Provisioning enabled.',
-                'Please follow instructions in %s to configure EAL2\n'
-                % CC_README,
+                'Please follow instructions in {} to configure EAL2\n'.format(
+                    CC_README
+                ),
             ]
         )
         assert (expected_stdout, '') == capsys.readouterr()

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -157,9 +157,8 @@ class TestFIPSEntitlementEnable:
         with mock.patch.object(entitlement, 'can_enable', return_value=True):
             with pytest.raises(exceptions.UserFacingError) as excinfo:
                 entitlement.enable()
-        error_msg = 'Empty %s apt suites directive from %s' % (
-            entitlement.name,
-            defaults.BASE_CONTRACT_URL,
+        error_msg = 'Empty {} apt suites directive from {}'.format(
+            entitlement.name, defaults.BASE_CONTRACT_URL
         )
         assert error_msg == excinfo.value.msg
         assert 0 == m_add_apt.call_count
@@ -189,7 +188,7 @@ class TestFIPSEntitlementEnable:
 
         error_msg = (
             "Cannot setup apt pin. Empty apt repo origin value 'None'.\n"
-            "Could not enable %s." % entitlement.title
+            "Could not enable {}.".format(entitlement.title)
         )
         assert error_msg == excinfo.value.msg
         assert 0 == m_add_apt.call_count
@@ -221,7 +220,7 @@ class TestFIPSEntitlementEnable:
 
             with pytest.raises(exceptions.UserFacingError) as excinfo:
                 entitlement.enable()
-            error_msg = 'Could not enable %s.' % entitlement.title
+            error_msg = 'Could not enable {}.'.format(entitlement.title)
             assert error_msg == excinfo.value.msg
 
         for call in m_subp.call_args_list:

--- a/uaclient/gpg.py
+++ b/uaclient/gpg.py
@@ -43,7 +43,7 @@ def export_gpg_key_from_keyring(
         )
     if 'nothing exported' in err:
         raise exceptions.UserFacingError(
-            "GPG key '%s' not found in %s" % (key_id, source_keyring_file)
+            "GPG key '{}' not found in {}".format(key_id, source_keyring_file)
         )
     if not os.path.exists(destination_keyfile):
         msg = "Unexpected error exporting GPG key '{}' from {}".format(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -58,7 +58,7 @@ class TestFindAptListFilesFromRepoSeries:
     @mock.patch('uaclient.util.subp')
     def test_find_all_apt_list_files_from_apt_config_key(self, m_subp, tmpdir):
         """Find all matching apt list files from apt-config dir."""
-        m_subp.return_value = ("key='%s'" % tmpdir.strpath, '')
+        m_subp.return_value = ("key='{}'".format(tmpdir.strpath), '')
         repo_url = 'http://c.com/fips-updates/'
         _protocol, repo_path = repo_url.split('://')
         prefix = repo_path.rstrip('/').replace('/', '_')
@@ -83,7 +83,7 @@ class TestRemoveAptListFiles:
         self, m_subp, tmpdir
     ):
         """Remove all matching apt list files from apt-config dir."""
-        m_subp.return_value = ("key='%s'" % tmpdir.strpath, '')
+        m_subp.return_value = ("key='{}'".format(tmpdir.strpath), '')
         repo_url = 'http://c.com/fips-updates/'
         _protocol, repo_path = repo_url.split('://')
         prefix = repo_path.rstrip('/').replace('/', '_')
@@ -99,7 +99,7 @@ class TestRemoveAptListFiles:
             util.write_file(path, '')
 
         assert None is remove_apt_list_files(repo_url, 'xenial')
-        assert [nomatch_file] == glob.glob('%s/*' % tmpdir.strpath)
+        assert [nomatch_file] == glob.glob('{}/*'.format(tmpdir.strpath))
 
 
 class TestValidAptCredentials:
@@ -224,8 +224,9 @@ class TestValidAptCredentials:
             )
         error_msg = (
             'Cannot validate credentials for APT repo. Timeout'
-            ' after %d seconds trying to reach fakerepo.'
-            % apt.APT_HELPER_TIMEOUT
+            ' after {} seconds trying to reach fakerepo.'.format(
+                apt.APT_HELPER_TIMEOUT
+            )
         )
         assert error_msg == excinfo.value.msg
         exists_calls = [
@@ -413,8 +414,8 @@ class TestAddAuthAptRepo:
         )
 
         expected_content = (
-            'machine fakerepo/ login user password password%s\n'
-            % APT_AUTH_COMMENT
+            'machine fakerepo/ login user password password'
+            '{}\n'.format(APT_AUTH_COMMENT)
         )
         assert expected_content == util.load_file(auth_file)
 
@@ -450,8 +451,8 @@ class TestAddAuthAptRepo:
         )
 
         expected_content = (
-            'machine fakerepo/ login bearer password SOMELONGTOKEN%s\n'
-            % APT_AUTH_COMMENT
+            'machine fakerepo/ login bearer password'
+            ' SOMELONGTOKEN{}\n'.format(APT_AUTH_COMMENT)
         )
         assert expected_content == util.load_file(auth_file)
 
@@ -480,14 +481,14 @@ class TestAddAptAuthConfEntry:
             login='newlogin', password='newpass', repo_url='http://fakerepo/'
         )
 
-        expected_content = dedent(
+        content_template = dedent(
             """\
             machine fakerepo1/ login me password password1
-            machine fakerepo/ login newlogin password newpass%s
+            machine fakerepo/ login newlogin password newpass{}
             machine fakerepo2/ login other password otherpass
         """
-            % APT_AUTH_COMMENT
         )
+        expected_content = content_template.format(APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
     @mock.patch('uaclient.apt.get_apt_auth_file_from_apt_config')
@@ -515,15 +516,15 @@ class TestAddAptAuthConfEntry:
             repo_url='http://fakerepo/subroute',
         )
 
-        expected_content = dedent(
+        content_template = dedent(
             """\
             machine fakerepo1/ login me password password1
-            machine fakerepo/subroute/ login new password newpass%s
+            machine fakerepo/subroute/ login new password newpass{}
             machine fakerepo/ login old password oldpassword
             machine fakerepo2/ login other password otherpass
         """
-            % APT_AUTH_COMMENT
         )
+        expected_content = content_template.format(APT_AUTH_COMMENT)
         assert expected_content == util.load_file(auth_file)
 
 

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -21,9 +21,9 @@ class TestProcessEntitlementDeltas:
     def test_error_on_missing_entitlement_type(self):
         """Raise an error when neither dict contains entitlement type."""
         new_access = {'entitlement': {'something': 'non-empty'}}
-        error_msg = 'Could not determine contract delta service type %s %s' % (
-            {},
-            new_access,
+        error_msg = (
+            'Could not determine contract delta service type'
+            ' {{}} {}'.format(new_access)
         )
         with pytest.raises(RuntimeError) as exc:
             process_entitlement_delta({}, new_access)

--- a/uaclient/tests/test_gpg.py
+++ b/uaclient/tests/test_gpg.py
@@ -37,9 +37,8 @@ class TestExportGPGKeyFromKeyring:
                 destination_keyfile=destination_keyfile,
             )
 
-        error_msg = "GPG key '%s' not found in %s" % (
-            key_id,
-            src_keyring.strpath,
+        error_msg = "GPG key '{}' not found in {}".format(
+            key_id, src_keyring.strpath
         )
         assert error_msg in str(excinfo.value)
         assert not os.path.exists(destination_keyfile)
@@ -64,7 +63,9 @@ class TestExportGPGKeyFromKeyring:
         )
         assert 'ERROR    {}'.format(msg) in caplog_text()
         assert not os.path.exists(destination_keyfile)
-        msg = 'Unable to export GPG keys from keyring %s' % (source_keyring,)
+        msg = 'Unable to export GPG keys from keyring {}'.format(
+            source_keyring
+        )
         assert msg == str(excinfo.value)
 
     def test_export_single_key_from_keyring(self, home_dir, tmpdir):


### PR DESCRIPTION
Except in a couple of cases where we were mistakenly doing a %-format
for a log message, where the fix is to pass the %-format arguments as
parameters.