### PR TITLE
features: make it more explicit that we use sudo for testing

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -34,14 +34,15 @@ def given_uat_is_installed(context):
     )
 
 
-@when("I run `{command}` as {user}")
-def when_i_run_command(context, command, user):
+@when("I run `{command}` {user_spec}")
+def when_i_run_command(context, command, user_spec):
     prefix = []
-    if user == "root":
+    if user_spec == "with sudo":
         prefix = ["sudo"]
-    elif user != "non-root":
+    elif user_spec != "as non-root":
         raise Exception(
-            "The two acceptable values for user are: root, non-root"
+            "The two acceptable values for user_spec are: 'with sudo',"
+            " 'as non-root'"
         )
     process = lxc_exec(
         context.container_name,

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -9,7 +9,7 @@ Feature: Command behaviour when unattached
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua detach` as root
+        When I run `ua detach` with sudo
         Then I will see the following on stderr:
             """
             This machine is not attached to a UA subscription.
@@ -25,7 +25,7 @@ Feature: Command behaviour when unattached
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua refresh` as root
+        When I run `ua refresh` with sudo
         Then I will see the following on stderr:
             """
             This machine is not attached to a UA subscription.
@@ -42,7 +42,7 @@ Feature: Command behaviour when unattached
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
-        When I run `ua enable livepatch` as root
+        When I run `ua enable livepatch` with sudo
         Then I will see the following on stderr:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -59,7 +59,7 @@ Feature: Command behaviour when unattached
             Cannot enable 'foobar'
             For a list of services see: sudo ua status
             """
-        When I run `ua enable foobar` as root
+        When I run `ua enable foobar` with sudo
         Then I will see the following on stderr:
             """
             Cannot enable 'foobar'
@@ -76,7 +76,7 @@ Feature: Command behaviour when unattached
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
-        When I run `ua disable livepatch` as root
+        When I run `ua disable livepatch` with sudo
         Then I will see the following on stderr:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -93,7 +93,7 @@ Feature: Command behaviour when unattached
             Cannot disable 'foobar'
             For a list of services see: sudo ua status
             """
-        When I run `ua disable foobar` as root
+        When I run `ua disable foobar` with sudo
         Then I will see the following on stderr:
             """
             Cannot disable 'foobar'

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -16,7 +16,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status` as root
+        When I run `ua status` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION


### PR DESCRIPTION
Running the command with sudo vs as a true root user may start to cause
differences in light of #873, so let's be explicit that we're using
sudo.