### PR TITLE
WIP: status: add account-id and subscription-id to status json

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -272,8 +272,10 @@ class UAConfig:
             {
                 "attached": True,
                 "account": self.accounts[0]["name"],
+                "account-id": self.accounts[0]["id"],
                 "origin": contractInfo.get("origin"),
                 "subscription": contractInfo["name"],
+                "subscription-id": contractInfo["id"],
             }
         )
         if contractInfo.get("effectiveTo"):

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -80,9 +80,9 @@ class FakeConfig(UAConfig):
             "machine-token": {
                 "machineToken": "not-null",
                 "machineTokenInfo": {
-                    "accountInfo": {"name": account_name},
+                    "accountInfo": {"id": "acct-1", "name": account_name},
                     "contractInfo": {
-                        "id": "cid",
+                        "id": "contract-1",
                         "name": "test_contract",
                         "resourceEntitlements": [],
                     },

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -429,9 +429,11 @@ class TestStatus:
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected.update(
             {
+                "account-id": "acct-1",
                 "account": "test_account",
                 "attached": True,
                 "services": expected_services,
+                "subscription-id": "contract-1",
                 "subscription": "test_contract",
             }
         )
@@ -540,8 +542,9 @@ class TestStatus:
         )
         token = {
             "machineTokenInfo": {
-                "accountInfo": {"id": "1", "name": "accountname"},
+                "accountInfo": {"id": "acct-1", "name": "accountname"},
                 "contractInfo": {
+                    "id": "contract-1",
                     "name": "contractname",
                     "resourceEntitlements": entitlements,
                 },
@@ -559,7 +562,9 @@ class TestStatus:
             {
                 "attached": True,
                 "account": "accountname",
+                "account-id": "acct-1",
                 "subscription": "contractname",
+                "subscription-id": "contract-1",
                 "techSupportLevel": support_level,
             }
         )
@@ -590,8 +595,9 @@ class TestStatus:
     ):
         token = {
             "machineTokenInfo": {
-                "accountInfo": {"id": "1", "name": "accountname"},
+                "accountInfo": {"id": "acct-1", "name": "accountname"},
                 "contractInfo": {
+                    "id": "contract-1",
                     "name": "contractname",
                     "effectiveTo": "2020-07-18T00:00:00Z",
                     "resourceEntitlements": [],


### PR DESCRIPTION
Attached machines should surface subscription-id and account-id to aid
in triage for backend account lookup issues.

Fixes: #805