### PR TITLE
sru: add sru subdirectory to track SRU verification scripts

### DIFF
--- a/sru/1832757/esm-trusty-test-1.md
+++ b/sru/1832757/esm-trusty-test-1.md
@@ -1,0 +1,52 @@
+# Test case 1: Attach a trusty machine and verify ESM is attached and ESM packages can be installed.
+```
+#!/bin/bash
+echo "--- Test 1: Attach a trusty machine using a token from auth.contracts.canonical.com and verify ESM is attached and ESM packages can be installed."
+
+echo "Launch Trusty container with allowing ssh access for <LP_ID>"
+
+export CONTRACT_TOKEN="<contractToken>"
+export ARCHIVE_URL="http://archive.ubuntu.com/ubuntu"
+
+cat >trusty-ssh.yaml <<EOF
+#cloud-config
+ssh_import_id: [chad.smith]
+EOF
+lxc launch ubuntu-daily:trusty sru-trusty -c user.user-data="$(cat trusty-ssh.yaml)"
+
+echo "Wait for cloud-init to finish startup on trusty"
+RUNLEVEL="NOTSET"
+while ! [ "N 2" = "$RUNLEVEL" ]; do echo -n '.'; sleep 1; RUNLEVEL=`lxc exec sru-trusty runlevel`; done; echo
+
+# emit script to upgrade u-a-t
+cat > add_uat_apt_pocket.sh << EOF
+#/bin/bash
+pocket_name=\$1
+echo deb $ARCHIVE_URL \$pocket_name main | tee /etc/apt/sources.list.d/\$pocket_name.list
+EOF
+
+echo "Upgrade ubuntu-advantage-tools to trusty-proposed"
+lxc file push add_uat_apt_pocket.sh sru-trusty/;
+lxc exec sru-trusty chmod 755 /add_uat_apt_pocket.sh;
+lxc exec sru-trusty /add_uat_apt_pocket.sh trusty-proposed;
+lxc exec sru-trusty -- apt-get update -q;
+lxc exec sru-trusty -- apt-get install -qy ubuntu-advantage-tools;
+
+echo "Confirm ubuntu-advantage-tools version from -proposed"
+lxc exec sru-trusty -- apt-cache policy ubuntu-advantage-tools;
+
+
+echo "Enable esm on trusty as non-root sudo"
+VM_IP=`lxc list sru-trusty -c 4 | awk '/10/{print $2}'`
+
+# Expect ua status to show esm enabled, livepatch n/a
+ssh ubuntu@$VM_IP -- sudo ua attach $CONTRACT_TOKEN
+
+echo "Confirm ansible is available for trusty esm PPA"
+ssh ubuntu@$VM_IP -- apt-cache policy ansible
+
+ANSIBLE_ESM_VER=`lxc exec sru-trusty -- apt-cache policy ansible | grep esm | grep Candidate | awk '{print $2}'`
+
+echo "Installing ansible from esm"
+ssh ubuntu@$VM_IP -- sudo apt-get install ansible=$ANSIBLE_ESM_VER -y
+```

