### PR TITLE
gpg: do not create .gnupg dir during key extraction from shared keyring

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -14,8 +14,9 @@ export_gpg_key_from_shared_keyring() {
     KEY_ID=$1
     if [ ! -z "$KEY_ID" ]; then
         rm -f $ESM_APT_GPG_KEY
-        gpg --no-auto-check-trustdb --options /dev/null --no-default-keyring \
-            --keyring $UA_KEYRING_FILE --export $KEY_ID > $ESM_APT_GPG_KEY
+        gpg --no-auto-check-trustdb --no-options --no-default-keyring \
+            --keyring $UA_KEYRING_FILE --export $KEY_ID \
+            --output $ESM_APT_GPG_KEY --yes
     fi
 }
 

--- a/uaclient/gpg.py
+++ b/uaclient/gpg.py
@@ -24,6 +24,7 @@ def export_gpg_key_from_keyring(
         destination_keyfile,
         "--yes",
         "--no-auto-check-trustdb",
+        "--no-options",
         "--no-default-keyring",
         "--keyring",
         source_keyring_file,


### PR DESCRIPTION
Both debian/postinst and uaclient/gpg call to gpg on the command line in
order to extract a known GPG key for a service we are enabling.

Update both of these callsites to use the same gpg parameters.
Also, add --no-options parameter which prevents custom gpg config
options from being sourced as well as preventing the creation of
.gnupg in the current user's homedir.

Fixes: #776