### PR TITLE
d/changelog: 19.6 entries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,16 @@
-ubuntu-advantage-tools (19.6) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (19.6) focal; urgency=medium
 
-  * New upstream release 
+  * New upstream release. Main changes:
+    - drop SSO interactive login support
+    - d/control: no longer depend on pymacaroons, which was only needed for
+      the SSO interactive login support
+    - drop keyrings for services not supported in trusty: cc-eal, fips,
+      fips-updates, cis audit
+    - make sure /var/lib/ubuntu-advantage/private has 0700 perms
+    - rename esm to esm-infra. Also handle upgrades
+    - don't unecessarily remove config files that are already handled by dpkg
+    - expand the apt related runtime dependencies
+    - handle sources.list.d esm snippet when release upgrading from precise
 
  -- Andreas Hasenack <andreas@canonical.com>  Thu, 04 Jul 2019 14:12:58 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,6 +11,8 @@ ubuntu-advantage-tools (19.6) focal; urgency=medium
     - don't unecessarily remove config files that are already handled by dpkg
     - expand the apt related runtime dependencies
     - handle sources.list.d esm snippet when release upgrading from precise
+    - ua status now reports availability of services even in unattached state
+    - the "ua status" output was changed, including the json format option
 
  -- Andreas Hasenack <andreas@canonical.com>  Thu, 04 Jul 2019 14:12:58 -0300
 


### PR DESCRIPTION
I looked at the git log from 19.5.1 to 7f277d09a48dc073fda6a91f2000a6275d4fc962 and these are the important changes I think should be mentioned in `debian/changelog`.
Once this lands, there should be another MP opening up 19.7 for development, with the ubuntu release name field set to `UNRELEASED`. I don't want to do that together here because I want to be able to use a 19.6 tag in the repository for the basis of building the trusty package.