### PR TITLE
pkg: dpkg-buildpackage should not package integration tests features dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     name=NAME,
     version=_get_version(),
     packages=setuptools.find_packages(
-        exclude=['*.testing', 'tests.*', '*.tests', 'tests']
+        exclude=['*.testing', 'tests.*', '*.tests', 'tests', 'features']
     ),
     data_files=[
         ('/etc/apt/apt.conf.d', ['apt.conf.d/51ubuntu-advantage-esm']),


### PR DESCRIPTION
Fixes: #903

# To test
```
lxc launch ubuntu-daily:trusty dev-t
lxc exec dev-t bash
git clone this branch
cd ubuntu-advantage-client
make deps
dpkg-buildpackage -us -uc
dpkg -c ../ubuntu-advantage-tools_19.6_amd64.deb | grep feature
```