--- a/sru/1832757/esm-trusty-test-2.md
+++ b/sru/1832757/esm-trusty-test-2.md
@@ -1,0 +1,93 @@
+# Test case 2
+
+2.
+ a. Start with a fresh Ubuntu instance which does not have u-a-t installed (i.e. ubuntu-minimal is not installed). Install u-a-t from -updates.
+ Do not enable ua. Upgrade to u-a-t from -proposed.
+ b. In an identical instance, install u-a-t from -proposed.
+ c. Confirm that the on-disk results of a) and b) are identical.
+
+```
+originally from https://gist.githubusercontent.com/panlinux/4caaf069356da7436d97b47afce32234/raw/d07504309557e9176ae887b8606b4de80c422e02/esm-trusty-test-2.txt
+
+
+sudo su -
+# adjust if needed, i.e., point to a mirror
+export ARCHIVE_URL=http://br.archive.ubuntu.com/ubuntu
+export PROPOSED_REPO="deb $ARCHIVE_URL trusty-proposed main"
+
+mkdir /esm-sru
+cd /esm-sru
+truncate -s 10G file.img
+zpool create -O sync=disabled tank $(pwd)/file.img
+zfs create tank/trusty-minimal
+debootstrap --exclude=ubuntu-minimal trusty /tank/trusty-minimal $ARCHIVE_URL
+zfs snapshot tank/trusty-minimal@fresh
+# confirm no ubuntu-minimal nor ubuntu-advantage-tools
+chroot /tank/trusty-minimal dpkg -l | grep -E "(ubuntu-minimal|ubuntu-advantage)"
+
+# create a clone from trusty-minimal called trusty-2a
+zfs clone tank/trusty-minimal@fresh tank/trusty-2a
+
+# add extra pockets
+cat >> /tank/trusty-2a/etc/apt/sources.list <<EOF
+deb $ARCHIVE_URL trusty-updates main
+deb $ARCHIVE_URL trusty-security main
+EOF
+
+# install u-a-t from updates
+chroot /tank/trusty-2a/ apt-get update
+chroot /tank/trusty-2a/ apt-get install ubuntu-advantage-tools -y
+
+# upgrade to u-a-t from proposed
+cat > /tank/trusty-2a/etc/apt/sources.list.d/proposed.list <<EOF
+$PROPOSED_REPO
+EOF
+chroot /tank/trusty-2a/ apt-get update
+chroot /tank/trusty-2a/ apt-get install ubuntu-advantage-tools -y
+
+# clone the first fresh snapshot and call it trusty-2b
+zfs clone tank/trusty-minimal@fresh tank/trusty-2b
+
+# install u-a-t directly from proposed
+cat >> /tank/trusty-2b/etc/apt/sources.list <<EOF
+deb $ARCHIVE_URL trusty-updates main
+deb $ARCHIVE_URL trusty-security main
+EOF
+
+cat > /tank/trusty-2b/etc/apt/sources.list.d/proposed.list <<EOF
+$PROPOSED_REPO
+EOF
+
+chroot /tank/trusty-2b/ apt-get update
+chroot /tank/trusty-2b/ apt-get install ubuntu-advantage-tools -y
+
+# get files from both datasets, stripping the zfs prefix
+find /tank/trusty-2a/ | sed -r 's,^/tank/[^/]+,,' | sort > trusty-2a.list
+find /tank/trusty-2b/ | sed -r 's,^/tank/[^/]+,,' | sort > trusty-2b.list
+
+# compare and verify the result. The difference should be just that the 2a list has the intermediary u-a-t package from trusty-updates in the apt cache
+diff -u trusty-2a.list trusty-2b.list
+--- trusty-2a.list	2019-10-24 15:55:01.120848221 -0300
++++ trusty-2b.list	2019-10-24 15:55:01.256846583 -0300
+@@ -13723,7 +13723,6 @@
+ /var/cache/apt/archives/sysv-rc_2.88dsf-41ubuntu6_all.deb
+ /var/cache/apt/archives/tar_1.27.1-1_amd64.deb
+ /var/cache/apt/archives/tzdata_2014b-1_all.deb
+-/var/cache/apt/archives/ubuntu-advantage-tools_10ubuntu0.14.04.4_all.deb
+ /var/cache/apt/archives/ubuntu-advantage-tools_19.6~ubuntu14.04.1~ppa2_amd64.deb
+ /var/cache/apt/archives/ubuntu-keyring_2012.05.19_all.deb
+ /var/cache/apt/archives/ucf_3.0027+nmu1_all.deb
+
+
+# diff the contents of /etc/apt, should be empty
+diff -uNr /tank/trusty-2{a,b}/etc/apt
+
+# OPTIONAL
+# to go back to a clean state, without having to debootstrap again:
+zfs destroy tank/trusty-2a
+zfs destroy tank/trusty-2b
+zfs rollback tank/trusty-minimal@fresh
+
+# confirming
+zfs list -t all -r tank
+```

