### PR TITLE
Feature/drop pending state

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -333,7 +333,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         user_facing_status = {
             status.ApplicationStatus.ENABLED: UserFacingStatus.ACTIVE,
             status.ApplicationStatus.DISABLED: UserFacingStatus.INACTIVE,
-            status.ApplicationStatus.PENDING: UserFacingStatus.PENDING,
         }[application_status]
         return user_facing_status, explanation
 

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -38,7 +38,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         if running_kernel.endswith("-fips"):
             return super_status, super_msg
         return (
-            status.ApplicationStatus.PENDING,
+            status.ApplicationStatus.ENABLED,
             "Reboot to FIPS kernel required",
         )
 

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -171,9 +171,10 @@ class TestUaEntitlement:
         (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
     )
     def test_can_enable_false_on_entitlement_active(
-        self, capsys, concrete_entitlement_factory, silent, application_status
+        self, capsys, concrete_entitlement_factory, silent
     ):
-        """When entitlement is ENABLED or PENDING, can_enable returns False."""
+        """When entitlement is ENABLED, can_enable returns False."""
+        application_status = status.ApplicationStatus.ENABLED
         entitlement = concrete_entitlement_factory(
             entitled=True, application_status=(application_status, "")
         )

--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -166,10 +166,6 @@ class TestUaEntitlement:
         assert expected_stdout == stdout
 
     @pytest.mark.parametrize("silent", (True, False, None))
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     def test_can_enable_false_on_entitlement_active(
         self, capsys, concrete_entitlement_factory, silent
     ):
@@ -442,10 +438,6 @@ class TestUaEntitlementUserFacingStatus:
             (
                 status.ApplicationStatus.DISABLED,
                 status.UserFacingStatus.INACTIVE,
-            ),
-            (
-                status.ApplicationStatus.PENDING,
-                status.UserFacingStatus.PENDING,
             ),
         ),
     )

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -70,7 +70,9 @@ class TestFIPSEntitlementEnable:
             stack.enter_context(
                 mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
             )
-            stack.enter_context(mock.patch(M_REPOPATH + "os.path.exists"))
+            m_exists = stack.enter_context(
+                mock.patch(M_REPOPATH + "os.path.exists")
+            )
             # Note that this patch uses a PropertyMock and happens on the
             # entitlement's type because packages is a property
             m_packages = mock.PropertyMock(return_value=patched_packages)
@@ -352,12 +354,12 @@ class TestFIPSEntitlementApplicationStatus:
             ),
             (
                 {"kernel": "4.4.0-148-generic"},
-                status.ApplicationStatus.PENDING,
+                status.ApplicationStatus.ENABLED,
                 "Reboot to FIPS kernel required",
             ),
         ),
     )
