### PR TITLE
Introduce integration testing driven by behave

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ The client also includes built-in dep8 tests. These are run as follows:
 autopkgtest -U --shell-fail . -- lxd ubuntu:xenial
 ```
 
+### Integration Tests
+
+ubuntu-advantage-client uses [behave](https://behave.readthedocs.io)
+for its integration testing.
+
+The integration test definitions are stored in the `features/`
+directory and consist of two parts: `.feature` files that define the
+tests we want to run, and `.py` files which implement the underlying
+logic for those tests.
+
+To run the tests, you can use `tox`:
+
+```shell
+tox -e behave
+```
+
+or, if you just want to run a specific file, or a test within a file:
+
+```shell
+tox -e behave features/unattached_commands.feature
+tox -e behave features/unattached_commands.feature:55
+```
+
+(If you're getting started with behave, we recommend at least reading
+through [the behave
+tutorial](https://behave.readthedocs.io/en/latest/tutorial.html) to get
+an idea of how it works, and how tests are written.)
+
 ## Building
 
 The packaging for the UA client package (ubuntu-advantage-tools) is

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -37,7 +37,7 @@ def _wait_for_boot(context: Context) -> None:
 
 
 @given("a trusty lxd container")
-def step_impl(context):
+def given_a_trusty_lxd_container(context):
     now = datetime.datetime.now()
     context.container_name = CONTAINER_PREFIX + now.strftime("%s%f")
     subprocess.run(["lxc", "launch", "ubuntu:trusty", context.container_name])
@@ -52,7 +52,7 @@ def step_impl(context):
 
 
 @given("ubuntu-advantage-tools is installed")
-def step_impl(context):
+def given_uat_is_installed(context):
     _lxc_exec(
         context,
         [
@@ -68,7 +68,7 @@ def step_impl(context):
 
 
 @when("I run `{command}` as non-root")
-def step_impl(context, command):
+def when_i_run_command(context, command):
     process = _lxc_exec(
         context, shlex.split(command), capture_output=True, text=True
     )
@@ -76,10 +76,10 @@ def step_impl(context, command):
 
 
 @then("I will see the following on stdout")
-def step_impl(context):
+def then_i_will_see_on_stdout(context):
     assert_that(context.process.stdout.strip(), equal_to(context.text))
 
 
 @then("I will see the following on stderr")
-def step_impl(context):
+def then_i_will_see_on_stderr(context):
     assert_that(context.process.stderr.strip(), equal_to(context.text))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,0 +1,39 @@
+import subprocess
+from typing import List
+
+from behave import given, then, when
+from hamcrest import assert_that, equal_to
+
+
+CONTAINER_NAME = "behave-test"
+
+
+def _lxc_exec(cmd: List[str], *args, **kwargs):
+    return subprocess.run(
+        ["lxc", "exec", CONTAINER_NAME, "--"] + cmd, *args, **kwargs
+    )
+
+
+@given("a trusty lxd container")
+def step_impl(context):
+    subprocess.run(["lxc", "launch", "ubuntu:trusty", CONTAINER_NAME])
+
+
+@given("ubuntu-advantage-tools is installed")
+def step_impl(context):
+    _lxc_exec(
+        ["add-apt-repository", "--yes", "ppa:canonical-server/ua-client-daily"]
+    )
+    _lxc_exec(["apt-get", "update", "-q"])
+    _lxc_exec(["apt-get", "install", "-q", "-y", "ubuntu-advantage-tools"])
+
+
+@when("I run `ua status` as non-root")
+def step_impl(context):
+    process = _lxc_exec(["ua", "status"], capture_output=True, text=True)
+    context.output = process.stdout.strip()
+
+
+@then("I will see the following output")
+def step_impl(context):
+    assert_that(context.output, equal_to(context.text))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -45,9 +45,9 @@ def step_impl(context, command):
     process = _lxc_exec(
         context, shlex.split(command), capture_output=True, text=True
     )
-    context.output = process.stdout.strip()
+    context.process = process
 
 
-@then("I will see the following output")
+@then("I will see the following on stdout")
 def step_impl(context):
-    assert_that(context.output, equal_to(context.text))
+    assert_that(context.process.stdout.strip(), equal_to(context.text))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -40,9 +40,9 @@ def step_impl(context):
             "ppa:canonical-server/ua-client-daily",
         ],
     )
-    _lxc_exec(context, ["apt-get", "update", "-q"])
+    _lxc_exec(context, ["apt-get", "update", "-qq"])
     _lxc_exec(
-        context, ["apt-get", "install", "-q", "-y", "ubuntu-advantage-tools"]
+        context, ["apt-get", "install", "-qq", "-y", "ubuntu-advantage-tools"]
     )
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,3 +1,4 @@
+import datetime
 import subprocess
 from typing import List
 
@@ -6,7 +7,7 @@ from behave.runner import Context
 from hamcrest import assert_that, equal_to
 
 
-CONTAINER_NAME = "behave-test"
+CONTAINER_PREFIX = "behave-test-"
 
 
 def _lxc_exec(context: Context, cmd: List[str], *args, **kwargs):
@@ -17,7 +18,8 @@ def _lxc_exec(context: Context, cmd: List[str], *args, **kwargs):
 
 @given("a trusty lxd container")
 def step_impl(context):
-    context.container_name = CONTAINER_NAME
+    now = datetime.datetime.now()
+    context.container_name = CONTAINER_PREFIX + now.strftime("%s%f")
     subprocess.run(["lxc", "launch", "ubuntu:trusty", context.container_name])
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -57,3 +57,8 @@ def step_impl(context, command):
 @then("I will see the following on stdout")
 def step_impl(context):
     assert_that(context.process.stdout.strip(), equal_to(context.text))
+
+
+@then("I will see the following on stderr")
+def step_impl(context):
+    assert_that(context.process.stderr.strip(), equal_to(context.text))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -23,6 +23,12 @@ def step_impl(context):
     context.container_name = CONTAINER_PREFIX + now.strftime("%s%f")
     subprocess.run(["lxc", "launch", "ubuntu:trusty", context.container_name])
 
+    def cleanup_container():
+        subprocess.run(["lxc", "stop", context.container_name])
+        subprocess.run(["lxc", "delete", context.container_name])
+
+    context.add_cleanup(cleanup_container)
+
 
 @given("ubuntu-advantage-tools is installed")
 def step_impl(context):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -2,35 +2,46 @@ import subprocess
 from typing import List
 
 from behave import given, then, when
+from behave.runner import Context
 from hamcrest import assert_that, equal_to
 
 
 CONTAINER_NAME = "behave-test"
 
 
-def _lxc_exec(cmd: List[str], *args, **kwargs):
+def _lxc_exec(context: Context, cmd: List[str], *args, **kwargs):
     return subprocess.run(
-        ["lxc", "exec", CONTAINER_NAME, "--"] + cmd, *args, **kwargs
+        ["lxc", "exec", context.container_name, "--"] + cmd, *args, **kwargs
     )
 
 
 @given("a trusty lxd container")
 def step_impl(context):
-    subprocess.run(["lxc", "launch", "ubuntu:trusty", CONTAINER_NAME])
+    context.container_name = CONTAINER_NAME
+    subprocess.run(["lxc", "launch", "ubuntu:trusty", context.container_name])
 
 
 @given("ubuntu-advantage-tools is installed")
 def step_impl(context):
     _lxc_exec(
-        ["add-apt-repository", "--yes", "ppa:canonical-server/ua-client-daily"]
+        context,
+        [
+            "add-apt-repository",
+            "--yes",
+            "ppa:canonical-server/ua-client-daily",
+        ],
     )
-    _lxc_exec(["apt-get", "update", "-q"])
-    _lxc_exec(["apt-get", "install", "-q", "-y", "ubuntu-advantage-tools"])
+    _lxc_exec(context, ["apt-get", "update", "-q"])
+    _lxc_exec(
+        context, ["apt-get", "install", "-q", "-y", "ubuntu-advantage-tools"]
+    )
 
 
 @when("I run `ua status` as non-root")
 def step_impl(context):
-    process = _lxc_exec(["ua", "status"], capture_output=True, text=True)
+    process = _lxc_exec(
+        context, ["ua", "status"], capture_output=True, text=True
+    )
     context.output = process.stdout.strip()
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1,4 +1,5 @@
 import datetime
+import shlex
 import subprocess
 from typing import List
 
@@ -39,10 +40,10 @@ def step_impl(context):
     )
 
 
-@when("I run `ua status` as non-root")
-def step_impl(context):
+@when("I run `{command}` as non-root")
+def step_impl(context, command):
     process = _lxc_exec(
-        context, ["ua", "status"], capture_output=True, text=True
+        context, shlex.split(command), capture_output=True, text=True
     )
     context.output = process.stdout.strip()
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -24,7 +24,11 @@ def _wait_for_boot(context: Context) -> None:
         process = _lxc_exec(
             context, ["runlevel"], capture_output=True, text=True
         )
-        _, runlevel = process.stdout.strip().split(" ", 2)
+        try:
+            _, runlevel = process.stdout.strip().split(" ", 2)
+        except ValueError:
+            print("Unexpected runlevel output: ", process.stdout.strip())
+            runlevel = None
         if runlevel == "2":
             break
         time.sleep(sleep_time)

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -1,0 +1,43 @@
+Feature: Command behaviour when unattached
+
+    Scenario: Unattached detach in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua detach` as non-root
+        Then I will see the following on stderr:
+            """
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+
+    Scenario: Unattached refresh in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua refresh` as non-root
+        Then I will see the following on stderr:
+            """
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """
+
+    Scenario: Unattached enable in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua enable livepatch` as non-root
+        Then I will see the following on stderr:
+            """
+            To use 'livepatch' you need an Ubuntu Advantage subscription.
+            Personal and community subscriptions are available at no charge
+            See https://ubuntu.com/advantage
+            """
+
+    Scenario: Unattached disable in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua disable livepatch` as non-root
+        Then I will see the following on stderr:
+            """
+            To use 'livepatch' you need an Ubuntu Advantage subscription.
+            Personal and community subscriptions are available at no charge
+            See https://ubuntu.com/advantage
+            """

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -20,7 +20,7 @@ Feature: Command behaviour when unattached
             See https://ubuntu.com/advantage
             """
 
