### PR TITLE
ux: remove "<entitlement> disabled." messaging on disable

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -151,8 +151,6 @@ class LivepatchEntitlement(base.UAEntitlement):
         if not silent:
             print("Removing canonical-livepatch snap")
         util.subp([SNAP_CMD, "remove", "canonical-livepatch"], capture=True)
-        if not silent:
-            print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True
 
     def application_status(self) -> "Tuple[ApplicationStatus, str]":

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -89,8 +89,6 @@ class RepoEntitlement(base.UAEntitlement):
         if not self.can_disable(silent):
             return False
         self._cleanup()
-        if not silent:
-            print(status.MESSAGE_DISABLED_TMPL.format(title=self.title))
         return True
 
     def _cleanup(self) -> None:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -124,7 +124,6 @@ MESSAGE_APT_POLICY_FAILED = "Failure checking APT policy."
 MESSAGE_CONNECTIVITY_ERROR = """\
 Failed to connect to authentication server
 Check your Internet connection and try again"""
-MESSAGE_DISABLED_TMPL = "{title} disabled."
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
 MESSAGE_ALREADY_DISABLED_TMPL = """\
 {title} is not currently enabled.\nSee: sudo ua status"""


### PR DESCRIPTION
This is part of addressing #726, and gets the UX in-line for livepatch. Another change for repo entitlements will follow, which will complete the fix.