--- a/sru/1832757/esm-trusty-test-3.md
+++ b/sru/1832757/esm-trusty-test-3.md
@@ -1,0 +1,139 @@
+# Test case 3: Install u-a-t on minimal system test enable-esm vs ua attach
+
+3.
+ a. Start with a fresh Ubuntu instance which does not have u-a-t installed (i.e. ubuntu-minimal is not installed). Install u-a-t from -updates. Enable esm with 'ubuntu-advantage enable-esm'. Upgrade to u-a-t from -proposed.
+ b. In an identical instance, install u-a-t from -proposed. Enable esm with 'ubuntu-advantage attach'.
+ c. Confirm that the on-disk results of a) and b) are identical.
+
+```
+# originally from https://gist.github.com/panlinux/4843bfc1e726a3f006aa44190411d582
+
+sudo su -
+# adjust if needed, i.e., point to a mirror
+export ARCHIVE_URL=http://br.archive.ubuntu.com/ubuntu
+export PROPOSED_REPO="deb $ARCHIVE_URL trusty-proposed main"
+
+# these are needed
+export LEGACY_ESM_TOKEN="user:password"
+export UA_CONTRACT_TOKEN="<token>"
+
+mkdir /esm-sru
+cd /esm-sru
+truncate -s 10G file.img
+zpool create -O sync=disabled tank $(pwd)/file.img
+zfs create tank/trusty-minimal
+debootstrap --exclude=ubuntu-minimal trusty /tank/trusty-minimal $ARCHIVE_URL
+zfs snapshot tank/trusty-minimal@fresh
+# confirm no ubuntu-minimal nor ubuntu-advantage-tools
+chroot /tank/trusty-minimal dpkg -l | grep -E "(ubuntu-minimal|ubuntu-advantage)"
+
+# create a clone from trusty-minimal called trusty-3a
+zfs clone tank/trusty-minimal@fresh tank/trusty-3a
+
+# add extra pockets
+cat >> /tank/trusty-3a/etc/apt/sources.list <<EOF
+deb $ARCHIVE_URL trusty-updates main
+deb $ARCHIVE_URL trusty-security main
+EOF
+
+# install u-a-t from updates
+chroot /tank/trusty-3a/ apt-get update
+chroot /tank/trusty-3a/ apt-get install ubuntu-advantage-tools -y
+
+# enable esm
+chroot /tank/trusty-3a/ ubuntu-advantage enable-esm "$LEGACY_ESM_TOKEN"
+
+# upgrade to u-a-t from proposed
+cat > /tank/trusty-3a/etc/apt/sources.list.d/proposed.list <<EOF
+$PROPOSED_REPO
+EOF
+chroot /tank/trusty-3a/ apt-get update
+chroot /tank/trusty-3a/ apt-get install ubuntu-advantage-tools -y
+
+# clone the first fresh snapshot and call it trusyt-3b
+zfs clone tank/trusty-minimal@fresh tank/trusty-3b
+
+# install u-a-t directly from proposed
+cat >> /tank/trusty-3b/etc/apt/sources.list <<EOF
+deb $ARCHIVE_URL trusty-updates main
+deb $ARCHIVE_URL trusty-security main
+EOF
+
+cat > /tank/trusty-3b/etc/apt/sources.list.d/proposed.list <<EOF
+$PROPOSED_REPO
+EOF
+
+chroot /tank/trusty-3b/ apt-get update
+chroot /tank/trusty-3b/ apt-get install ubuntu-advantage-tools -y
+
+# with the new u-a-t from proposed, run attach, which also enables esm
+chroot /tank/trusty-3b/ ua attach $UA_CONTRACT_TOKEN
+
+# get files from both datasets, stripping the zfs prefix
+find /tank/trusty-3a/ | sed -r 's,^/tank/[^/]+,,' | sort > trusty-3a.list
+find /tank/trusty-3b/ | sed -r 's,^/tank/[^/]+,,' | sort > trusty-3b.list
+
+# compare and verify the result
+diff -u trusty-3a.list trusty-3b.list
+--- trusty-3a.list	2019-10-24 11:20:19.207260287 -0300
++++ trusty-3b.list	2019-10-24 11:20:21.939243951 -0300
+@@ -13723,7 +13723,6 @@
+ /var/cache/apt/archives/sysv-rc_2.88dsf-41ubuntu6_all.deb
+ /var/cache/apt/archives/tar_1.27.1-1_amd64.deb
+ /var/cache/apt/archives/tzdata_2014b-1_all.deb
+-/var/cache/apt/archives/ubuntu-advantage-tools_10ubuntu0.14.04.4_all.deb
+ /var/cache/apt/archives/ubuntu-advantage-tools_19.6~ubuntu14.04.1~ppa2_amd64.deb
+ /var/cache/apt/archives/ubuntu-keyring_2012.05.19_all.deb
+ /var/cache/apt/archives/ucf_3.0027+nmu1_all.deb
+@@ -13762,10 +13761,10 @@
+ /var/lib/apt/lists/br.archive.ubuntu.com_ubuntu_dists_trusty-updates_InRelease
+ /var/lib/apt/lists/br.archive.ubuntu.com_ubuntu_dists_trusty-updates_main_binary-amd64_Packages
+ /var/lib/apt/lists/br.archive.ubuntu.com_ubuntu_dists_trusty-updates_main_i18n_Translation-en
+-/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-security_InRelease
+-/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-security_main_binary-amd64_Packages
+-/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-updates_InRelease
+-/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-updates_main_binary-amd64_Packages
++/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-infra-security_InRelease
++/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-infra-security_main_binary-amd64_Packages
++/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-infra-updates_InRelease
++/var/lib/apt/lists/esm.ubuntu.com_ubuntu_dists_trusty-infra-updates_main_binary-amd64_Packages
+ /var/lib/apt/lists/lock
+ /var/lib/apt/lists/partial
+ /var/lib/apt/lists/ppa.launchpad.net_ci-train-ppa-service_3830_ubuntu_dists_trusty_InRelease
+@@ -14881,6 +14880,16 @@
+ /var/lib/systemd/deb-systemd-helper-enabled/rsyslog.service.dsh-also
+ /var/lib/systemd/deb-systemd-helper-enabled/syslog.service
+ /var/lib/ubuntu-advantage
++/var/lib/ubuntu-advantage/machine-id
++/var/lib/ubuntu-advantage/private
++/var/lib/ubuntu-advantage/private/machine-access-cc-eal.json
++/var/lib/ubuntu-advantage/private/machine-access-esm-infra.json
++/var/lib/ubuntu-advantage/private/machine-access-fips.json
++/var/lib/ubuntu-advantage/private/machine-access-fips-updates.json
++/var/lib/ubuntu-advantage/private/machine-access-livepatch.json
++/var/lib/ubuntu-advantage/private/machine-access-support.json
++/var/lib/ubuntu-advantage/private/machine-token.json
++/var/lib/ubuntu-advantage/status.json
+ /var/lib/ucf
+ /var/lib/ucf/cache
+ /var/lib/ucf/cache/:etc:rsyslog.d:50-default.conf
+
+# since 3a just upgraded to new u-a-t but didn't run attach, it won't have the /var/lib/ubuntu-advantage contents that 3b has
+# 3a also won't have the new "infra" name in its repositories, so that's another expected difference
+# finally, 3b won't have the package from trusty-updates, since it got the proposed one installed directly
+
+# diff the contents of /etc/apt. The expected changes are:
+# - /etc/apt/auth.conf.d/90ubuntu-advantage: switch from old credentials to bearer token
+# - /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list: switch to the infra repositories
+diff -uNr /tank/trusty-3{a,b}/etc/apt
+
+
+# OPTIONAL
+# to go back to a clean state, without having to debootstrap again:
+zfs destroy tank/trusty-3a
+zfs destroy tank/trusty-3b
+zfs rollback tank/trusty-minimal@fresh
+
+# confirming
+zfs list -t all -r tank
+```

