### PR TITLE
d/postinst: remove client upgrade logic

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -56,13 +56,6 @@ EOF
     fi
 }
 
-upgrade_to_status_cache() {
-    # Remove all publicly-readable files
-    find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f -delete
-    # Regenerate the status.json cache
-    ua status 2>&1 > /dev/null
-}
-
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -78,12 +71,6 @@ case "$1" in
               fi
               ;;
       esac
-
-      # We changed the way we store public files in 19.5; transition to the new
-      # status cache for installs of a previous version
-      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "19.5~"; then
-          upgrade_to_status_cache
-      fi
 
       # CACHE_DIR is no longer present or used since 19.1
       rm -rf /var/cache/ubuntu-advantage-tools


### PR DESCRIPTION
The client does not need to deal with upgrades for Trusty. The previous
version of the client never knew about a cache and therefore this logic
is working around a future issue that may or may not exist.

This logic can be re-introduced we a client for Xenial, Bionic, or other
releases is worked on.

Fixes #881