### PR TITLE
ux: esm service renamed to esm-infra

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python
 
-"""\
-Client to manage Ubuntu Advantage support services on a machine.
-
-Available services:
- - cc-eal: Canonical Common Criteria EAL2 Provisioning
-   (https://ubuntu.com/cc-eal)
- - cis-audit: Canonical CIS Benchmark Audit Tool (https://ubuntu.com/cis)
- - esm: Extended Security Maintenance (https://ubuntu.com/esm)
- - fips: FIPS 140-2 (https://ubuntu.com/fips)
- - fips-updates: FIPS 140-2 with updates
- - livepatch: Canonical Livepatch (https://ubuntu.com/livepatch)
-
-"""
+"""Client to manage Ubuntu Advantage support services on a machine."""
 
 import argparse
 from functools import wraps
@@ -323,10 +311,20 @@ def action_attach(args, cfg):
 
 
 def get_parser():
+    service_line_tmpl = " - {name}: {description}{url}"
+    description_lines = [__doc__]
+    sorted_classes = sorted(entitlements.ENTITLEMENT_CLASS_BY_NAME.items())
+    for name, ent_cls in sorted_classes:
+        if ent_cls.help_doc_url:
+            url = " ({})".format(ent_cls.help_doc_url)
+        else:
+            url = ""
+        description.append(service_line_tmpl.format(name=name, description=ent_cls.description, url=url)
+
     parser = argparse.ArgumentParser(
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=__doc__,
+        description="\n".join(description),
         usage=USAGE_TMPL.format(name=NAME, command="[command]"),
         epilog=EPILOG_TMPL.format(name=NAME, command="[command]"),
     )

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -319,12 +319,23 @@ def get_parser():
             url = " ({})".format(ent_cls.help_doc_url)
         else:
             url = ""
-        description.append(service_line_tmpl.format(name=name, description=ent_cls.description, url=url)
+        service_line = service_line_tmpl.format(
+            name=name, description=ent_cls.description, url=url
+        )
+        if len(service_line) <= 80:
+            description_lines.append(service_line)
+        else:
+            wrapped_words = []
+            line = service_line
+            while len(line) > 80:
+                [line, wrapped_word] = line.rsplit(" ", 1)
+                wrapped_words.insert(0, wrapped_word)
+            description_lines.extend([line, "   " + " ".join(wrapped_words)])
 
     parser = argparse.ArgumentParser(
         prog=NAME,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="\n".join(description),
+        description="\n".join(description_lines),
         usage=USAGE_TMPL.format(name=NAME, command="[command]"),
         epilog=EPILOG_TMPL.format(name=NAME, command="[command]"),
     )

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -115,8 +115,7 @@ class UAContractClient(serviceclient.UAServiceClient):
 
         @param machine_token: The authentication token needed to talk to
             this contract service endpoint.
-        @param resource: Entitlement name. One of: livepatch, esm, fips or
-            fips-updates.
+        @param resource: Entitlement name.
         @param machine_id: Optional unique system machine id. When absent,
             contents of /etc/machine-id will be used.
 

--- a/uaclient/entitlements/__init__.py
+++ b/uaclient/entitlements/__init__.py
@@ -22,6 +22,7 @@ ENTITLEMENT_CLASSES = [
     LivepatchEntitlement,
 ]  # type: List[Type[UAEntitlement]]
 
+
 ENTITLEMENT_CLASS_BY_NAME = dict(
     (cast(str, cls.name), cls) for cls in ENTITLEMENT_CLASSES
 )  # type: Dict[str, Type[UAEntitlement]]

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -28,6 +28,10 @@ RE_KERNEL_UNAME = (
 
 
 class UAEntitlement(metaclass=abc.ABCMeta):
+
+    # Optional URL for top-level product service information
+    help_doc_url = None  # type: str
+
     @property
     @abc.abstractmethod
     def name(self) -> str:

--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -5,6 +5,7 @@ CC_README = "/usr/share/doc/ubuntu-commoncriteria/README"
 
 class CommonCriteriaEntitlement(repo.RepoEntitlement):
 
+    help_doc_url = "https://ubuntu.com/cc-eal"
     name = "cc-eal"
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -3,6 +3,7 @@ from uaclient.entitlements import repo
 
 class CISEntitlement(repo.RepoEntitlement):
 
+    help_doc_url = "https://ubuntu.com/cis-audit"
     name = "cis-audit"
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -3,7 +3,8 @@ from uaclient.entitlements import repo
 
 class ESMEntitlement(repo.RepoEntitlement):
 
-    name = "esm"
+    help_doc_url = "https://ubuntu.com/esm"
+    name = "esm-infra"
     title = "ESM Infra"
     origin = "UbuntuESM"
     description = "UA Infra: Extended Security Maintenance"

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -55,6 +55,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
 
 class FIPSEntitlement(FIPSCommonEntitlement):
 
+    help_doc_url = "https://ubuntu.com/fips"
     name = "fips"
     title = "FIPS"
     description = "NIST-certified FIPS modules"

--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -22,6 +22,7 @@ ERROR_MSG_MAP = {
 
 class LivepatchEntitlement(base.UAEntitlement):
 
+    help_doc_url = "https://ubuntu.com/livepatch"
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -26,7 +26,7 @@ class TestESMEntitlementEnable:
         original_exists = os.path.exists
 
         def fake_exists(path):
-            if path == "/etc/apt/preferences.d/ubuntu-esm-trusty":
+            if path == "/etc/apt/preferences.d/ubuntu-esm-infra-trusty":
                 return True
             if path in (apt.APT_METHOD_HTTPS_FILE, apt.CA_CERTIFICATES_FILE):
                 return True
@@ -72,7 +72,7 @@ class TestESMEntitlementEnable:
                 "/etc/apt/sources.list.d/ubuntu-{}-trusty.list".format(
                     entitlement.name
                 ),
-                "http://ESM",
+                "http://ESM-INFRA",
                 "TOKEN",
                 ["trusty"],
                 "APTKEY",
@@ -98,7 +98,9 @@ class TestESMEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         assert 0 == m_add_pinning.call_count
         assert subp_calls == m_subp.call_args_list
-        unlink_calls = [mock.call("/etc/apt/preferences.d/ubuntu-esm-trusty")]
+        unlink_calls = [
+            mock.call("/etc/apt/preferences.d/ubuntu-esm-infra-trusty")
+        ]
         assert unlink_calls == m_unlink.call_args_list
 
     def test_enable_cleans_up_apt_sources_and_auth_files_on_error(
@@ -108,7 +110,7 @@ class TestESMEntitlementEnable:
         original_exists = os.path.exists
 
         def fake_exists(path):
-            if path == "/etc/apt/preferences.d/ubuntu-esm-trusty":
+            if path == "/etc/apt/preferences.d/ubuntu-esm-infra-trusty":
                 return True
             if path in (apt.APT_METHOD_HTTPS_FILE, apt.CA_CERTIFICATES_FILE):
                 return True
@@ -159,7 +161,7 @@ class TestESMEntitlementEnable:
                 "/etc/apt/sources.list.d/ubuntu-{}-trusty.list".format(
                     entitlement.name
                 ),
-                "http://ESM",
+                "http://ESM-INFRA",
                 "TOKEN",
                 ["trusty"],
                 "APTKEY",
@@ -180,7 +182,9 @@ class TestESMEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         assert 0 == m_add_pinning.call_count
         assert subp_calls == m_subp.call_args_list
-        unlink_calls = [mock.call("/etc/apt/preferences.d/ubuntu-esm-trusty")]
+        unlink_calls = [
+            mock.call("/etc/apt/preferences.d/ubuntu-esm-infra-trusty")
+        ]
         assert unlink_calls == m_unlink.call_args_list
         assert [mock.call()] == m_remove_apt_config.call_args_list
 
@@ -225,15 +229,15 @@ class TestESMEntitlementDisable:
         # Disable esm repo again
         write_calls = [
             mock.call(
-                "/etc/apt/preferences.d/ubuntu-esm-trusty",
+                "/etc/apt/preferences.d/ubuntu-esm-infra-trusty",
                 "Package: *\nPin: release o=UbuntuESM, n=trusty\n"
                 "Pin-Priority: never\n",
             )
         ]
         assert write_calls == m_write.call_args_list
         assert [mock.call(True)] == m_can_disable.call_args_list
-        auth_call = mock.call("http://ESM")
+        auth_call = mock.call("http://ESM-INFRA")
         assert [auth_call] == m_rm_repo_from_auth.call_args_list
         assert [
-            mock.call("/etc/apt/sources.list.d/ubuntu-esm-trusty.list")
+            mock.call("/etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list")
         ] == m_restore_commented_apt_list_file.call_args_list

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -55,8 +55,8 @@ class TestDisable:
         cfg = FakeConfig()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
-            args.name = "esm"
+            args.name = "esm-infra"
             action_disable(args, cfg)
         assert status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL.format(
-            name="esm"
+            name="esm-infra"
         ) == str(err.value)

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -374,14 +374,14 @@ class TestStatus:
         """Test we get the correct status dict when unattached"""
         cfg = FakeConfig({})
         m_get_available_resources.return_value = [
-            {"name": "esm", "available": True},
+            {"name": "esm-infra", "available": True},
             {"name": "fips", "available": False},
         ]
-        esm_desc = ENTITLEMENT_CLASS_BY_NAME["esm"].description
+        esm_desc = ENTITLEMENT_CLASS_BY_NAME["esm-infra"].description
         fips_desc = ENTITLEMENT_CLASS_BY_NAME["fips"].description
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected["services"] = [
-            {"available": "yes", "name": "esm", "description": esm_desc},
+            {"available": "yes", "name": "esm-infra", "description": esm_desc},
             {"available": "no", "name": "fips", "description": fips_desc},
         ]
         assert expected == cfg.status()

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -50,7 +50,7 @@ class TestProcessEntitlementDeltas:
         self, m_process_contract_deltas
     ):
         """Call entitlement.process_contract_deltas to handle any deltas."""
-        original_access = {"entitlement": {"type": "esm"}}
+        original_access = {"entitlement": {"type": "esm-infra"}}
         new_access = copy.deepcopy(original_access)
         new_access["entitlement"]["newkey"] = "newvalue"
         expected = {"entitlement": {"newkey": "newvalue"}}
@@ -67,7 +67,7 @@ class TestProcessEntitlementDeltas:
         """Process and report full deltas on empty original access dict."""
         # Limit delta processing logic to handle attached state-A to state-B
         # Fresh installs will have empty/unset
-        new_access = {"entitlement": {"type": "esm", "other": "val2"}}
+        new_access = {"entitlement": {"type": "esm-infra", "other": "val2"}}
         assert new_access == process_entitlement_delta({}, new_access)
         expected_calls = [mock.call({}, new_access, allow_enable=False)]
         assert expected_calls == m_process_contract_deltas.call_args_list


### PR DESCRIPTION
User docs, cli and contracts backend will now all refer to esm as esm-infra in preparation for the eventual esm-apps service.  Even though ESM for Apps will not be on trusty, we want to align the service name on all distributions to avoid confusion.

To support this change
 - ESMEntitlement.name is now esm-infra
 - ua --help docs now source *Entitlement.description values to avoid updating two places in source
    with the same text

Fixes: #724