### PR TITLE
status: custom descriptions for n/a service status

### DIFF
--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -214,11 +214,15 @@ def format_tabular(status: "Dict[str, Any]") -> str:
     content = [STATUS_HEADER]
     for service_status in status["services"]:
         entitled = service_status["entitled"]
+        descr_override = service_status["description_override"]
+        description = (
+            descr_override if descr_override else service_status["description"]
+        )
         fmt_args = {
             "name": service_status["name"],
             "entitled": colorize(entitled),
             "status": colorize(service_status["status"]),
-            "description": service_status["description"],
+            "description": description,
         }
         content.append(STATUS_TMPL.format(**fmt_args))
     content.append("\nEnable services with: ua enable <service>\n")

--- a/uaclient/tests/test_status.py
+++ b/uaclient/tests/test_status.py
@@ -140,3 +140,28 @@ class TestFormatTabular:
             status_dict = status_dict_unattached
 
         assert not format_tabular(status_dict).startswith("\n")
+
+    @pytest.mark.parametrize(
+        "description_override, uf_status, uf_descr",
+        (
+            ("", "n/a", "Common Criteria EAL2 default descr"),
+            ("Custom descr", "n/a", "Custom descr"),
+            ("Custom call to action", "enabled", "Custom call to action"),
+        ),
+    )
+    def test_custom_descr(
+        self, description_override, uf_status, uf_descr, status_dict_attached
+    ):
+        """Services can provide a custom call to action if present."""
+        default_descr = "Common Criteria EAL2 default descr"
+        status_dict_attached["services"] = [
+            {
+                "name": "cc-eal",
+                "description": default_descr,
+                "available": "no",
+                "status": uf_status,
+                "entitled": True,
+                "description_override": description_override,
+            }
+        ]
+        assert uf_descr in format_tabular(status_dict_attached)


### PR DESCRIPTION


The response from machine attach (machine-token.json) provides an
availableResources list.  Any item in availableResources which is not
"available" will provide a "description" that should be surfaced as a
user-facing custom description for any n/a service.

The command `ua status` should surface these custom descriptions in the
DESCRIPTION column for any n/a service.

In the absence of a custom status "description" for an inapplicable
service, use the static entitlement.description.

Fixes: #790