### PR TITLE
fips: generic reboot required message

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -59,9 +59,7 @@ class FIPSEntitlement(FIPSCommonEntitlement):
     title = "FIPS"
     description = "NIST-certified FIPS modules"
     messaging = {
-        "post_enable": [
-            "FIPS configured and pending, please reboot to make active."
-        ]
+        "post_enable": ["A reboot is required to complete the install"]
     }
     origin = "UbuntuFIPS"
     repo_url = "https://esm.ubuntu.com/fips"


### PR DESCRIPTION
FIPS: generic messaging for reboot required during post_enable. Don't mention pending state.