--- a/sru/1832757/esm-trusty-test-4.md
+++ b/sru/1832757/esm-trusty-test-4.md
@@ -1,0 +1,112 @@
+# Test case 4: Start from cloud-image with u-a-t installed, compar enable-esm vs ua attach
+
+4.
+ a. Start with a fresh Ubuntu instance which does have u-a-t installed. Enable esm with 'ubuntu-advantage enable-esm'. Upgrade to u-a-t from -proposed.
+ b. In an identical instance, upgrade to u-a-t from -proposed. Enable esm with 'ubuntu-advantage attach'.
+ c. Confirm that the on-disk results of a) and b) are identical other than legacyToken|contractToken
+
+```
+# Originally from https://gist.github.com/blackboxsw/0e968aeabd42c23df619d29c7906c76e
+
+export LEGACY_ESM_TOKEN=<ppauser:password>
+export UA_CONTRACT_TOKEN=<NewContractToken>
+export ARCHIVE_URL=http://archive.ubuntu.com/ubuntu
+
+echo -- BEGIN test 4a: enable esm via `ubuntu-advantage enable-esm` on typical trusty-updates cloud-images which already have -updates installed
+
+# Launch a basic trusty cloud-image that is updated to latest ubuntu-advantage-tools from -updates
+cat > update-uat-trusty.yaml <<EOF
+#cloud-config
+package_update: true
+package_upgrade: true
+runcmd:
+ - apt-get install -qy ubuntu-advantage-tools 
+EOF
+
+lxc launch ubuntu-daily:trusty esm-sru-4a -c user.user-data="$(cat update-uat-trusty.yaml)"
+
+echo "Wait for cloud-init to finish startup on trusty"
+RUNLEVEL="NOTSET"
+while ! [ "N 2" = "$RUNLEVEL" ]; do echo -n '.'; sleep 1; RUNLEVEL=`lxc exec esm-sru-4a runlevel`; done; echo
+mkdir /esm-sru
+cd /esm-sru
+mkdir 4a 4b
+
+echo "Confirm u-a-t is already installed"
+lxc exec esm-sru-4a -- apt-cache policy ubuntu-advantage-tools
+
+cat > ppa-key << EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xo0EUs00cgEEAJJqaPue5gzQiLB1krT9slYbqVW/bSBpW9+qX8gFI44IVM/Bo3yh
+9BPAs1RAzja96N0FS6SNlew4JYfk7MBT2sFDGpm3bTKt9Go7muO0JkvKv0vYgrrw
+qORlWK3SfsYa6EpsCdVzZPAKvGzc8I0XywVgcJhM5okx+3J2naBaSp9NABEBAAHN
+K0xhdW5jaHBhZCBQUEEgZm9yIENJIFRyYWluIFBQQSBTZXJ2aWNlIFRlYW3CuAQT
+AQIAIgUCUs00cgIbAwYLCQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQhVBBKOzx
+IEy62gP/T2h98ongV+RXekM1DpgTNoH0PBHrZVj4zfrvrYKZOaxRmJ6TWtzG8tFI
+uB4gPjaFeenJBhCFaZ9UncFQemS9jztQ/pA049L1N7Tijd8/BKD7gc7tM07+Fq+Q
+6DT7VuUFiVlfZUwWYzk5UXEk6ctluoIRpnRWUHmh6NssuAgd1Nk=
+=aPbC
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
+# emit script to upgrade u-a-t
+cat > add_uat_apt_pocket.sh << EOF
+#/bin/bash
+pocket_name=\$1
+if [ "\$pocket_name" = "devel" ]; then
+  echo deb [trusted=yes] http://ppa.launchpad.net/ci-train-ppa-service/3830/ubuntu trusty main | tee /etc/apt/sources.list.d/\$pocket_name.list
+  apt-key add /ppa-key
+else
+  echo deb $ARCHIVE_URL \$pocket_name main | tee /etc/apt/sources.list.d/\$pocket_name.list
+fi
+EOF
+
+lxc file push ppa-key esm-sru-4a/
+lxc file push add_uat_apt_pocket.sh esm-sru-4a/
+lxc exec esm-sru-4a chmod 755 /add_uat_apt_pocket.sh
+
+echo "Make a pristine lxc snapshot for 4a and 4b"
+lxc snapshot esm-sru-4a esm-sru-4a-pristine
+
+echo "Enable esm via ubuntu-advantage enable-esm"
+lxc exec esm-sru-4a -- ubuntu-advantage enable-esm $LEGACY_ESM_TOKEN
+
+echo "Confirm ansible is available for esm PPA"
+lxc exec esm-sru-4a apt-cache policy ansible
+
+echo "Upgrade u-a-t to trusty-proposed"
+lxc exec esm-sru-4a /add_uat_apt_pocket.sh trusty-proposed #   or devel
+lxc exec esm-sru-4a -- apt-get update -q;
+lxc exec esm-sru-4a -- apt-get install -qy ubuntu-advantage-tools;
+
+echo "Confirm ansible is available for esm PPA"
+lxc exec esm-sru-4a apt-cache policy ansible
+
+lxc exec esm-sru-4a -- find / -xdev | sort > 4a/files.list
+lxc file pull -r esm-sru-4a/etc 4a/
+
+
+echo -- BEGIN test 4b: upgrade u-a-t to -proposed version on typical trusty-updates cloud-images which already have -updates installed
+lxc restore esm-sru-4a esm-sru-4a-pristine
+
+echo "Confirm u-a-t is already installed from trusty-updates v. 10ubuntu0.14.04.4"
+lxc exec esm-sru-4a -- apt-cache policy ubuntu-advantage-tools
+
+echo "Upgrade u-a-t to trusty-proposed"
+lxc exec esm-sru-4a /add_uat_apt_pocket.sh trusty-proposed   # or devel
+lxc exec esm-sru-4a -- apt-get update -q;
+lxc exec esm-sru-4a -- apt-get install -qy ubuntu-advantage-tools;
+
+echo "Enable esm via: ua attach <contractToken>"
+lxc exec esm-sru-4a ua attach $UA_CONTRACT_TOKEN
+
+echo "Confirm ansible is available for esm PPA"
+lxc exec esm-sru-4a apt-cache policy ansible
+
+lxc exec esm-sru-4a -- find / -xdev | sort > 4b/files.list
+lxc file pull -r esm-sru-4a/etc 4b/
+
+echo --- BEGIN test 4c: ensure no filesystem diffs between 4a and 4b with exception of token used
+diff -urN 4a 4b
+```

