### PR TITLE
pkg: dpkg-buildpackage should also ignore all modules under features dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     name=NAME,
     version=_get_version(),
     packages=setuptools.find_packages(
-        exclude=['*.testing', 'tests.*', '*.tests', 'tests', 'features']
+        exclude=['*.testing', 'tests.*', '*.tests', 'tests', 'features', 'features.*']
     ),
     data_files=[
         ('/etc/apt/apt.conf.d', ['apt.conf.d/51ubuntu-advantage-esm']),


### PR DESCRIPTION
Fixes: #903




# Testing performed on a clean trusty vm:
```
# Built deb via dpkg-buildpackage -us -uc

 dpkg-genchanges  >../ubuntu-advantage-tools_19.6_amd64.changes
dpkg-genchanges: including full source code in upload
 dpkg-source --after-build ubuntu-advantage-client
dpkg-buildpackage: full upload; Debian-native package (full source is included)

# confirm that no sru files or features files or submodules are included in the deb
root@dev-t:~/ubuntu-advantage-client# dpkg -c ../ubuntu-advantage-tools_19.6_amd64.deb | egrep 'sru|entitlements|feature'
drwxr-xr-x root/root         0 2019-10-30 19:28 ./usr/lib/python3/dist-packages/uaclient/entitlements/
-rw-r--r-- root/root      3056 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/fips.py
-rw-r--r-- root/root     13728 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/base.py
-rw-r--r-- root/root       803 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/cc.py
-rw-r--r-- root/root      9703 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/livepatch.py
-rw-r--r-- root/root       464 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/cis.py
-rw-r--r-- root/root       472 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/esm.py
-rw-r--r-- root/root     11551 2019-10-30 18:12 ./usr/lib/python3/dist-packages/uaclient/entitlements/repo.py
-rw-r--r-- root/root       900 2019-10-29 18:45 ./usr/lib/python3/dist-packages/uaclient/entitlements/__init__.py
```
