### PR TITLE
Integration tests: actually run non-root tests as non-root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
     - python: 3.7
       env: TOXENV=behave
       script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
+          - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c 'make test'
@@ -64,6 +69,11 @@ matrix:
     - python: 3.7
       env: TOXENV=behave
       script:
+          # bionic has lxd from deb installed, remove it first to avoid
+          # confusion over versions
+          - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo rm -Rf /var/lib/lxd
+          - sudo snap install lxd
           - sudo lxd init --auto
           - sudo usermod -a -G lxd $USER
           - sg lxd -c 'make test'

--- a/features/environment.py
+++ b/features/environment.py
@@ -143,13 +143,14 @@ def _install_uat_in_container(container_name: str) -> None:
     lxc_exec(
         container_name,
         [
+            "sudo",
             "add-apt-repository",
             "--yes",
             "ppa:canonical-server/ua-client-daily",
         ],
     )
-    lxc_exec(container_name, ["apt-get", "update", "-qq"])
+    lxc_exec(container_name, ["sudo", "apt-get", "update", "-qq"])
     lxc_exec(
         container_name,
-        ["apt-get", "install", "-qq", "-y", "ubuntu-advantage-tools"],
+        ["sudo", "apt-get", "install", "-qq", "-y", "ubuntu-advantage-tools"],
     )

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -17,14 +17,15 @@ def given_a_trusty_lxd_container(context):
     launch_lxd_container(context, context.image_name, context.container_name)
 
 
-@when("I run `{command}` as {user}")
-def when_i_run_command(context, command, user):
+@when("I run `{command}` {user_spec}")
+def when_i_run_command(context, command, user_spec):
     prefix = []
-    if user == "root":
+    if user_spec == "with sudo":
         prefix = ["sudo"]