--- a/sru/1832757/esm-trusty-test-5.md
+++ b/sru/1832757/esm-trusty-test-5.md
@@ -1,0 +1,90 @@
+# Test case 5: Start with minimal precise vm with enable-esm and dist-upgrade to trusty -poposed
+
+5.
+ a. Start with a fresh Ubuntu *precise* instance which does have u-a-t installed and esm enabled. Dist-upgrade to trusty, then upgrade to u-a-t from -proposed.
+ b. In an identical instance, dist-upgrade to trusty with -proposed enabled.
+ c. Confirm that the on-disk results of a) and b) are identical.
+
+## 5a. Start with a fresh Ubuntu *precise* instance which does have u-a-t installed and esm enabled. Dist-upgrade to trusty, then upgrade to u-a-t from -proposed.
+
+```
+# Originally from https://gist.github.com/panlinux/e5bda289401660d77ed5eff4d980c30c  10/25
+echo --- BEGIN test 5a: dist-upgrade an esm-enable precise-updates to trusty-updates, then upgrade to -proposed
+
+mkdir -p 5a/var/lib/
+echo "Launch precise container with allowing ssh access for <LP_ID>"
+
+cat >precise.yaml <<EOF
+#cloud-config
+ssh_import_id: [<LP_ID>]
+EOF
+lxc launch ubuntu-daily:precise sru-precise -c user.user-data="$(cat precise.yaml)"
+
+echo "Enable esm on precise"
+lxc exec sru-precise ubuntu-advantage enable-esm <legacyToken>
+
+echo "Dist-upgrade precise -> trusty"
+VM_IP=`lxc list dev-p -c 4 | awk '/10/{print $2}'`
+ssh ubuntu@$VM_IP
+sudo mkdir -p /etc/update-manager/release-upgrades.d
+echo -e "[Sources]\nAllowThirdParty=yes" > allow.cfg
+sudo mv allow.cfg /etc/update-manager/release-upgrades.d
+sudo do-release-upgrade # respond yes to any interactive prompts
+
+echo "Confirm ansible is available for trusty esm PPA"
+apt-cache policy ansible
+
+echo "Upgrade u-a-t to trusty-proposed"
+lxc file push ua_tools_install_from_pocket.sh sru-precise/
+lxc exec sru-precise "bash /ua_tools_install_from_pocket.sh trusty-proposed"
+
+lxc exec sru-precise -- dpkg -l > 5a/dpkg.list
+lxc file pull -r sru-precise/etc 5a/
+lxc file pull -r sru-precise/var/lib/ubuntu-advantage 5a/var/lib
+lxc stop sru-precise
+lxc delete sru-precise
+```
+
+##  b. In an identical instance, dist-upgrade to trusty with -proposed enabled.
+```
+echo --- BEGIN test 5b: dist-upgrade an esm-enable precise-proposed to trusty-proposed
+mkdir -p 5b/var/lib/
+echo "Launch precise container with allowing ssh access for <LP_ID>"
+
+cat >precise.yaml <<EOF
+#cloud-config
+ssh_import_id: [<LP_ID>]
+EOF
+lxc launch ubuntu-daily:precise sru-precise -c user.user-data="$(cat precise.yaml)"
+
+echo "Enable esm on precise"
+lxc exec sru-precise ubuntu-advantage enable-esm <legacyToken>
+
+echo "Upgrade u-a-t to precise-proposed" # no-op
+lxc file push ua_tools_install_from_pocket.sh sru-precise/
+lxc exec sru-precise "bash /ua_tools_install_from_pocket.sh sru-proposed"
+lxc exec sru-precise "apt-get dist-upgrade"
+
+echo "Dist-upgrade precise-proposed -> trusty-proposed"
+VM_IP=`lxc list dev-p -c 4 | awk '/10/{print $2}'`
+ssh ubuntu@$VM_IP
+sudo mkdir -p /etc/update-manager/release-upgrades.d
+echo -e "[Sources]\nAllowThirdParty=yes" > allow.cfg
+sudo mv allow.cfg /etc/update-manager/release-upgrades.d
+sudo do-release-upgrade # respond yes to any interactive prompts
+
+echo "Confirm ansible is available for trusty esm PPA"
+apt-cache policy ansible
+
+lxc exec sru-precise -- dpkg -l > 5b/dpkg.list
+lxc file pull -r sru-precise/etc 5b/
+lxc file pull -r sru-precise/var/lib/ubuntu-advantage 5b/var/lib
+lxc stop sru-precise
+lxc delete sru-precise
+```
+
+##  c. Confirm that the on-disk results of a) and b) are identical.
+```
+echo --- BEGIN test 5c: confirm filesytem changes of test 5a and 5b are identical
+dirr -urN 5a 5b
+```

