### PR TITLE
ux: new messaging during ua enable failures

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 import logging
 
 from uaclient import exceptions
+from uaclient import status
 from uaclient import serviceclient
 from uaclient import util
 
@@ -218,6 +220,12 @@ def request_updated_contract(
         new_token = contract_client.request_machine_token_refresh(
             machine_token=machine_token, contract_id=contract_id
         )
+    expiry = new_token["machineTokenInfo"]["contractInfo"].get("effectiveTo")
+    if expiry:
+        if datetime.strptime(expiry, "%Y-%m-%dT%H:%M:%SZ") < datetime.utcnow():
+            raise exceptions.UserFacingError(
+                status.MESSAGE_CONTRACT_EXPIRED_ERROR
+            )
     user_errors = []
     for name, entitlement in sorted(cfg.entitlements.items()):
         if entitlement["entitlement"].get("entitled"):

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -124,7 +124,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "Test Concrete Entitlement is not currently enabled.\n"
-            "See `ua status`\n"
+            "See: sudo ua status\n"
         )
         stdout, _ = capsys.readouterr()
         assert expected_stdout == stdout
@@ -158,7 +158,7 @@ class TestUaEntitlement:
 
         expected_stdout = (
             "This subscription is not entitled to Test Concrete Entitlement.\n"
-            "See `ua status` or https://ubuntu.com/advantage\n"
+            "See: sudo ua status or https://ubuntu.com/advantage\n"
         )
         if silent:
             expected_stdout = ""
@@ -184,7 +184,8 @@ class TestUaEntitlement:
         assert not entitlement.can_enable(**kwargs)
 
         expected_stdout = (
-            "Test Concrete Entitlement is already enabled.\nSee `ua status`\n"
+            "Test Concrete Entitlement is already enabled.\n"
+            "See: sudo ua status\n"
         )
         if silent:
             expected_stdout = ""

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -24,5 +24,5 @@ class NonRootUserError(UserFacingError):
 class UnattachedError(UserFacingError):
     """An exception to be raised when a machine needs to be attached."""
 
-    def __init__(self) -> None:
-        super().__init__(status.MESSAGE_UNATTACHED)
+    def __init__(self, msg: str = status.MESSAGE_UNATTACHED) -> None:
+        super().__init__(msg)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -101,10 +101,11 @@ MESSAGE_APT_POLICY_FAILED = "Failure checking APT policy."
 MESSAGE_DISABLED_TMPL = "{title} disabled."
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
 MESSAGE_ALREADY_DISABLED_TMPL = """\
-{title} is not currently enabled.\nSee `ua status`"""
+{title} is not currently enabled.\nSee: sudo ua status"""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
 MESSAGE_ENABLED_TMPL = "{title} enabled."
-MESSAGE_ALREADY_ENABLED_TMPL = "{title} is already enabled.\nSee `ua status`"
+MESSAGE_ALREADY_ENABLED_TMPL = """\
+{title} is already enabled.\nSee: sudo ua status"""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\
 {title} is not available for platform {arch}.
 Supported platforms are: {supported_arches}"""
@@ -118,7 +119,7 @@ MESSAGE_INAPPLICABLE_KERNEL_VER_TMPL = """\
 Minimum kernel version required: {min_kernel}"""
 MESSAGE_UNENTITLED_TMPL = """\
 This subscription is not entitled to {title}.
-See `ua status` or https://ubuntu.com/advantage"""
+See: sudo ua status or https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
 See `ua attach` or https://ubuntu.com/advantage"""
@@ -132,9 +133,19 @@ MESSAGE_ATTACH_SUCCESS_TMPL = """\
 This machine is now attached to '{contract_name}'.
 """
 
-MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
+MESSAGE_CONTRACT_EXPIRED_ERROR = """\
+Subscription has expired
+To obtain a token please visit: https://ubuntu.com/advantage"""
+MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
+Cannot {operation} '{name}'
+For a list of services see: sudo ua status"""
+MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
+To use '{name}' you need an Ubuntu Advantage subscription.
+Personal and community subscriptions are available at no charge
+See https://ubuntu.com/advantage"""
+MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service '{name}'"
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
-Service {name} is recommended by default. To enable run `ua enable {name}`"""
+Service '{name}' is recommended by default. To enable run: ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"
 
 MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -17,7 +17,7 @@ from uaclient.testing.fakes import FakeConfig
 
 class TestAssertAttachedRoot:
     def test_assert_attached_root_happy_path(self, capsys):
-        @assert_attached_root
+        @assert_attached_root()
         def test_function(args, cfg):
             return mock.sentinel.success
 
@@ -42,7 +42,7 @@ class TestAssertAttachedRoot:
     def test_assert_attached_root_exceptions(
         self, attached, uid, expected_exception
     ):
-        @assert_attached_root
+        @assert_attached_root()
         def test_function(args, cfg):
             return mock.sentinel.success
 
@@ -106,7 +106,7 @@ class TestMain:
 
         out, err = capsys.readouterr()
         assert "" == out
-        assert "ERROR: {}\n".format(msg) == err
+        assert "{}\n".format(msg) == err
         error_log = caplog_text()
         assert msg in error_log
         assert "Traceback (most recent call last):" in error_log

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -2,7 +2,47 @@ import mock
 
 import pytest
 
-from uaclient.cli import _perform_enable
+from uaclient.cli import _perform_enable, action_enable
+from uaclient import exceptions
+from uaclient import status
+from uaclient.testing.fakes import FakeConfig
+
+
+@mock.patch("uaclient.cli.os.getuid")
+class TestActionEnable:
+    def test_non_root_users_are_rejected(self, getuid):
+        """Check that a UID != 0 will receive a message and exit non-zero"""
+        getuid.return_value = 1
+
+        cfg = FakeConfig.for_attached_machine()
+        with pytest.raises(exceptions.NonRootUserError):
+            action_enable(mock.MagicMock(), cfg)
+
+    def test_unattached_error_message(self, getuid):
+        """Check that root user gets unattached message."""
+
+        getuid.return_value = 0
+        cfg = FakeConfig()
+        with pytest.raises(exceptions.UserFacingError) as err:
+            args = mock.MagicMock()
+            args.name = "esm"
+            action_enable(args, cfg)
+        assert status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL.format(
+            name="esm"
+        ) == str(err.value)
+
+    def test_invalid_service_error_message(self, getuid):
+        """Check invalid service name results in custom error message."""
+
+        getuid.return_value = 0
+        cfg = FakeConfig.for_attached_machine()
+        with pytest.raises(exceptions.UserFacingError) as err:
+            args = mock.MagicMock()
+            args.name = "bogus"
+            action_enable(args, cfg)
+        assert status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL.format(
+            operation="enable", name="bogus"
+        ) == str(err.value)
 
 
 class TestPerformEnable:

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -9,6 +9,7 @@ from uaclient.contract import (
     request_updated_contract,
 )
 from uaclient import exceptions
+from uaclient.status import MESSAGE_CONTRACT_EXPIRED_ERROR
 
 from uaclient.testing.fakes import FakeConfig, FakeContractClient
 
@@ -248,3 +249,50 @@ class TestRequestUpdatedContract:
             ),
         ]
         assert process_calls == process_entitlement_delta.call_args_list
+
+    @mock.patch(M_PATH + "process_entitlement_delta")
+    @mock.patch("uaclient.util.get_machine_id", return_value="mid")
+    @mock.patch(M_PATH + "UAContractClient")
+    def test_attached_config_refresh_errors_on_expired_contract(
+        self, client, get_machine_id, process_entitlement_delta
+    ):
+        """Error when refreshing contract parses an expired contract token."""
+
+        machine_token = {
+            "machineToken": "mToken",
+            "machineTokenInfo": {
+                "contractInfo": {
+                    "effectiveTo": "2018-07-18T00:00:00Z",  # Expired date
+                    "id": "cid",
+                    "resourceEntitlements": [
+                        {"entitled": False, "type": "ent2"},
+                        {"entitled": True, "type": "ent1"},
+                    ],
+                }
+            },
+        }
+
+        def fake_contract_client(cfg):
+            client = FakeContractClient(cfg)
+            # Note ent2 access route is not called
+            client._responses = {
+                self.refresh_route: machine_token,
+                self.access_route_ent1: {
+                    "entitlement": {
+                        "entitled": True,
+                        "type": "ent1",
+                        "new": "newval",
+                    }
+                },
+            }
+            return client
+
+        client.side_effect = fake_contract_client
+        cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
+        with pytest.raises(exceptions.UserFacingError) as exc:
+            request_updated_contract(cfg)
+        assert MESSAGE_CONTRACT_EXPIRED_ERROR == str(exc.value)
+        assert machine_token == cfg.read_cache("machine-token")
+
+        # No deltas are processed when contract is expired
+        assert 0 == process_entitlement_delta.call_count


### PR DESCRIPTION
 - exceptions.UnattachedError accepts an optional msg param allowing for
   override with specific "Cannot use `blah` with Personal or community
   subscription"
 - On unattached machine, a ua enable <x> will message about Personal and
   community subscription availability @ https://ubuntu.com/advantage
 - Upon contract expiry and alert "Subscription has expired" during
   ua enable X
 - On ua enable <invalid service name>, Cannot enable ‘foobar’...
 - Drop leading ERROR: prefix for UserFacingErrors on the console

Fixes: #723