### PR TITLE
status: dynamic available status now from refreshed machine-token

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -288,7 +288,9 @@ class UAConfig:
                 contractInfo["effectiveTo"], "%Y-%m-%dT%H:%M:%SZ"
             )
 
-        resources = get_available_resources(self)
+        resources = self.machine_token.get("availableResources")
+        if not resources:
+            resources = get_available_resources(self)
         inapplicable_resources = {
             resource["name"]: resource.get("description")
             for resource in sorted(resources, key=lambda x: x["name"])

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -78,6 +78,7 @@ class FakeConfig(UAConfig):
     ):
         value = {
             "machine-token": {
+                "availableResources": [],
                 "machineToken": "not-null",
                 "machineTokenInfo": {
                     "accountInfo": {"id": "acct-1", "name": account_name},

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -21,6 +21,7 @@ M_PATH = "uaclient.cli."
 
 # Also used in test_cli_auto_attach.py
 BASIC_MACHINE_TOKEN = {
+    "availableResources": [],
     "machineTokenInfo": {
         "contractInfo": {
             "name": "mycontract",
@@ -28,7 +29,7 @@ BASIC_MACHINE_TOKEN = {
             "resourceEntitlements": [],
         },
         "accountInfo": {"id": "acct-1", "name": "accountName"},
-    }
+    },
 }
 
 

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -7,7 +7,7 @@ import urllib
 from uaclient.contract import (
     API_V1_CONTEXT_MACHINE_TOKEN,
     API_V1_RESOURCES,
-    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH,
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE,
     API_V1_TMPL_RESOURCE_MACHINE_ACCESS,
     ContractAPIError,
     UAContractClient,
@@ -139,7 +139,7 @@ class TestGetAvailableResources:
 
 class TestRequestUpdatedContract:
 
-    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH.format(
+    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
         contract="cid", machine="mid"
     )
     access_route_ent1 = API_V1_TMPL_RESOURCE_MACHINE_ACCESS.format(


### PR DESCRIPTION
For attached machines only.

When `ua enable <SERVICE>` or `ua refresh` is called, the client
now POSTs updated arch, kernel and OS information to the contracts
server. The contract server response will contain an updated
'availableResources' key which updates the 'status' and 'description'
columns for each applicable/inapplicable service.

This is a followup branch iteratively improving the behavior introduced
by fixing #790 to add dynamic description content from the backend
server. Now uaclient performs less API calls by avoiding a round trip to
contracts.canonical.com/v1/resources to obtain updated status
information.

There will need to be a single followup branch that will address a  gap in this behavior (#913): 
On trusty vm with stock kernel:
```
sudo ua attach
sudo apt-get install --install-recommends linux-generic-lts-xenial  
sudo reboot             # boot into HWE kernel
;   # machine-token not yet refreshed, so any ua status will still report:
;  #  livepatch     yes       n/a       Available with the HWE kernel
sudo ua status
```