### PR TITLE
cli: use "ua" as the command name in help messages

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -19,7 +19,7 @@ from uaclient import status as ua_status
 from uaclient import util
 from uaclient import version
 
-NAME = "ubuntu-advantage"
+NAME = "ua"
 
 USAGE_TMPL = "{name} {command} [flags]"
 EPILOG_TMPL = (
@@ -517,7 +517,7 @@ def main(sys_argv=None):
     cli_arguments = sys_argv[1:]
     if not cli_arguments:
         parser.print_usage()
-        print("Try 'ubuntu-advantage --help' for more information.")
+        print("Try 'ua --help' for more information.")
         sys.exit(1)
     args = parser.parse_args(args=cli_arguments)
     cfg = config.UAConfig()

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -111,7 +111,7 @@ class TestParser:
     def test_attach_parser_creates_a_parser_when_not_provided(self):
         """Create a named parser configured for 'attach'."""
         m_parser = attach_parser(mock.Mock())
-        assert "ubuntu-advantage attach <token> [flags]" == m_parser.usage
+        assert "ua attach <token> [flags]" == m_parser.usage
         assert "attach" == m_parser.prog
         assert "Flags" == m_parser._optionals.title
 


### PR DESCRIPTION
Instead of "ubuntu-advantage".  This will make us consistent with other
documentation.

Fixes #844