### PR TITLE
output: remove unecessary periods

### DIFF
--- a/uaclient/entitlements/tests/test_base.py
+++ b/uaclient/entitlements/tests/test_base.py
@@ -123,7 +123,7 @@ class TestUaEntitlement:
         assert not entitlement.can_disable()
 
         expected_stdout = (
-            "Test Concrete Entitlement is not currently enabled.\n"
+            "Test Concrete Entitlement is not currently enabled\n"
             "See: sudo ua status\n"
         )
         stdout, _ = capsys.readouterr()

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -228,7 +228,7 @@ class TestCommonCriteriaEntitlementEnable:
                 "Installing CC EAL2 packages",
                 "(This will download more than 500MB of packages, so may take"
                 " some time.)",
-                "CC EAL2 enabled.",
+                "CC EAL2 enabled",
                 "Please follow instructions in {} to configure EAL2\n".format(
                     CC_README
                 ),

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -94,6 +94,6 @@ class TestCISEntitlementEnable:
         expected_stdout = (
             "Updating package lists\n"
             "Installing CIS Audit packages\n"
-            "CIS Audit enabled.\n"
+            "CIS Audit enabled\n"
         )
         assert (expected_stdout, "") == capsys.readouterr()

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -346,7 +346,7 @@ class TestRepoEnable:
         expected_output = dedent(
             """\
         Updating package lists
-        Repo Test Class enabled.
+        Repo Test Class enabled
         """
         )
         if packages is not None:
@@ -370,7 +370,7 @@ class TestRepoEnable:
                             "Installing Repo Test Class packages",
                         ]
                         + (pre_install_msgs if with_pre_install_msg else [])
-                        + ["Repo Test Class enabled."]
+                        + ["Repo Test Class enabled"]
                     )
                     + "\n"
                 )

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -122,9 +122,9 @@ Failed to connect to authentication server
 Check your Internet connection and try again"""
 MESSAGE_NONROOT_USER = "This command must be run as root (try using sudo)"
 MESSAGE_ALREADY_DISABLED_TMPL = """\
-{title} is not currently enabled.\nSee: sudo ua status"""
+{title} is not currently enabled\nSee: sudo ua status"""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
-MESSAGE_ENABLED_TMPL = "{title} enabled."
+MESSAGE_ENABLED_TMPL = "{title} enabled"
 MESSAGE_ALREADY_ENABLED_TMPL = """\
 {title} is already enabled.\nSee: sudo ua status"""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\
@@ -164,7 +164,7 @@ Failed to attach machine. See https://ubuntu.com/advantage"""
 MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES = """\
 Failed to enable default services, check: sudo ua status"""
 MESSAGE_ATTACH_SUCCESS_TMPL = """\
-This machine is now attached to '{contract_name}'.
+This machine is now attached to '{contract_name}'
 """
 
 MESSAGE_CONTRACT_EXPIRED_ERROR = """\
@@ -174,7 +174,7 @@ MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} '{name}'
 For a list of services see: sudo ua status"""
 MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
-To use '{name}' you need an Ubuntu Advantage subscription.
+To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge
 See https://ubuntu.com/advantage"""
 MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"


### PR DESCRIPTION
We removed unnecessary periods from a number of messages, but not everything. This grabs a few more. There are some additional messages that should also be cleaned up in future releases as we add additional services.