### PR TITLE
pkg: postinst no longer need to call ua status to update cache files

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -56,13 +56,6 @@ EOF
     fi
 }
 
-upgrade_to_status_cache() {
-    # Remove all publicly-readable files
-    find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f -delete
-    # Regenerate the status.json cache
-    ua status 2>&1 > /dev/null
-}
-
 case "$1" in
     configure)
       PREVIOUS_PKG_VER=$2
@@ -79,10 +72,10 @@ case "$1" in
               ;;
       esac
 
-      # We changed the way we store public files in 19.5; transition to the new
-      # status cache for installs of a previous version
+      # We changed the way we store public files in 19.5
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "19.5~"; then
-          upgrade_to_status_cache
+          # Remove all publicly-readable files
+          find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f -delete
       fi
 
       # CACHE_DIR is no longer present or used since 19.1


### PR DESCRIPTION
UA client for root and non-root both can succeed in absence of
/var/lib/ubuntu-advantag/status.json. Running ua status from
postist will break dep8 tests due to ua status requiring external
network connectivity.

Fixes: #881