### PR TITLE
51ubuntu-advantage-esm: update Allowed-Origins for new naming

### DIFF
--- a/apt.conf.d/51ubuntu-advantage-esm
+++ b/apt.conf.d/51ubuntu-advantage-esm
@@ -1,3 +1,3 @@
 Unattended-Upgrade::Allowed-Origins {
-  "${distro_id}ESM:${distro_codename}-security";
+  "${distro_id}ESM:${distro_codename}-infra-security";
 };


### PR DESCRIPTION
i.e. trusty-infra-security instead of trusty-security

Fixes #825