### PR TITLE
packaging: enable esm trusty-infra-updates and -security suites on trusty

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,6 +2,8 @@
 
 set -e
 
+. /etc/os-release  # For VERSION_ID
+
 ESM_KEY_ID_TRUSTY="56F7650A24C9E9ECF87C4D8D4067E40313CB4B13"
 ESM_APT_GPG_KEY="/etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg"
 ESM_APT_GPG_KEY_OLD="/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg"
@@ -20,6 +22,11 @@ export_gpg_key_from_shared_keyring() {
     fi
 }
 
+unconfigure_esm() {
+    rm -f $ESM_APT_GPG_KEY $ESM_APT_GPG_KEY_OLD $ESM_APT_SOURCE_FILE
+    rm -f $ESM_APT_PREF_FILE
+}
+
 configure_esm() {
     rm -f $ESM_APT_GPG_KEY_OLD  # Remove retired key from key list
     if [ ! -f "$ESM_APT_GPG_KEY" ]; then
@@ -29,11 +36,11 @@ configure_esm() {
     if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
         cat > $ESM_APT_SOURCE_FILE <<EOF
 # Written by ubuntu-advantage-tools
-deb https://esm.ubuntu.com/ubuntu trusty-security main
-# deb-src https://esm.ubuntu.com/ubuntu trusty-security main
+deb https://esm.ubuntu.com/ubuntu trusty-infra-security main
+# deb-src https://esm.ubuntu.com/ubuntu trusty-infra-security main
 
-deb https://esm.ubuntu.com/ubuntu trusty-updates main
-# deb-src https://esm.ubuntu.com/ubuntu trusty-updates main
+deb https://esm.ubuntu.com/ubuntu trusty-infra-updates main
+# deb-src https://esm.ubuntu.com/ubuntu trusty-infra-updates main
 EOF
     fi
     if [ ! -e "$ESM_APT_PREF_FILE" ]; then
@@ -67,7 +74,11 @@ case "$1" in
       # CACHE_DIR is no longer present or used since 19.1
       rm -rf /var/cache/ubuntu-advantage-tools
 
-      grep -iq trusty /etc/os-release && configure_esm
+      if [ "14.04" = "$VERSION_ID" ]; then
+        configure_esm
+      else
+        unconfigure_esm
+      fi
       if [ ! -f /var/log/ubuntu-advantage.log ]; then
           touch /var/log/ubuntu-advantage.log
       fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -7,7 +7,8 @@ set -e
 ESM_KEY_ID_TRUSTY="56F7650A24C9E9ECF87C4D8D4067E40313CB4B13"
 ESM_APT_GPG_KEY="/etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg"
 ESM_APT_GPG_KEY_OLD="/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg"
-ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
+ESM_APT_SOURCE_FILE_OLD="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
+ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list"
 ESM_APT_PREF_FILE="/etc/apt/preferences.d/ubuntu-esm-trusty"
 UA_KEYRING_FILE="/usr/share/keyrings/ubuntu-advantage-keyring.gpg"
 
@@ -33,6 +34,9 @@ configure_esm() {
         export_gpg_key_from_shared_keyring $ESM_KEY_ID_TRUSTY
     fi
 
+    if [ -e "$ESM_APT_SOURCE_FILE_OLD" ]; then
+	mv $ESM_APT_SOURCE_FILE_OLD $ESM_APT_SOURCE_FILE
+    fi
     if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
         cat > $ESM_APT_SOURCE_FILE <<EOF
 # Written by ubuntu-advantage-tools

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,7 +9,8 @@ ESM_APT_GPG_KEY="/etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg"
 ESM_APT_GPG_KEY_OLD="/etc/apt/trusted.gpg.d/ubuntu-esm-keyring.gpg"
 ESM_APT_SOURCE_FILE_OLD="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
 ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list"
-ESM_APT_PREF_FILE="/etc/apt/preferences.d/ubuntu-esm-trusty"
+ESM_APT_PREF_FILE_OLD="/etc/apt/preferences.d/ubuntu-esm-trusty"
+ESM_APT_PREF_FILE="/etc/apt/preferences.d/ubuntu-esm-infra-trusty"
 UA_KEYRING_FILE="/usr/share/keyrings/ubuntu-advantage-keyring.gpg"
 
 
@@ -25,7 +26,7 @@ export_gpg_key_from_shared_keyring() {
 
 unconfigure_esm() {
     rm -f $ESM_APT_GPG_KEY $ESM_APT_GPG_KEY_OLD $ESM_APT_SOURCE_FILE
-    rm -f $ESM_APT_PREF_FILE
+    rm -f $ESM_APT_PREF_FILE_OLD $ESM_APT_PREF_FILE
 }
 
 configure_esm() {
@@ -35,7 +36,10 @@ configure_esm() {
     fi
 
     if [ -e "$ESM_APT_SOURCE_FILE_OLD" ]; then
-	mv $ESM_APT_SOURCE_FILE_OLD $ESM_APT_SOURCE_FILE
+        mv $ESM_APT_SOURCE_FILE_OLD $ESM_APT_SOURCE_FILE
+    fi
+    if [ -e "$ESM_APT_PREF_FILE_OLD" ]; then
+        mv $ESM_APT_PREF_FILE_OLD $ESM_APT_PREF_FILE
     fi
     if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
         cat > $ESM_APT_SOURCE_FILE <<EOF
@@ -46,17 +50,13 @@ deb https://esm.ubuntu.com/ubuntu trusty-infra-security main
 deb https://esm.ubuntu.com/ubuntu trusty-infra-updates main
 # deb-src https://esm.ubuntu.com/ubuntu trusty-infra-updates main
 EOF
-    fi
-    if [ ! -e "$ESM_APT_PREF_FILE" ]; then
-        ESM_POLICY=`apt-cache policy | grep https://esm.ubuntu.com | awk 'END{print $1}'`
-        if [ "500" != "$ESM_POLICY" ]; then  # we are inactive
-            cat > $ESM_APT_PREF_FILE <<EOF
+        # Automatically disable esm sources via apt preferences until enabled
+        cat > $ESM_APT_PREF_FILE <<EOF
 # Written by ubuntu-advantage-tools
 Package: *
 Pin: release o=UbuntuESM, n=trusty
 Pin-Priority: never
 EOF
-        fi
     fi
 }
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -22,6 +22,7 @@ remove_logs(){
 remove_esm(){
     rm -f /etc/apt/trusted.gpg.d/ubuntu-esm-v2-keyring.gpg
     rm -f /etc/apt/sources.list.d/ubuntu-esm-trusty.list
+    rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list
     rm -f /etc/apt/apt.conf.d/51ubuntu-advantage-esm
     rm -f /etc/apt/preferences.d/ubuntu-esm-trusty
 }

--- a/debian/postrm
+++ b/debian/postrm
@@ -25,6 +25,7 @@ remove_esm(){
     rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list
     rm -f /etc/apt/apt.conf.d/51ubuntu-advantage-esm
     rm -f /etc/apt/preferences.d/ubuntu-esm-trusty
+    rm -f /etc/apt/preferences.d/ubuntu-esm-infra-trusty
 }
 
 case "$1" in


### PR DESCRIPTION
Ensure that esm apt list files are not installed on non-trusty or
removed across package upgrade.

Also add upgrade path from existing ubuntu-advantage-tools v8 (the shell version) which named the apt 
/etc/apt/sources.list.d/ubuntu-esm-trusty.list.

Since service-name is now esm-infra we needed to mv the old filename to the new ubuntu-esm-trusty.list
to maintain properly configured esm apt sources, as well as overwrite the settings if the new-client attaches.


Fixes: #718

Also fix #778 
- Emit Priority-Pin: Never if we are also installing the apt/sources.list.d/*esm file (because we are not enabled for esm package downloads yet)

ESM repos are essentially read-only public for package lists in order to allow non-root users to see upgradable esm packages. Change debian/postinst to automatically create an apt pref file with  Pin-Priority: never for ESM until the service is enabled. This will prevent apt from thinking it has access and credentials to actually download and install esm packages until `ua enable esm` is called (which adds credentials and removes the pin file).
