### PR TITLE
Display the correct wording for unattached enable/disable of invalid services

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -78,6 +78,29 @@ def assert_attached(unattached_msg_tmpl=None):
     return wrapper
 
 
+def require_valid_entitlement_name(operation: str):
+    """Decorator ensuring that args.name is a valid service.
+
+    :param operation: the operation name to use in error messages
+    """
+
+    def wrapper(f):
+        @wraps(f)
+        def new_f(args, cfg):
+            if hasattr(args, "name"):
+                name = args.name
+                tmpl = ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL
+                if name not in entitlements.ENTITLEMENT_CLASS_BY_NAME:
+                    raise exceptions.UserFacingError(
+                        tmpl.format(operation=operation, name=name)
+                    )
+            return f(args, cfg)
+
+        return new_f
+
+    return wrapper
+
+
 def attach_parser(parser):
     """Build or extend an arg parser for attach subcommand."""
     usage = USAGE_TMPL.format(name=NAME, command="attach <token>")

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -214,18 +214,13 @@ def status_parser(parser):
 
 
 @assert_root
+@require_valid_entitlement_name("disable")
 @assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 def action_disable(args, cfg):
     """Perform the disable action on a named entitlement.
 
     @return: 0 on success, 1 otherwise
     """
-    if args.name not in entitlements.ENTITLEMENT_CLASS_BY_NAME:
-        raise exceptions.UserFacingError(
-            ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL.format(
-                operation="disable", name=args.name
-            )
-        )
     ent_cls = entitlements.ENTITLEMENT_CLASS_BY_NAME[args.name]
     entitlement = ent_cls(cfg)
     ret = 0 if entitlement.disable() else 1

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -255,18 +255,13 @@ def _perform_enable(
 
 
 @assert_root
+@require_valid_entitlement_name("enable")
 @assert_attached(ua_status.MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL)
 def action_enable(args, cfg):
     """Perform the enable action on a named entitlement.
 
     @return: 0 on success, 1 otherwise
     """
-    if args.name not in entitlements.ENTITLEMENT_CLASS_BY_NAME:
-        raise exceptions.UserFacingError(
-            ua_status.MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL.format(
-                operation="enable", name=args.name
-            )
-        )
     print(ua_status.MESSAGE_REFRESH_ENABLE)
     try:
         contract.request_updated_contract(cfg)

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -7,14 +7,14 @@ from uaclient import status
 from uaclient.testing.fakes import FakeConfig
 
 
+@mock.patch("uaclient.cli.os.getuid", return_value=0)
 class TestDisable:
     @pytest.mark.parametrize(
         "disable_return,return_code", ((True, 0), (False, 1))
     )
     @mock.patch("uaclient.cli.entitlements")
-    @mock.patch("uaclient.cli.os.getuid", return_value=0)
     def test_entitlement_instantiated_and_disabled(
-        self, _m_getuid, m_entitlements, disable_return, return_code
+        self, m_entitlements, _m_getuid, disable_return, return_code
     ):
         m_entitlement_cls = mock.Mock()
         m_entitlement = m_entitlement_cls.return_value
@@ -37,7 +37,6 @@ class TestDisable:
 
         assert 1 == m_cfg.status.call_count
 
-    @mock.patch("uaclient.cli.os.getuid", return_value=0)
     def test_invalid_service_error_message(self, m_getuid):
         """Check invalid service name results in custom error message."""
         cfg = FakeConfig.for_attached_machine()
@@ -49,7 +48,6 @@ class TestDisable:
             operation="disable", name="bogus"
         ) == str(err.value)
 
-    @mock.patch("uaclient.cli.os.getuid", return_value=0)
     def test_unattached_error_message(self, m_getuid):
         """Check that root user gets unattached message."""
         cfg = FakeConfig()


### PR DESCRIPTION
It does so by introducing a new decorator for the "is this a valid service name" check which is interjected between the root check and the attached check.

Fixes #777 