### PR TITLE
bash: auto-completion of esm-infra instead of esm

### DIFF
--- a/tools/ua.bash
+++ b/tools/ua.bash
@@ -1,6 +1,6 @@
 # bash completion for ubuntu-advantage-tools
 
-SERVICES="cc-eal cis-audit esm fips fips-updates livepatch"
+SERVICES="cc-eal cis-audit esm-infra fips fips-updates livepatch"
 
 _ua_complete()
 {


### PR DESCRIPTION
tab completion needs to use esm-infra service name instead of esm.