### PR TITLE
pkg: precise to trusty upgrade move valid apt creds to trusty apt source

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -5,34 +5,40 @@ set -e
 . /etc/os-release  # For VERSION_ID
 
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
-ESM_INFRA_KEY="ubuntu-advantage-esm-infra-trusty.gpg"
-ESM_APT_SOURCE_FILE_OLD="/etc/apt/sources.list.d/ubuntu-esm-trusty.list"
-ESM_APT_SOURCE_FILE="/etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list"
-ESM_APT_PREF_FILE_OLD="/etc/apt/preferences.d/ubuntu-esm-trusty"
-ESM_APT_PREF_FILE="/etc/apt/preferences.d/ubuntu-esm-infra-trusty"
 UA_KEYRING_DIR="/usr/share/keyrings/"
+
+ESM_INFRA_KEY_TRUSTY="ubuntu-advantage-esm-infra-trusty.gpg"
+
+APT_SRC_DIR="/etc/apt/sources.list.d"
+ESM_APT_SOURCE_FILE_PRECISE="$APT_SRC_DIR/ubuntu-esm-precise.list"
+ESM_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-trusty.list"
+ESM_INFRA_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-infra-trusty.list"
+
+ESM_APT_PREF_FILE_TRUSTY="/etc/apt/preferences.d/ubuntu-esm-trusty"
+ESM_INFRA_APT_PREF_FILE_TRUSTY="/etc/apt/preferences.d/ubuntu-esm-infra-trusty"
 
 
 unconfigure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
-    rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY $ESM_APT_SOURCE_FILE
-    rm -f $ESM_APT_PREF_FILE_OLD $ESM_APT_PREF_FILE
+    rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
+    rm -f $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
+    rm -f $ESM_APT_PREF_FILE_TRUSTY $ESM_INFRA_APT_PREF_FILE_TRUSTY
 }
 
 configure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
-    if [ ! -f "$APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY" ]; then
-        cp $UA_KEYRING_DIR/$ESM_INFRA_KEY $APT_TRUSTED_KEY_DIR
+    if [ ! -f "$APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY" ]; then
+        cp $UA_KEYRING_DIR/$ESM_INFRA_KEY_TRUSTY $APT_TRUSTED_KEY_DIR
     fi
 
-    if [ -e "$ESM_APT_SOURCE_FILE_OLD" ]; then
-        mv $ESM_APT_SOURCE_FILE_OLD $ESM_APT_SOURCE_FILE
+    if [ -e "$ESM_APT_SOURCE_FILE_TRUSTY" ]; then
+        mv $ESM_APT_SOURCE_FILE_TRUSTY $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
     fi
-    if [ -e "$ESM_APT_PREF_FILE_OLD" ]; then
-        mv $ESM_APT_PREF_FILE_OLD $ESM_APT_PREF_FILE
+    if [ -e "$ESM_APT_PREF_FILE_TRUSTY" ]; then
+        mv $ESM_APT_PREF_FILE_TRUSTY $ESM_INFRA_APT_PREF_FILE_TRUSTY
     fi
-    if [ ! -e "$ESM_APT_SOURCE_FILE" ]; then
-        cat > $ESM_APT_SOURCE_FILE <<EOF
+    if [ ! -e "$ESM_INFRA_APT_SOURCE_FILE_TRUSTY" ]; then
+        cat > $ESM_INFRA_APT_SOURCE_FILE_TRUSTY <<EOF
 # Written by ubuntu-advantage-tools
 deb https://esm.ubuntu.com/ubuntu trusty-infra-security main
 # deb-src https://esm.ubuntu.com/ubuntu trusty-infra-security main
@@ -41,7 +47,7 @@ deb https://esm.ubuntu.com/ubuntu trusty-infra-updates main
 # deb-src https://esm.ubuntu.com/ubuntu trusty-infra-updates main
 EOF
         # Automatically disable esm sources via apt preferences until enabled
-        cat > $ESM_APT_PREF_FILE <<EOF
+        cat > $ESM_INFRA_APT_PREF_FILE_TRUSTY <<EOF
 # Written by ubuntu-advantage-tools
 Package: *
 Pin: release o=UbuntuESM, n=trusty
@@ -59,9 +65,23 @@ upgrade_to_status_cache() {
 
 case "$1" in
     configure)
+      PREVIOUS_PKG_VER=$2
+      # Special case: legacy precise creds allowed for trusty esm
+      # do-release-upgrade substitutes s/precise/trusty/ in all apt sources.
+      # So all we need to do is rename the precise sources file to trusty.
+      # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/693
+      case $PREVIOUS_PKG_VER in
+          *12.04*) # upgraded from precise
+              if [ -e "$ESM_APT_SOURCE_FILE_PRECISE" ]; then
+                  mv $ESM_APT_SOURCE_FILE_PRECISE \
+                      $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
+              fi
+              ;;
+      esac
+
       # We changed the way we store public files in 19.5; transition to the new
       # status cache for installs of a previous version
-      if dpkg --compare-versions "$2" lt-nl "19.5~"; then
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "19.5~"; then
           upgrade_to_status_cache
       fi
 


### PR DESCRIPTION
Precise legacy creds are entitled to esm on trusty. do-release-upgrade
will have re-written existing apt sources list files replacing 'precise'
pockets with 'trusty'.

On precise machines which had ESM enabled, the debian/postinst will now
migrate valid apt sources filename during do-release-upgrade from:
/etc/apt/sources.list.d/ubuntu-esm-precise.list
to:
/etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list

This way precise credentials are retained and uaclient runtime will
update or remove /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list if
"ua disable or enable esm" operations are performed on trusty.

Fix: #693