--- a/sru/README.md
+++ b/sru/README.md
@@ -1,0 +1,12 @@
+# SRU: Collection of Stable Release Update integration tests
+## Intent
+This is a collection for scripts which have been manually run during the verification of ubuntu-advantage-client SRUs (Stable Release Updates). These scripts and their results were attached to each SRU process bug in order to pass SRU verification and publish that version of ubuntu-advantage-tools. Each subdirectory name will be the launchpad SRU process bug associated with that release. Within the subdir will be scripts that can be manually run to validate certain features of ubuntu-advantage-tools.
+
+The hope is that we can codify these manual scripts into automated behave integration tests in the future and have less and less of this manual work in subsequent SRUs. In the meantime, have a pool of scripts that exercise certain aspects of ua-tools setup and teardown is helpful reference fo future SRUs, and behave integration test writing.
+
+## SRU scripts
+
+
+| SRU bug (series)| package version | Release date | Scripts |
+| -------- | -------- | -------- | ------- |
+| [Bug #1832757](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/1832757) (trusty)    |  19.6~ubuntu14.04.2  | 11/05/2019 |  [esm-trusty-test-1.md](./1832757/esm-trusty-test-1.md)<br/>[esm-trusty-test-2.md](./1832757/esm-trusty-test-2.md)<br/>[esm-trusty-test-3.md](./1832757/esm-trusty-test-3.md)<br/>[esm-trusty-test-4.md](./1832757/esm-trusty-test-4.md)<br/>[esm-trusty-test-5.md](./1832757/esm-trusty-test-5.md)<br/> |


### PR DESCRIPTION
Add a collection of SRU manual verification scripts to an ./sru subdirectory.
We can leverage these scripts in filing SRU results as well as having a tome of scripts for reference when we have other SRU verfications to exercise.