### PR TITLE
livepatch: check is_container before recommending kernel upgrade

### DIFF
--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -141,6 +141,9 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 ApplicabilityStatus.APPLICABLE,
                 "no entitlement affordances checked",
             )
+        for error_message, functor, expected_result in self.static_affordances:
+            if functor() != expected_result:
+                return ApplicabilityStatus.INAPPLICABLE, error_message
         affordances = entitlement_cfg["entitlement"].get("affordances", {})
         platform = util.get_platform_info()
         affordance_arches = affordances.get("architectures", [])
@@ -201,9 +204,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                 ]
             ):
                 return ApplicabilityStatus.INAPPLICABLE, invalid_msg
-        for error_message, functor, expected_result in self.static_affordances:
-            if functor() != expected_result:
-                return ApplicabilityStatus.INAPPLICABLE, error_message
         return ApplicabilityStatus.APPLICABLE, ""
 
     @abc.abstractmethod

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -219,9 +219,11 @@ class TestLivepatchEntitlementCanEnable:
 
     def test_can_enable_false_on_containers(self, capsys, entitlement):
         """When is_container is True, can_enable returns False."""
+        unsupported_min_kernel = copy.deepcopy(dict(PLATFORM_INFO_SUPPORTED))
+        unsupported_min_kernel["kernel"] = "4.2.9-00-generic"
         with mock.patch("uaclient.util.get_platform_info") as m_platform:
             with mock.patch("uaclient.util.is_container") as m_container:
-                m_platform.return_value = PLATFORM_INFO_SUPPORTED
+                m_platform.return_value = unsupported_min_kernel
                 m_container.return_value = True
                 entitlement = LivepatchEntitlement(entitlement.cfg)
                 assert not entitlement.can_enable()


### PR DESCRIPTION
livepatch: check is_container before recommending kernel upgrade

On a container, livepatch isn't every going to be supported, so
there is little sense in checking kernel version first and telling
the user to upgrade their kernel only to find out after reboot that
they still can't enable livepatch because livepatch doesn't run on the
container.
    
Reorder static_affordances (which tend to be uncorrectable on a
platform) before more dynamic environment affordances like <series>
or kernel revision which can up updated on a machine to bring it into
compliance.

Fixes: #807

