### PR TITLE
log: log connectivity error message and url instead of traceback

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -511,7 +511,12 @@ def main_error_handler(func):
             sys.exit(1)
         except util.UrlError as exc:
             with util.disable_log_to_console():
-                logging.exception(exc)
+                msg_args = {"url": exc.url, "error": exc}
+                if exc.url:
+                    msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL
+                else:
+                    msg_tmpl = ua_status.LOG_CONNECTIVITY_ERROR_TMPL
+                logging.exception(msg_tmpl.format(**msg_args))
             print(ua_status.MESSAGE_CONNECTIVITY_ERROR, file=sys.stderr)
             sys.exit(1)
         except exceptions.UserFacingError as exc:

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -120,6 +120,10 @@ MESSAGE_APT_UPDATING_LISTS = "Updating package lists"
 MESSAGE_CONNECTIVITY_ERROR = """\
 Failed to connect to authentication server
 Check your Internet connection and try again"""
+LOG_CONNECTIVITY_ERROR_TMPL = MESSAGE_CONNECTIVITY_ERROR + ". {error}"
+LOG_CONNECTIVITY_ERROR_WITH_URL_TMPL = (
+    MESSAGE_CONNECTIVITY_ERROR + ". Failed to access URL: {url}. {error}"
+)
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
 MESSAGE_ALREADY_DISABLED_TMPL = """\
 {title} is not currently enabled\nSee: sudo ua status"""


### PR DESCRIPTION
In the event of unhandled UrlErrors from ua-client operations log
the same connectivity error message seen to the console and the error
string instead of a full traceback in the logs.

Only log the exception traceback if the UrlError doesn't have a defined
url.

Fixes: #868