### PR TITLE
Ua nonx86 fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-advantage-tools (19.6~ubuntu14.04.4) trusty; urgency=medium
+
+  * d/postinst: only configure ESM on supported architectures (LP: #1851858)
+
+ -- Andreas Hasenack <andreas@canonical.com>  Mon, 11 Nov 2019 09:56:46 -0300
+
 ubuntu-advantage-tools (19.6~ubuntu14.04.3) trusty; urgency=medium
 
   * d/postinst: rename existing ubuntu-esm-precise.list file to trusty.

--- a/debian/postinst
+++ b/debian/postinst
@@ -17,6 +17,8 @@ ESM_INFRA_APT_SOURCE_FILE_TRUSTY="$APT_SRC_DIR/ubuntu-esm-infra-trusty.list"
 ESM_APT_PREF_FILE_TRUSTY="/etc/apt/preferences.d/ubuntu-esm-trusty"
 ESM_INFRA_APT_PREF_FILE_TRUSTY="/etc/apt/preferences.d/ubuntu-esm-infra-trusty"
 
+MYARCH="$(dpkg --print-architecture)"
+ESM_SUPPORTED_ARCHS="i386 amd64"
 
 unconfigure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
@@ -78,8 +80,15 @@ case "$1" in
       rm -rf /var/cache/ubuntu-advantage-tools
 
       if [ "14.04" = "$VERSION_ID" ]; then
-        configure_esm
+        if echo "$ESM_SUPPORTED_ARCHS" | grep -qw "$MYARCH"; then
+          # 14.04 and supported arch
+          configure_esm
+        else
+          # 14.04 and unsupported arch
+          unconfigure_esm
+        fi
       else
+        # not 14.04, regardless of arch
         unconfigure_esm
       fi
       if [ ! -f /var/log/ubuntu-advantage.log ]; then


### PR DESCRIPTION
Fixes issue #911 

I'm using `dpkg --print-architecture` and not `uname -a`, but it's fine since it's contained in the postinst script. This does introduce another point where the list of supported architectures for esm-infra is stored, however. If this list ever changes, an SRU will be needed.
@blackboxsw wondered if we couldn't do something dynamic in postinst, but that would involve a network call, like `ua status` already does. It could be an option I guess, and fallback to a hardcoded list if the network isn't available, but it might be frowned upon, and will not work in our builders and DEP8 runners (egress filtering would block it).
