### PR TITLE
pkg: prev_version in precise is version 1 and doesn't contan 12.04

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -71,7 +71,7 @@ case "$1" in
       # So all we need to do is rename the precise sources file to trusty.
       # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/693
       case $PREVIOUS_PKG_VER in
-          *12.04*) # upgraded from precise
+          1) # upgraded from precise which will only ever have version 1
               if [ -e "$ESM_APT_SOURCE_FILE_PRECISE" ]; then
                   mv $ESM_APT_SOURCE_FILE_PRECISE \
                       $ESM_INFRA_APT_SOURCE_FILE_TRUSTY


### PR DESCRIPTION
Update postinst to look for previous package version 1 to know that it
is upgrading from precise to trusty. Can't use 12.04 series because that series wasn't included
in the published precise package ver.

Fixes: #693