### PR TITLE
ux: add attached status description column and headers

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -233,6 +233,7 @@ class UAConfig:
 
     def _attached_status(self) -> "Dict[str, Any]":
         """Return configuration of attached status as a dictionary."""
+        from uaclient.contract import get_available_resources
         from uaclient.entitlements import ENTITLEMENT_CLASSES
 
         response = copy.deepcopy(DEFAULT_STATUS)
@@ -249,10 +250,20 @@ class UAConfig:
             response["expires"] = datetime.strptime(
                 contractInfo["effectiveTo"], "%Y-%m-%dT%H:%M:%SZ"
             )
+
+        resources = get_available_resources(self)
+        unavailable_resources = [
+            resource["name"]
+            for resource in sorted(resources, key=lambda x: x["name"])
+            if not resource["available"]
+        ]
+
         for ent_cls in ENTITLEMENT_CLASSES:
             ent = ent_cls(self)
             contract_status = ent.contract_status().value
             ent_status, details = ent.user_facing_status()
+            if ent.name in unavailable_resources:
+                ent_status = status.UserFacingStatus.UNAVAILABLE
             service_status = {
                 "name": ent.name,
                 "description": ent.description,

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -255,6 +255,7 @@ class UAConfig:
             ent_status, details = ent.user_facing_status()
             service_status = {
                 "name": ent.name,
+                "description": ent.description,
                 "entitled": contract_status,
                 "status": ent_status.value,
                 "statusDetails": details,

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -75,10 +75,11 @@ class UserFacingStatus(enum.Enum):
     business logic.
     """
 
-    ACTIVE = "active"
-    INACTIVE = "inactive"
+    ACTIVE = "enabled"
+    INACTIVE = "disabled"
     INAPPLICABLE = "n/a"
     PENDING = "pending"
+    UNAVAILABLE = "—"
 
 
 ESSENTIAL = "essential"
@@ -101,6 +102,11 @@ STATUS_COLOR = {
         + UserFacingStatus.INAPPLICABLE.value
         + TxtColor.ENDC
     ),  # noqa: E501
+    UserFacingStatus.UNAVAILABLE.value: (
+        TxtColor.DISABLEGREY
+        + UserFacingStatus.UNAVAILABLE.value
+        + TxtColor.ENDC
+    ),
     ContractStatus.ENTITLED.value: (
         TxtColor.OKGREEN + ContractStatus.ENTITLED.value + TxtColor.ENDC
     ),

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -27,6 +27,15 @@ KNOWN_DATA_PATHS = (("machine-token", "machine-token.json"),)
 M_PATH = "uaclient.entitlements."
 
 
+RESP_ALL_RESOURCES_AVAILABLE = [
+    {"name": name, "available": True} for name in ENTITLEMENT_CLASS_BY_NAME
+]
+RESP_ONLY_FIPS_RESOURCE_AVAILABLE = [
+    {"name": name, "available": name == "fips"}
+    for name in ENTITLEMENT_CLASS_BY_NAME
+]
+
+
 class TestEntitlements:
     def test_entitlements_property_keyed_by_entitlement_name(self, tmpdir):
         """Return machine_token resourceEntitlements, keyed by name."""
@@ -377,20 +386,36 @@ class TestStatus:
         ]
         assert expected == cfg.status()
 
+    @pytest.mark.parametrize(
+        "resources,get_avail_resp",
+        (
+            (
+                entitlements.ENTITLEMENT_CLASS_BY_NAME.keys(),
+                RESP_ALL_RESOURCES_AVAILABLE,
+            ),
+            ("fips", RESP_ONLY_FIPS_RESOURCE_AVAILABLE),
+        ),
+    )
+    @mock.patch("uaclient.contract.get_available_resources")
     @mock.patch("uaclient.config.os.getuid", return_value=0)
-    def test_root_attached(self, _m_getuid):
+    def test_root_attached(
+        self, _m_getuid, m_get_available_resources, resources, get_avail_resp
+    ):
         """Test we get the correct status dict when attached with basic conf"""
         cfg = FakeConfig.for_attached_machine()
+        inapplicable = status.UserFacingStatus.INAPPLICABLE.value
+        unavail = status.UserFacingStatus.UNAVAILABLE.value
         expected_services = [
             {
                 "description": cls.description,
                 "entitled": status.ContractStatus.UNENTITLED.value,
                 "name": cls.name,
-                "status": status.UserFacingStatus.INAPPLICABLE.value,
+                "status": inapplicable if cls.name in resources else unavail,
                 "statusDetails": mock.ANY,
             }
             for cls in entitlements.ENTITLEMENT_CLASSES
         ]
+        m_get_available_resources.return_value = get_avail_resp
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected.update(
             {
@@ -419,10 +444,10 @@ class TestStatus:
 
         assert root_unattached_status == nonroot_status
 
-    @mock.patch("uaclient.contract.get_available_resources", return_value=[])
+    @mock.patch("uaclient.contract.get_available_resources")
     @mock.patch("uaclient.config.os.getuid")
     def test_root_followed_by_nonroot(
-        self, m_getuid, _m_get_available_resources, tmpdir
+        self, m_getuid, m_get_available_resources, tmpdir
     ):
         """Ensure that non-root run after root returns data"""
         cfg = UAConfig({"data_dir": tmpdir.strpath})
@@ -470,13 +495,20 @@ class TestStatus:
             ],
         ),
     )
+    @mock.patch("uaclient.contract.get_available_resources")
     @mock.patch("uaclient.config.os.getuid", return_value=0)
     @mock.patch(M_PATH + "livepatch.LivepatchEntitlement.user_facing_status")
     @mock.patch(M_PATH + "repo.RepoEntitlement.user_facing_status")
     def test_attached_reports_contract_and_service_status(
-        self, m_repo_uf_status, m_livepatch_uf_status, _m_getuid, entitlements
+        self,
+        m_repo_uf_status,
+        m_livepatch_uf_status,
+        _m_getuid,
+        m_get_available_resources,
+        entitlements,
     ):
         """When attached, return contract and service user-facing status."""
+        m_get_available_resources.return_value = RESP_ALL_RESOURCES_AVAILABLE
         m_repo_uf_status.return_value = (
             status.UserFacingStatus.INAPPLICABLE,
             "repo details",

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -383,6 +383,7 @@ class TestStatus:
         cfg = FakeConfig.for_attached_machine()
         expected_services = [
             {
+                "description": cls.description,
                 "entitled": status.ContractStatus.UNENTITLED.value,
                 "name": cls.name,
                 "status": status.UserFacingStatus.INAPPLICABLE.value,
@@ -519,6 +520,7 @@ class TestStatus:
             expected["services"].append(
                 {
                     "name": cls.name,
+                    "description": cls.description,
                     "entitled": status.ContractStatus.UNENTITLED.value,
                     "status": expected_status,
                     "statusDetails": details,

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -62,7 +62,7 @@ class TestFormatTabular:
         tabular_output = format_tabular(status_dict_attached)
         colon_idx = None
         for line in tabular_output.splitlines():
-            if ":" not in line:
+            if ":" not in line or "Enable services" in line:
                 # This isn't a header line
                 continue
             if colon_idx is None:
@@ -97,6 +97,6 @@ class TestFormatTabular:
         headers = [
             line.split(":")[0].strip()
             for line in tabular_output.splitlines()
-            if ":" in line
+            if ":" in line and "Enable services" not in line
         ]
         assert list(expected_headers) == headers


### PR DESCRIPTION
- Add new status template for attached machines that includes description column
- Rename UserFacingStatus.(ACTIVE|INACTIVE) printed values:
    active -> "enabled"
    inactive -> "disabled"
- Add new UserFacingStatus.UNAVAILABLE -> "—"