### PR TITLE
Update apt deps

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,8 +12,6 @@ else ifeq (${VERSION_ID},"16.04")
 APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
 else ifeq (${VERSION_ID},"18.04")
 APT_PKG_DEPS="apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
-else ifeq (${VERSION_ID},"18.10")
-APT_PKG_DEPS="apt (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
 else ifeq (${VERSION_ID},"19.04")
 APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
 else ifeq (${VERSION_ID},"19.10")

--- a/debian/rules
+++ b/debian/rules
@@ -11,13 +11,13 @@ APT_PKG_DEPS="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23)
 else ifeq (${VERSION_ID},"16.04")
 APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
 else ifeq (${VERSION_ID},"18.04")
-APT_PKG_DEPS="apt (>= 1.6.11), apt-transport-https (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
+APT_PKG_DEPS="apt (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
 else ifeq (${VERSION_ID},"18.10")
-APT_PKG_DEPS="apt (>= 1.7.5), apt-transport-https (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
+APT_PKG_DEPS="apt (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
 else ifeq (${VERSION_ID},"19.04")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
 else ifeq (${VERSION_ID},"19.10")
-APT_PKG_DEPS="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -7,17 +7,17 @@ FLAKE8 := $(shell flake8 --version 2> /dev/null)
 include /etc/os-release
 # see https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1840091/comments/3
 ifeq (${VERSION_ID},"14.04")
-LIBAPT_PKG_DEP="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23), apt-utils (>= 1.0.1ubuntu2.23), libapt-inst1.5 (>= 1.0.1ubuntu2.23), libapt-pkg4.12 (>= 1.0.1ubuntu2.23) "
+APT_PKG_DEPS="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23), apt-utils (>= 1.0.1ubuntu2.23), libapt-inst1.5 (>= 1.0.1ubuntu2.23), libapt-pkg4.12 (>= 1.0.1ubuntu2.23) "
 else ifeq (${VERSION_ID},"16.04")
-LIBAPT_PKG_DEP="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
+APT_PKG_DEPS="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
 else ifeq (${VERSION_ID},"18.04")
-LIBAPT_PKG_DEP="apt (>= 1.6.11), apt-transport-https (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
+APT_PKG_DEPS="apt (>= 1.6.11), apt-transport-https (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
 else ifeq (${VERSION_ID},"18.10")
-LIBAPT_PKG_DEP="apt (>= 1.7.5), apt-transport-https (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
+APT_PKG_DEPS="apt (>= 1.7.5), apt-transport-https (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
 else ifeq (${VERSION_ID},"19.04")
-LIBAPT_PKG_DEP="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
 else ifeq (${VERSION_ID},"19.10")
-LIBAPT_PKG_DEP="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
+APT_PKG_DEPS="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:
@@ -40,7 +40,7 @@ endif
 endif
 
 override_dh_gencontrol:
-	[ -z '$(LIBAPT_PKG_DEP)' ] || echo extra:Depends=$(LIBAPT_PKG_DEP) >> debian/ubuntu-advantage-tools.substvars
+	[ -z '$(APT_PKG_DEPS)' ] || echo extra:Depends=$(APT_PKG_DEPS) >> debian/ubuntu-advantage-tools.substvars
 	dh_gencontrol
 
 override_dh_auto_install:

--- a/debian/rules
+++ b/debian/rules
@@ -5,16 +5,19 @@ include /usr/share/dpkg/pkg-info.mk
 FLAKE8 := $(shell flake8 --version 2> /dev/null)
 
 include /etc/os-release
+# see https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1840091/comments/3
 ifeq (${VERSION_ID},"14.04")
-LIBAPT_PKG_DEP="libapt-pkg4.12 (>= 1.0.1ubuntu2.23)"
+LIBAPT_PKG_DEP="apt (>= 1.0.1ubuntu2.23), apt-transport-https (>= 1.0.1ubuntu2.23), apt-utils (>= 1.0.1ubuntu2.23), libapt-inst1.5 (>= 1.0.1ubuntu2.23), libapt-pkg4.12 (>= 1.0.1ubuntu2.23) "
 else ifeq (${VERSION_ID},"16.04")
-LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.2.31)"
+LIBAPT_PKG_DEP="apt (>= 1.2.32), apt-transport-https (>= 1.2.32), apt-utils (>= 1.2.32), libapt-inst2.0 (>= 1.2.32), libapt-pkg5.0 (>= 1.2.32)"
 else ifeq (${VERSION_ID},"18.04")
-LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.6.9)"
+LIBAPT_PKG_DEP="apt (>= 1.6.11), apt-transport-https (>= 1.6.11), apt-utils (>= 1.6.11), libapt-inst2.0 (>= 1.6.11), libapt-pkg5.0 (>= 1.6.11)"
 else ifeq (${VERSION_ID},"18.10")
-LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.7.4)"
+LIBAPT_PKG_DEP="apt (>= 1.7.5), apt-transport-https (>= 1.7.5), apt-utils (>= 1.7.5), libapt-inst2.0 (>= 1.7.5), libapt-pkg5.0 (>= 1.7.5)"
 else ifeq (${VERSION_ID},"19.04")
-LIBAPT_PKG_DEP="libapt-pkg5.0 (>= 1.8.1)"
+LIBAPT_PKG_DEP="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-inst2.0 (>= 1.8.1), libapt-pkg5.0 (>= 1.8.1)"
+else ifeq (${VERSION_ID},"19.10")
+LIBAPT_PKG_DEP="apt (>= 1.8.1), apt-transport-https (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:


### PR DESCRIPTION
Fixes issue #845 
Mostly based on https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1840091/comments/3. Interesting bits:
- apt-transport-https was merged with apt in v1.5, and the package became a transitional package and was moved to universe. That's why we don't depend on it past xenial
- likewise, `libapt-instXX` was merged with `libapt-pkg` in version 1.9.0 and that's why we don't depend on it in eoan
- I picked the version to depend on based on this changelog entry: `Add test case for local-only packages pinned to never`, which was a test case for another feature we need (the `Never` pinning case), and came after support for `auth.conf.d` was added.
- I debated whether to add the dependencies for eoan or not, since the released version will have the fixes we need, but thought to better error on the side of caution.

I tested all of these in containers with the `ppa:ahasenack/ua-temp` ppa. I downgraded apt to whatever was in the `security` pocket, confirmed there was no `/etc/apt/auth.conf.d` directory, and then installed `ubuntu-advantage-tools` from my ppa. Afterwards, the `auth.conf.d` directory showed up.