-    Scenario: Unattached enable in a trusty lxd container
+    Scenario: Unattached enable of a known service in a trusty lxd container
         Given a trusty lxd container
           And ubuntu-advantage-tools is installed
         When I run `ua enable livepatch` as non-root
@@ -31,7 +31,17 @@ Feature: Command behaviour when unattached
             See https://ubuntu.com/advantage
             """
 
-    Scenario: Unattached disable in a trusty lxd container
+    Scenario: Unattached enable of an unknown service in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua enable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            Cannot enable 'foobar'
+            For a list of services see: sudo ua status
+            """
+
+    Scenario: Unattached disable of a known service in a trusty lxd container
         Given a trusty lxd container
           And ubuntu-advantage-tools is installed
         When I run `ua disable livepatch` as non-root
@@ -40,4 +50,14 @@ Feature: Command behaviour when unattached
             To use 'livepatch' you need an Ubuntu Advantage subscription.
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
+            """
+
+    Scenario: Unattached disable of an unknown service in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua disable foobar` as non-root
+        Then I will see the following on stderr:
+            """
+            Cannot disable 'foobar'
+            For a list of services see: sudo ua status
             """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -1,0 +1,18 @@
+Feature: Unattached status
+
+    Scenario: Unattached status in a trusty lxd container
+        Given a trusty lxd container
+          And ubuntu-advantage-tools is installed
+        When I run `ua status` as non-root
+        Then I will see the following output:
+            """
+            SERVICE       AVAILABLE  DESCRIPTION
+            cc-eal        no         Common Criteria EAL2 Provisioning Packages
+            esm-infra     yes        UA Infra: Extended Security Maintenance
+            fips          no         NIST-certified FIPS modules
+            fips-updates  no         Uncertified security updates to FIPS modules
+            livepatch     yes        Canonical Livepatch service
+
+            This machine is not attached to a UA subscription.
+            See https://ubuntu.com/advantage
+            """

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -4,7 +4,7 @@ Feature: Unattached status
         Given a trusty lxd container
           And ubuntu-advantage-tools is installed
         When I run `ua status` as non-root
-        Then I will see the following output:
+        Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION
             cc-eal        no         Common Criteria EAL2 Provisioning Packages

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,9 @@ ignore_errors = True
 
 [mypy-apt_pkg]
 ignore_missing_imports = True
+
+[mypy-behave.*]
+ignore_missing_imports = True
+
+[mypy-hamcrest]
+ignore_missing_imports = True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,12 @@
+# Linting
 flake8
-mock
 pycodestyle
+
+# Unit testing
+mock
 pytest
 pytest-cov
+
+# Integration testing
+behave
+PyHamcrest

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,12 @@ deps =
     black: -rdev-requirements.txt
 commands =
     py3: py.test {posargs:--cov uaclient uaclient}
-    flake8: flake8 uaclient setup.py
-    mypy: mypy --python-version 3.4 uaclient/
-    mypy: mypy --python-version 3.5 uaclient/
-    mypy: mypy --python-version 3.6 uaclient/
-    mypy: mypy --python-version 3.7 uaclient/
-    black: black --check --diff uaclient/
+    flake8: flake8 uaclient setup.py features
+    mypy: mypy --python-version 3.4 uaclient/ features/steps/
+    mypy: mypy --python-version 3.5 uaclient/ features/steps/
+    mypy: mypy --python-version 3.6 uaclient/ features/steps/
+    mypy: mypy --python-version 3.7 uaclient/ features/steps/
+    black: black --check --diff uaclient/ features/
     behave: behave {posargs}
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/
     mypy: mypy --python-version 3.7 uaclient/
     black: black --check --diff uaclient/
+    behave: behave {posargs}
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
This PR introduces integration testing for the project. It leverages the [behave](https://behave.readthedocs.io/en/latest/index.html) BDD framework to allow us to write tests that look similar to the UX documentation we've been given, with the implementation of those steps written in Python code.

This PR is enough for people to start iterating on new tests locally, but there is more work to be done: #853, #854, #855, #856, #857 