-    def test_kernels_are_used_to_switch_enabled_to_pending(
+    def test_kernels_are_used_to_detemine_application_status_message(
         self, entitlement, platform_info, expected_status, expected_msg
     ):
         msg = "sure is some status here"
@@ -390,6 +392,6 @@ class TestFIPSEntitlementApplicationStatus:
 
         expected_status = status.ApplicationStatus.DISABLED
         if isinstance(entitlement, FIPSUpdatesEntitlement):
-            expected_status = status.ApplicationStatus.PENDING
+            expected_status = status.ApplicationStatus.ENABLED
 
         assert expected_status == application_status

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -70,9 +70,7 @@ class TestFIPSEntitlementEnable:
             stack.enter_context(
                 mock.patch(M_GETPLATFORM, return_value={"series": "xenial"})
             )
-            m_exists = stack.enter_context(
-                mock.patch(M_REPOPATH + "os.path.exists")
-            )
+            stack.enter_context(mock.patch(M_REPOPATH + "os.path.exists"))
             # Note that this patch uses a PropertyMock and happens on the
             # entitlement's type because packages is a property
             m_packages = mock.PropertyMock(return_value=patched_packages)

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -261,10 +261,6 @@ class TestLivepatchProcessContractDeltas:
         assert [] == m_setup_livepatch_config.call_args_list
 
     @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
-    @pytest.mark.parametrize(
         "directives,process_directives,process_token",
         (
             ({"caCerts": "new"}, True, False),
@@ -282,9 +278,9 @@ class TestLivepatchProcessContractDeltas:
         directives,
         process_directives,
         process_token,
-        application_status,
     ):
         """Run setup when livepatch ACTIVE and deltas are supported keys."""
+        application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         deltas = {"entitlement": {"directives": directives}}
         assert entitlement.process_contract_deltas({}, deltas, False)
@@ -299,10 +295,6 @@ class TestLivepatchProcessContractDeltas:
             setup_calls = []
         assert setup_calls == m_setup_livepatch_config.call_args_list
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @pytest.mark.parametrize(
         "deltas,process_directives,process_token",
         (
@@ -320,9 +312,9 @@ class TestLivepatchProcessContractDeltas:
         deltas,
         process_directives,
         process_token,
-        application_status,
     ):
         """Run livepatch calls setup when resourceToken changes."""
+        application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         entitlement.process_contract_deltas({}, deltas, False)
         if any([process_directives, process_token]):
@@ -396,10 +388,6 @@ class TestLivepatchEntitlementEnable:
         expected_call = mock.call(silent=bool(silent_if_inapplicable))
         assert [expected_call] == m_can_enable.call_args_list
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.which", return_value=False)
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
@@ -408,6 +396,7 @@ class TestLivepatchEntitlementEnable:
         self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Install snapd and canonical-livepatch snap when not on system."""
+        application_status = status.ApplicationStatus.ENABLED
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert self.mocks_install + self.mocks_config in m_subp.call_args_list
@@ -423,10 +412,6 @@ class TestLivepatchEntitlementEnable:
         ]
         assert expected_calls == m_which.call_args_list
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch("uaclient.util.subp", return_value=("snapd", ""))
     @mock.patch(
         "uaclient.util.which", side_effect=lambda cmd: cmd == "/usr/bin/snap"
@@ -437,6 +422,7 @@ class TestLivepatchEntitlementEnable:
         self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Install canonical-livepatch snap when not present on the system."""
+        application_status = status.ApplicationStatus.ENABLED
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert (
@@ -477,10 +463,6 @@ class TestLivepatchEntitlementEnable:
         )
         assert expected_msg == excinfo.value.msg
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.which", return_value="/found/livepatch")
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
@@ -489,6 +471,7 @@ class TestLivepatchEntitlementEnable:
         self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Do not attempt to install livepatch snap when it is present."""
+        application_status = status.ApplicationStatus.ENABLED
         m_app_status.return_value = application_status, "enabled"
         assert entitlement.enable()
         assert self.mocks_config == m_subp.call_args_list

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -405,14 +405,7 @@ class TestLivepatchEntitlementEnable:
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_installs_snapd_and_livepatch_snap_when_absent(
-        self,
-        m_can_enable,
-        m_app_status,
-        m_which,
-        m_subp,
-        capsys,
-        entitlement,
-        application_status,
+        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Install snapd and canonical-livepatch snap when not on system."""
         m_app_status.return_value = application_status, "enabled"
@@ -441,14 +434,7 @@ class TestLivepatchEntitlementEnable:
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_installs_only_livepatch_snap_when_absent_but_snapd_present(
-        self,
-        m_can_enable,
-        m_app_status,
-        m_which,
-        m_subp,
-        capsys,
-        entitlement,
-        application_status,
+        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Install canonical-livepatch snap when not present on the system."""
         m_app_status.return_value = application_status, "enabled"
@@ -500,14 +486,7 @@ class TestLivepatchEntitlementEnable:
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_does_not_install_livepatch_snap_when_present(
-        self,
-        m_can_enable,
-        m_app_status,
-        m_which,
-        m_subp,
-        capsys,
-        entitlement,
-        application_status,
+        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
     ):
         """Do not attempt to install livepatch snap when it is present."""
         m_app_status.return_value = application_status, "enabled"

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -98,10 +98,6 @@ class TestProcessContractDeltas:
         assert [] == m_setup_apt_config.call_args_list
 
     @pytest.mark.parametrize("entitled", (False, util.DROPPED_KEY))
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch.object(RepoTestEntitlement, "disable")
     @mock.patch.object(RepoTestEntitlement, "can_disable", return_value=True)
     @mock.patch.object(RepoTestEntitlement, "application_status")
@@ -112,9 +108,9 @@ class TestProcessContractDeltas:
         m_disable,
         entitlement,
         entitled,
-        application_status,
     ):
         """Disable the service on contract transitions to unentitled."""
+        application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         assert entitlement.process_contract_deltas(
             {"entitlement": {"entitled": True}},
@@ -213,10 +209,6 @@ class TestProcessContractDeltas:
         )
         assert expected_msg in caplog_text()
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
     @mock.patch.object(RepoTestEntitlement, "setup_apt_config")
     @mock.patch.object(RepoTestEntitlement, "remove_apt_config")
@@ -228,9 +220,9 @@ class TestProcessContractDeltas:
         m_setup_apt_config,
         m_remove_auth_apt_repo,
         entitlement,
-        application_status,
     ):
         """Update_apt_config when service is active and not enableByDefault."""
+        application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         assert entitlement.process_contract_deltas(
             {"entitlement": {"entitled": True}},
@@ -243,10 +235,6 @@ class TestProcessContractDeltas:
         assert [mock.call()] == m_setup_apt_config.call_args_list
         assert [] == m_remove_auth_apt_repo.call_args_list
 
-    @pytest.mark.parametrize(
-        "application_status",
-        (status.ApplicationStatus.ENABLED, status.ApplicationStatus.PENDING),
-    )
     @mock.patch(
         M_PATH + "util.get_platform_info", return_value={"series": "trusty"}
     )
@@ -262,9 +250,9 @@ class TestProcessContractDeltas:
         m_remove_auth_apt_repo,
         m_platform_info,
         entitlement,
-        application_status,
     ):
         """Remove old apt url when aptURL delta occurs on active service."""
+        application_status = status.ApplicationStatus.ENABLED
         m_application_status.return_value = (application_status, "")
         assert entitlement.process_contract_deltas(
             {

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -23,7 +23,6 @@ class ApplicationStatus(enum.Enum):
 
     ENABLED = object()
     DISABLED = object()
-    PENDING = object()
 
 
 @enum.unique
@@ -78,7 +77,6 @@ class UserFacingStatus(enum.Enum):
     ACTIVE = "enabled"
     INACTIVE = "disabled"
     INAPPLICABLE = "n/a"
-    PENDING = "pending"
     UNAVAILABLE = "—"
 
 
@@ -90,9 +88,6 @@ ADVANCED = "advanced"
 STATUS_COLOR = {
     UserFacingStatus.ACTIVE.value: (
         TxtColor.OKGREEN + UserFacingStatus.ACTIVE.value + TxtColor.ENDC
-    ),
-    UserFacingStatus.PENDING.value: (
-        TxtColor.DISABLEGREY + UserFacingStatus.PENDING.value + TxtColor.ENDC
     ),
     UserFacingStatus.INACTIVE.value: (
         TxtColor.FAIL + UserFacingStatus.INACTIVE.value + TxtColor.ENDC


### PR DESCRIPTION
fips: report ENABLED instead of PENDING status before rebooting

No longer set FIPS to 'pending' state. Leave it as 'enabled' because
we are touching /var/run/reboot-required to alert the system to a reboot
needed.

Fixes: #721
