### PR TITLE
cli: fix minor nit in help output for enable and disable

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -140,7 +140,7 @@ def enable_parser(parser=None):
     else:
         parser.usage = usage
         parser.prog = "enable"
-    parser._positionals.title = "Services"
+    parser._positionals.title = "Arguments"
     parser._optionals.title = "Flags"
     parser.add_argument(
         "name",
@@ -162,7 +162,7 @@ def disable_parser(parser=None):
     else:
         parser.usage = usage
         parser.prog = "disable"
-    parser._positionals.title = "Services"
+    parser._positionals.title = "Arguments"
     parser._optionals.title = "Flags"
     parser.add_argument(
         "name",


### PR DESCRIPTION
Changes the help text from:

```
usage: ubuntu-advantage enable [flags] <name>

Services:
  name        The name of the support service to enable

Flags:
  -h, --help  show this help message and exit
```

to the more clear:

```
usage: ubuntu-advantage enable [flags] <name>

Arguments:
  name        The name of the support service to enable

Flags:
  -h, --help  show this help message and exit
```

(And does the same for disable, too.)