### PR TITLE
Demo/aws premium

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -328,7 +328,7 @@ def action_attach_premium(args, cfg):
     if os.getuid() != 0:
         raise exceptions.NonRootUserError()
     cloud_type = identity.get_cloud_type()
-    if cloud_type != "aws":
+    if cloud_type not in ("aws", "ec2"):
         print(
             "Premium image support is not supported on '%s'.\n"
             "For more information see: https://ubuntu.com/advantage"

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -30,7 +30,10 @@ def get_cloud_type() -> str:
 def cloud_instance_factory() -> clouds.UAPremiumCloudInstance:
     from uaclient.clouds import aws
 
-    cloud_instance_map = {"aws": aws.UAPremiumAWSInstance}
+    cloud_instance_map = {
+        "aws": aws.UAPremiumAWSInstance,
+        "ec2": aws.UAPremiumAWSInstance,
+    }
 
     cloud_type = get_cloud_type()
     if not cloud_type:

--- a/upstart/ua-premium.conf
+++ b/upstart/ua-premium.conf
@@ -6,7 +6,8 @@
 
 description    "Ubuntu Advantage premium attach"
 
-start on runlevel [2345]
+# Only start once cloud-init finishes detecting the DataSource on trusty
+start on file FILE=/var/lib/cloud/data/result.json
 
 task
 # Attempt to attach-premium action if machine is not already attached


### PR DESCRIPTION
- Update upstart "start on" condition to only exec once cloud-init emits /var/lib/cloud/data/result.json
- Add 'ec2' alias for cloud platform name on Trusty