### PR TITLE
ux: simplified attach console messages

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -138,7 +138,6 @@ def add_auth_apt_repo(
         updates_enabled = True
         break
 
-    logging.info("Enabling authenticated repo: %s", repo_url)
     content = ""
     for suite in suites:
         if series not in suite:
@@ -226,7 +225,6 @@ def remove_auth_apt_repo(
     repo_filename: str, repo_url: str, keyring_file: str = None
 ) -> None:
     """Remove an authenticated apt repo and credentials to the system"""
-    logging.info("Removing authenticated apt repo: %s", repo_url)
     util.del_file(repo_filename)
     if keyring_file:
         util.del_file(keyring_file)

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -172,9 +172,9 @@ MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
 To use '{name}' you need an Ubuntu Advantage subscription.
 Personal and community subscriptions are available at no charge
 See https://ubuntu.com/advantage"""
-MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service '{name}'"
+MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
-Service '{name}' is recommended by default. To enable run: ua enable {name}"""
+Service {name} is recommended by default. Run: sudo ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"
 
 MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"


### PR DESCRIPTION
 - Drop quotes around service name when Enabling default service 'x'
 - Drop apt authenticated repository messages to the 

Fixes: #728
