### PR TITLE
status: user-facing-error on get_available_resources connectivity issues

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -500,6 +500,11 @@ def main_error_handler(func):
                 logging.exception("KeyboardInterrupt")
             print("Interrupt received; exiting.", file=sys.stderr)
             sys.exit(1)
+        except util.UrlError as exc:
+            with util.disable_log_to_console():
+                logging.exception(exc)
+            print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
+            sys.exit(1)
         except exceptions.UserFacingError as exc:
             with util.disable_log_to_console():
                 logging.exception(exc.msg)

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -1,0 +1,100 @@
+import json
+import mock
+import socket
+
+import pytest
+
+from uaclient.testing.fakes import FakeConfig
+from uaclient import util
+
+from uaclient.cli import action_status
+
+M_PATH = "uaclient.cli."
+
+
+RESPONSE_LIVEPATCH_AVAILABLE = [{"name": "livepatch", "available": True}]
+UNATTACHED_STATUS = """\
+SERVICE       AVAILABLE  DESCRIPTION
+livepatch     yes        Canonical Livepatch service
+
+This machine is not attached to a UA subscription.
+See https://ubuntu.com/advantage
+"""
+
+ATTACHED_STATUS = """\
+SERVICE       ENTITLED  STATUS    DESCRIPTION
+cc-eal        no        —         Common Criteria EAL2 Provisioning Packages
+cis-audit     no        —         Center for Internet Security Audit Tools
+esm-infra     no        —         UA Infra: Extended Security Maintenance
+fips          no        —         NIST-certified FIPS modules
+fips-updates  no        —         Uncertified security updates to FIPS modules
+livepatch     no        —         Canonical Livepatch service
+
+Enable services with: ua enable <service>
+
+                Account: test_account
+           Subscription: test_contract
+            Valid until: n/a
+Technical support level: n/a
+"""
+
+
+@mock.patch(
+    M_PATH + "contract.get_available_resources",
+    return_value=RESPONSE_LIVEPATCH_AVAILABLE,
+)
+@mock.patch(M_PATH + "os.getuid", return_value=0)
+class TestActionStatus:
+    def test_attached(self, m_getuid, m_get_avail_resources, capsys):
+        """Check that root and non-root will emit attached status"""
+        cfg = FakeConfig.for_attached_machine()
+        assert 0 == action_status(mock.MagicMock(), cfg)
+        # capsys already converts colorized non-printable chars to space
+        # Strip non-printables from output
+        printable_stdout = capsys.readouterr()[0].replace(" " * 17, " " * 8)
+        assert ATTACHED_STATUS == printable_stdout
+
+    def test_unattached(self, m_getuid, m_get_avail_resources, capsys):
+        """Check that unattached status is emitted to console"""
+        cfg = FakeConfig()
+
+        assert 0 == action_status(mock.MagicMock(), cfg)
+        assert UNATTACHED_STATUS == capsys.readouterr()[0]
+
+    def test_unattached_json(self, m_getuid, m_get_avail_resources, capsys):
+        """Check that unattached status json output is emitted to console"""
+        cfg = FakeConfig()
+
+        args = mock.MagicMock(format="json")
+        assert 0 == action_status(args, cfg)
+        expected = {
+            "_doc": (
+                "Content provided in json response is currently "
+                "considered Experimental and may change"
+            ),
+            "attached": False,
+            "expires": "n/a",
+            "origin": None,
+            "services": [
+                {
+                    "name": "livepatch",
+                    "description": "Canonical Livepatch service",
+                    "available": "yes",
+                }
+            ],
+            "techSupportLevel": "n/a",
+        }
+        assert expected == json.loads(capsys.readouterr()[0])
+
+    def test_error_on_connectivity_errors(
+        self, m_getuid, m_get_avail_resources, capsys
+    ):
+        """Raise UrlError on connectivity issues"""
+        m_get_avail_resources.side_effect = util.UrlError(
+            socket.gaierror(-2, "Name or service not known")
+        )
+
+        cfg = FakeConfig()
+
+        with pytest.raises(util.UrlError):
+            action_status(mock.MagicMock(), cfg)


### PR DESCRIPTION
status: better user-facing error on connectivity errors

Generalize exception handling for any util.UrlError raised by the
commandline. Log any urlerror tracebacks and emit the message:
Failed to connect to authentication server
Check your Internet connection and try again
    
Fixes: #858

