### PR TITLE
serviceclient: handle non-HTTPErrors gracefully

### DIFF
--- a/uaclient/serviceclient.py
+++ b/uaclient/serviceclient.py
@@ -59,5 +59,7 @@ class UAServiceClient(metaclass=abc.ABCMeta):
                     error_details = None
                 if error_details:
                     raise self.api_error_cls(e, error_details)
-            raise util.UrlError(e, code=e.code, headers=headers, url=url)
+            raise util.UrlError(
+                e, code=getattr(e, "code", None), headers=headers, url=url
+            )
         return response, headers


### PR DESCRIPTION
The code previously was attempting to access `e.code`, which will only
exist on HTTPError instances.  As a result, more general URLErrors would
cause an unexpected traceback, which would be exposed to users.

Fixes #740