### PR TITLE
status: add account-id and subscription-id to status json

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -274,8 +274,10 @@ class UAConfig:
             {
                 "attached": True,
                 "account": self.accounts[0]["name"],
+                "account-id": self.accounts[0]["id"],
                 "origin": contractInfo.get("origin"),
                 "subscription": contractInfo["name"],
+                "subscription-id": contractInfo["id"],
             }
         )
         if contractInfo.get("effectiveTo"):

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -80,7 +80,7 @@ class FakeConfig(UAConfig):
             "machine-token": {
                 "machineToken": "not-null",
                 "machineTokenInfo": {
-                    "accountInfo": {"name": account_name},
+                    "accountInfo": {"id": "acct-1", "name": account_name},
                     "contractInfo": {
                         "id": "cid",
                         "name": "test_contract",

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -17,8 +17,12 @@ M_PATH = "uaclient.cli."
 
 BASIC_MACHINE_TOKEN = {
     "machineTokenInfo": {
-        "contractInfo": {"name": "mycontract", "resourceEntitlements": []},
-        "accountInfo": {"name": "accountName"},
+        "contractInfo": {
+            "name": "mycontract",
+            "id": "contract-1",
+            "resourceEntitlements": [],
+        },
+        "accountInfo": {"id": "acct-1", "name": "accountName"},
     }
 }
 

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -429,10 +429,12 @@ class TestStatus:
         expected = copy.deepcopy(DEFAULT_STATUS)
         expected.update(
             {
+                "account-id": "acct-1",
                 "account": "test_account",
                 "attached": True,
                 "services": expected_services,
                 "subscription": "test_contract",
+                "subscription-id": "cid",
             }
         )
         assert expected == cfg.status()
@@ -542,6 +544,7 @@ class TestStatus:
             "machineTokenInfo": {
                 "accountInfo": {"id": "1", "name": "accountname"},
                 "contractInfo": {
+                    "id": "contract-1",
                     "name": "contractname",
                     "resourceEntitlements": entitlements,
                 },
@@ -559,7 +562,9 @@ class TestStatus:
             {
                 "attached": True,
                 "account": "accountname",
+                "account-id": "1",
                 "subscription": "contractname",
+                "subscription-id": "contract-1",
                 "techSupportLevel": support_level,
             }
         )
@@ -593,6 +598,7 @@ class TestStatus:
                 "accountInfo": {"id": "1", "name": "accountname"},
                 "contractInfo": {
                     "name": "contractname",
+                    "id": "contract-1",
                     "effectiveTo": "2020-07-18T00:00:00Z",
                     "resourceEntitlements": [],
                 },


### PR DESCRIPTION
Attached machines should surface subscription-id and account-id to aid
in triage for backend account lookup issues.

Fixes: #805