-    elif user != "non-root":
+    elif user_spec != "as non-root":
         raise Exception(
-            "The two acceptable values for user are: root, non-root"
+            "The two acceptable values for user_spec are: 'with sudo',"
+            " 'as non-root'"
         )
     process = lxc_exec(
         context.container_name,

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -5,8 +5,7 @@ Feature: Command behaviour when unattached
         When I run `ua detach` as non-root
         Then I will see the following on stderr:
             """
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            This command must be run as root (try using sudo)
             """
         When I run `ua detach` with sudo
         Then I will see the following on stderr:
@@ -20,8 +19,7 @@ Feature: Command behaviour when unattached
         When I run `ua refresh` as non-root
         Then I will see the following on stderr:
             """
-            This machine is not attached to a UA subscription.
-            See https://ubuntu.com/advantage
+            This command must be run as root (try using sudo)
             """
         When I run `ua refresh` with sudo
         Then I will see the following on stderr:
@@ -35,9 +33,7 @@ Feature: Command behaviour when unattached
         When I run `ua enable livepatch` as non-root
         Then I will see the following on stderr:
             """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
+            This command must be run as root (try using sudo)
             """
         When I run `ua enable livepatch` with sudo
         Then I will see the following on stderr:
@@ -52,8 +48,7 @@ Feature: Command behaviour when unattached
         When I run `ua enable foobar` as non-root
         Then I will see the following on stderr:
             """
-            Cannot enable 'foobar'
-            For a list of services see: sudo ua status
+            This command must be run as root (try using sudo)
             """
         When I run `ua enable foobar` with sudo
         Then I will see the following on stderr:
@@ -67,9 +62,7 @@ Feature: Command behaviour when unattached
         When I run `ua disable livepatch` as non-root
         Then I will see the following on stderr:
             """
-            To use 'livepatch' you need an Ubuntu Advantage subscription
-            Personal and community subscriptions are available at no charge
-            See https://ubuntu.com/advantage
+            This command must be run as root (try using sudo)
             """
         When I run `ua disable livepatch` with sudo
         Then I will see the following on stderr:
@@ -84,8 +77,7 @@ Feature: Command behaviour when unattached
         When I run `ua disable foobar` as non-root
         Then I will see the following on stderr:
             """
-            Cannot disable 'foobar'
-            For a list of services see: sudo ua status
+            This command must be run as root (try using sudo)
             """
         When I run `ua disable foobar` with sudo
         Then I will see the following on stderr:

--- a/features/unattached_commands.feature
+++ b/features/unattached_commands.feature
@@ -8,7 +8,7 @@ Feature: Command behaviour when unattached
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua detach` as root
+        When I run `ua detach` with sudo
         Then I will see the following on stderr:
             """
             This machine is not attached to a UA subscription.
@@ -23,7 +23,7 @@ Feature: Command behaviour when unattached
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua refresh` as root
+        When I run `ua refresh` with sudo
         Then I will see the following on stderr:
             """
             This machine is not attached to a UA subscription.
@@ -39,7 +39,7 @@ Feature: Command behaviour when unattached
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
-        When I run `ua enable livepatch` as root
+        When I run `ua enable livepatch` with sudo
         Then I will see the following on stderr:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -55,7 +55,7 @@ Feature: Command behaviour when unattached
             Cannot enable 'foobar'
             For a list of services see: sudo ua status
             """
-        When I run `ua enable foobar` as root
+        When I run `ua enable foobar` with sudo
         Then I will see the following on stderr:
             """
             Cannot enable 'foobar'
@@ -71,7 +71,7 @@ Feature: Command behaviour when unattached
             Personal and community subscriptions are available at no charge
             See https://ubuntu.com/advantage
             """
-        When I run `ua disable livepatch` as root
+        When I run `ua disable livepatch` with sudo
         Then I will see the following on stderr:
             """
             To use 'livepatch' you need an Ubuntu Advantage subscription
@@ -87,7 +87,7 @@ Feature: Command behaviour when unattached
             Cannot disable 'foobar'
             For a list of services see: sudo ua status
             """
-        When I run `ua disable foobar` as root
+        When I run `ua disable foobar` with sudo
         Then I will see the following on stderr:
             """
             Cannot disable 'foobar'

--- a/features/unattached_status.feature
+++ b/features/unattached_status.feature
@@ -15,7 +15,7 @@ Feature: Unattached status
             This machine is not attached to a UA subscription.
             See https://ubuntu.com/advantage
             """
-        When I run `ua status` as root
+        When I run `ua status` with sudo
         Then I will see the following on stdout:
             """
             SERVICE       AVAILABLE  DESCRIPTION

--- a/features/util.py
+++ b/features/util.py
@@ -30,7 +30,7 @@ def launch_lxd_container(
 
 
 def lxc_exec(
-    container_name: str, cmd: List[str], *args: Any, **kwargs: Any
+    container_name: str, cmd: List[str], **kwargs: Any
 ) -> subprocess.CompletedProcess:
     """Run `lxc exec` in a container.
 
@@ -39,14 +39,14 @@ def lxc_exec(
     :param cmd:
         A list containing the command to be run and its parameters; this will
         be appended to a list that is passed to `subprocess.run`.
-    :param args, kwargs:
+    :param kwargs:
         These are passed directly to `subprocess.run`.
 
     :return:
         The `subprocess.CompletedProcess` returned by `subprocess.run`.
     """
     return subprocess.run(
-        ["lxc", "exec", container_name, "--"] + cmd, *args, **kwargs
+        ["lxc", "exec", container_name, "--"] + cmd, **kwargs
     )
 
 

--- a/features/util.py
+++ b/features/util.py
@@ -46,7 +46,7 @@ def lxc_exec(
         The `subprocess.CompletedProcess` returned by `subprocess.run`.
     """
     return subprocess.run(
-        ["lxc", "exec", container_name, "--"] + cmd, **kwargs
+        ["lxc", "exec", "--user", "1000", container_name, "--"] + cmd, **kwargs
     )
 
 


### PR DESCRIPTION
`lxc exec` runs as root by default, so we modify the way we call it to specify UID 1000. This also updates other code that uses `lxc_exec` to add `sudo` if needed, and fixes the feature files to reflect the actual non-root output.