### PR TITLE
pkg: rename existing ubuntu-esm-precise.list file to trusty

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -63,14 +63,10 @@ case "$1" in
       # do-release-upgrade substitutes s/precise/trusty/ in all apt sources.
       # So all we need to do is rename the precise sources file to trusty.
       # https://github.com/CanonicalLtd/ubuntu-advantage-client/issues/693
-      case $PREVIOUS_PKG_VER in
-          1) # upgraded from precise which will only ever have version 1
-              if [ -e "$ESM_APT_SOURCE_FILE_PRECISE" ]; then
-                  mv $ESM_APT_SOURCE_FILE_PRECISE \
-                      $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
-              fi
-              ;;
-      esac
+      if [ -e "$ESM_APT_SOURCE_FILE_PRECISE" ]; then
+          mv $ESM_APT_SOURCE_FILE_PRECISE \
+              $ESM_INFRA_APT_SOURCE_FILE_TRUSTY
+      fi
 
       # We changed the way we store public files in 19.5
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "19.5~"; then


### PR DESCRIPTION
When upgrading from precise to trusty and esm is enabled,
ubuntu-advantage-tools v 10ubuntu0.14.04.4 does not rename
any apt precise apt sources files to trusty.

So if customers have already upgraded from precise enabled-esm to trusty
10ubuntu0.14.04.4, a subsequent upgrade to version 19.6 will
skip trying to rename:
ubuntu-esm-precise.list -> ubuntu-esm-infra-trusty.list.

postinst unconditionally renames ubuntu-esm-precise.list to
ubuntu-esm-infra-trusty.list. It no longer limits this rename
operation to the case where postinst is upgrading from version 1 (the precise
package version)

Fixes: #899