### PR TITLE
Refactor assert_attached_root into separate decorators

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -53,8 +53,8 @@ def assert_root(f):
     return new_f
 
 
-def assert_attached_root(unattached_msg_tmpl=None):
-    """Decorator asserting root user and attached config.
+def assert_attached(unattached_msg_tmpl=None):
+    """Decorator asserting attached config.
 
     :param unattached_msg_tmpl: Optional msg template to format if raising an
         UnattachedError
@@ -62,7 +62,6 @@ def assert_attached_root(unattached_msg_tmpl=None):
 
     def wrapper(f):
         @wraps(f)
-        @assert_root
         def new_f(args, cfg):
             if not cfg.is_attached:
                 if unattached_msg_tmpl:
@@ -75,6 +74,21 @@ def assert_attached_root(unattached_msg_tmpl=None):
             return f(args, cfg)
 
         return new_f
+
+    return wrapper
+
+
+def assert_attached_root(unattached_msg_tmpl=None):
+    """Decorator asserting root user and attached config.
+
+    This is sugar for using assert_root and assert_attached together.
+
+    :param unattached_msg_tmpl: Optional msg template to format if raising an
+        UnattachedError
+    """
+
+    def wrapper(f):
+        return wraps(f)(assert_root(assert_attached(unattached_msg_tmpl)(f)))
 
     return wrapper
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -41,6 +41,18 @@ DEFAULT_LOG_FORMAT = (
 STATUS_FORMATS = ["tabular", "json"]
 
 
+def assert_root(f):
+    """Decorator asserting root user"""
+
+    @wraps(f)
+    def new_f(*args, **kwargs):
+        if os.getuid() != 0:
+            raise exceptions.NonRootUserError()
+        return f(*args, **kwargs)
+
+    return new_f
+
+
 def assert_attached_root(unattached_msg_tmpl=None):
     """Decorator asserting root user and attached config.
 
@@ -50,9 +62,8 @@ def assert_attached_root(unattached_msg_tmpl=None):
 
     def wrapper(f):
         @wraps(f)
+        @assert_root
         def new_f(args, cfg):
-            if os.getuid() != 0:
-                raise exceptions.NonRootUserError()
             if not cfg.is_attached:
                 if unattached_msg_tmpl:
                     name = getattr(args, "name", "None")

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -78,21 +78,6 @@ def assert_attached(unattached_msg_tmpl=None):
     return wrapper
 
 
-def assert_attached_root(unattached_msg_tmpl=None):
-    """Decorator asserting root user and attached config.
-
-    This is sugar for using assert_root and assert_attached together.
-
-    :param unattached_msg_tmpl: Optional msg template to format if raising an
-        UnattachedError
-    """
-
-    def wrapper(f):
-        return wraps(f)(assert_root(assert_attached(unattached_msg_tmpl)(f)))
-
-    return wrapper
-
-
 def attach_parser(parser):
     """Build or extend an arg parser for attach subcommand."""
     usage = USAGE_TMPL.format(name=NAME, command="attach <token>")
@@ -205,7 +190,8 @@ def status_parser(parser):
     return parser
 
 
-@assert_attached_root(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
+@assert_root
+@assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 def action_disable(args, cfg):
     """Perform the disable action on a named entitlement.
 
@@ -250,7 +236,8 @@ def _perform_enable(
     return ret
 
 
-@assert_attached_root(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
+@assert_root
+@assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 def action_enable(args, cfg):
     """Perform the enable action on a named entitlement.
 
@@ -271,7 +258,8 @@ def action_enable(args, cfg):
     return 0 if _perform_enable(args.name, cfg) else 1
 
 
-@assert_attached_root()
+@assert_root
+@assert_attached()
 def action_detach(args, cfg):
     """Perform the detach action for this machine.
 
@@ -430,7 +418,8 @@ def print_version(_args=None, _cfg=None):
     print(version.get_version())
 
 
-@assert_attached_root()
+@assert_root
+@assert_attached()
 def action_refresh(args, cfg):
     try:
         contract.request_updated_contract(cfg)

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -10,7 +10,6 @@ import pytest
 
 from uaclient.cli import (
     assert_attached,
-    assert_attached_root,
     assert_root,
     get_parser,
     main,
@@ -75,47 +74,6 @@ class TestCLIParser:
         help_file = io.StringIO()
         parser.print_help(file=help_file)
         assert SERVICES_WRAPPED_HELP in help_file.getvalue()
-
-
-class TestAssertAttachedRoot:
-    def test_assert_attached_root_happy_path(self, capsys):
-        @assert_attached_root()
-        def test_function(args, cfg):
-            return mock.sentinel.success
-
-        cfg = FakeConfig.for_attached_machine()
-
-        with mock.patch("uaclient.cli.os.getuid", return_value=0):
-            ret = test_function(mock.Mock(), cfg)
-
-        assert mock.sentinel.success == ret
-
-        out, _err = capsys.readouterr()
-        assert "" == out.strip()
-
-    @pytest.mark.parametrize(
-        "attached,uid,expected_exception",
-        [
-            (True, 1000, NonRootUserError),
-            (False, 1000, NonRootUserError),
-            (False, 0, UnattachedError),
-        ],
-    )
-    def test_assert_attached_root_exceptions(
-        self, attached, uid, expected_exception
-    ):
-        @assert_attached_root()
-        def test_function(args, cfg):
-            return mock.sentinel.success
-
-        if attached:
-            cfg = FakeConfig.for_attached_machine()
-        else:
-            cfg = FakeConfig()
-
-        with pytest.raises(expected_exception):
-            with mock.patch("uaclient.cli.os.getuid", return_value=uid):
-                test_function(mock.Mock(), cfg)
 
 
 class TestAssertRoot:


### PR DESCRIPTION
As discussed in #777, we want to interject a new check after we've checked that a user is root, but before we check if they are attached or not. To that end, this PR refactors `assert_attached_root` into `assert_root` and `assert_attached` for the two checks it performs. (As `refresh` and `detach` will both continue wanting it, `assert_attached_root` is retained as sugar for using the two decorators together.)

(Side note: I normally prefer to include usage of new functions being introduced in my PRs and while this doesn't include any new, direct use of the two decorators, they are still used by every command definition, so I'm relaxing my rule a little to split this review across more than 1 PR.)