### PR TITLE
pkg: postinst esm keyring creation redirect stdout instead of --output

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,7 +20,7 @@ export_gpg_key_from_shared_keyring() {
         rm -f $ESM_APT_GPG_KEY
         gpg --no-auto-check-trustdb --no-options --no-default-keyring \
             --keyring $UA_KEYRING_FILE --export $KEY_ID \
-            --output $ESM_APT_GPG_KEY --yes
+            --yes > $ESM_APT_GPG_KEY
     fi
 }
 


### PR DESCRIPTION
using --output in postinst results in a lot of noise on stdout. Prefer
redirect to create the desired esm keyring file

Fixes: #798