### PR TITLE
Revert "Makefile: don't use a DEBOOTSTRAP_MIRROR for trusty"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,16 +39,13 @@ travis-deb-install:
 
 # Use the mirror for a GCE region, to speed things up. (Travis build VMs use
 # DataSourceNone so we can't dynamically determine the correct region.)
+travis-deb-script: export DEBOOTSTRAP_MIRROR=http://us-central1.gce.archive.ubuntu.com/ubuntu/
 travis-deb-script:
 	debuild -S -uc -us
 	sudo sbuild-adduser ${USER}
 	cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/${USER}/.sbuildrc
 	# Use this to get a new shell where we're in the sbuild group
-	case ${PACKAGE_BUILD_SERIES} in \
-		trusty) ;; \
-		*) DEBOOTSTRAP_MIRROR=http://us-central1.gce.archive.ubuntu.com/ubuntu/;; \
-	esac; \
-		sudo -E su ${USER} -c 'mk-sbuild ${PACKAGE_BUILD_SERIES}'
+	sudo -E su ${USER} -c 'mk-sbuild ${PACKAGE_BUILD_SERIES}'
 	sudo -E su ${USER} -c 'sbuild --nolog --verbose --dist=${PACKAGE_BUILD_SERIES} ../ubuntu-advantage-tools*.dsc'
 
 


### PR DESCRIPTION
It turns out that archive.ubuntu.com exhibits the same issues as the
in-cloud mirrors, so we may as well use the in-cloud mirrors for
improved performance.

This reverts commit 5904e79ed4c7000f27ed75f4e9643fd02567fb6a.