### PR TITLE
ux: new messaging on ua disable failures

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -164,13 +164,9 @@ def disable_parser(parser=None):
         parser.prog = "disable"
     parser._positionals.title = "Services"
     parser._optionals.title = "Flags"
-    entitlement_names = list(
-        cls.name for cls in entitlements.ENTITLEMENT_CLASSES
-    )
     parser.add_argument(
         "name",
         action="store",
-        choices=entitlement_names,
         help="The name of the support service to disable",
     )
     return parser
@@ -206,12 +202,18 @@ def status_parser(parser=None):
     return parser
 
 
-@assert_attached_root()
+@assert_attached_root(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 def action_disable(args, cfg):
     """Perform the disable action on a named entitlement.
 
     @return: 0 on success, 1 otherwise
     """
+    if args.name not in entitlements.ENTITLEMENT_CLASS_BY_NAME:
+        raise exceptions.UserFacingError(
+            ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL.format(
+                operation="disable", name=args.name
+            )
+        )
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     ret = 0 if entitlement.disable() else 1

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -2,6 +2,9 @@ import mock
 import pytest
 
 from uaclient.cli import action_disable
+from uaclient import exceptions
+from uaclient import status
+from uaclient.testing.fakes import FakeConfig
 
 
 class TestDisable:
@@ -33,3 +36,27 @@ class TestDisable:
         assert return_code == ret
 
         assert 1 == m_cfg.status.call_count
+
+    @mock.patch("uaclient.cli.os.getuid", return_value=0)
+    def test_invalid_service_error_message(self, m_getuid):
+        """Check invalid service name results in custom error message."""
+        cfg = FakeConfig.for_attached_machine()
+        with pytest.raises(exceptions.UserFacingError) as err:
+            args = mock.MagicMock()
+            args.name = "bogus"
+            action_disable(args, cfg)
+        assert status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL.format(
+            operation="disable", name="bogus"
+        ) == str(err.value)
+
+    @mock.patch("uaclient.cli.os.getuid", return_value=0)
+    def test_unattached_error_message(self, m_getuid):
+        """Check that root user gets unattached message."""
+        cfg = FakeConfig()
+        with pytest.raises(exceptions.UserFacingError) as err:
+            args = mock.MagicMock()
+            args.name = "esm"
+            action_disable(args, cfg)
+        assert status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL.format(
+            name="esm"
+        ) == str(err.value)


### PR DESCRIPTION
- On ua enable <invalid service name>, Cannot enable 'foobar'...
- When unattached,  ua disable <x> will message about Personal and
  community subscription availability @ https://ubuntu.com/advantage

Fixes: #725