### PR TITLE
premium: add aws support for premium images

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -78,6 +78,18 @@ def assert_attached(unattached_msg_tmpl=None):
     return wrapper
 
 
+def assert_not_attached(f):
+    """Decorator asserting unattached config."""
+
+    @wraps(f)
+    def new_f(args, cfg):
+        if cfg.is_attached:
+            raise exceptions.AlreadyAttachedError(cfg)
+        return f(args, cfg)
+
+    return new_f
+
+
 def require_valid_entitlement_name(operation: str):
     """Decorator ensuring that args.name is a valid service.
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -114,7 +114,7 @@ def require_valid_entitlement_name(operation: str):
 
 
 def attach_premium_parser(parser):
-    """Build or extend an arg parser for init-attach subcommand."""
+    """Build or extend an arg parser for attach-premium subcommand."""
     parser.prog = "attach-premium"
     parser.usage = USAGE_TMPL.format(name=NAME, command=parser.prog)
     parser._optionals.title = "Flags"

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -327,18 +327,11 @@ def action_detach(args, cfg):
     return 0
 
 
+@assert_not_attached
+@assert_root
 def action_attach_premium(args, cfg):
     from uaclient.clouds import identity
 
-    if cfg.is_attached:
-        print(
-            "This machine is already attached to '{}'.".format(
-                cfg.accounts[0]["name"]
-            )
-        )
-        return 0
-    if os.getuid() != 0:
-        raise exceptions.NonRootUserError()
     cloud_type = identity.get_cloud_type()
     if cloud_type not in ("aws",):  # TODO(avoid hard-coding supported types)
         print(
@@ -369,16 +362,9 @@ def action_attach_premium(args, cfg):
     )
 
 
+@assert_not_attached
+@assert_root
 def action_attach(args, cfg):
-    if cfg.is_attached:
-        print(
-            "This machine is already attached to '{}'.".format(
-                cfg.accounts[0]["name"]
-            )
-        )
-        return 0
-    if os.getuid() != 0:
-        raise exceptions.NonRootUserError()
     if not args.token:
         raise exceptions.UserFacingError(
             ua_status.MESSAGE_ATTACH_REQUIRES_TOKEN

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -587,7 +587,7 @@ def main_error_handler(func):
             with util.disable_log_to_console():
                 logging.exception(exc.msg)
             print("{}".format(exc.msg), file=sys.stderr)
-            sys.exit(1)
+            sys.exit(exc.exit_code)
 
     return wrapper
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -18,6 +18,7 @@ from uaclient import exceptions
 from uaclient import status as ua_status
 from uaclient import util
 from uaclient import version
+from uaclient.clouds import identity
 
 NAME = "ua"
 
@@ -348,9 +349,6 @@ def _attach_with_token(
 @assert_not_attached
 @assert_root
 def action_attach_premium(args, cfg):
-    # TODO(import identity from the top of the module)
-    from uaclient.clouds import identity
-
     cloud_type = identity.get_cloud_type()
     if cloud_type not in ("aws",):  # TODO(avoid hard-coding supported types)
         print(

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,0 +1,15 @@
+import abc
+
+
+class UAPremiumCloudInstance(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def identity_doc(self) -> str:
+        """Return the identity document representing this cloud instance"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def is_viable(self) -> bool:
+        """Return True if the machine is a viable UAPremiumCloudInstance."""
+        pass

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -1,0 +1,27 @@
+from uaclient.clouds import UAPremiumCloudInstance
+from uaclient import util
+
+IMDS_URL = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
+SYS_HYPERVISOR_PRODUCT_UUID = "/sys/hypervisor/uuid"
+DMI_PRODUCT_SERIAL = "/sys/class/dmi/id/product_serial"
+DMI_PRODUCT_UUID = "/sys/class/dmi/id/product_uuid"
+
+
+class UAPremiumAWSInstance(UAPremiumCloudInstance):
+    @property
+    def identity_doc(self):
+        response, _headers = util.readurl(IMDS_URL)
+        return response
+
+    @property
+    def is_viable(self):
+        """This machine is a viable AWSInstance"""
+        hypervisor_uuid = util.load_file(SYS_HYPERVISOR_PRODUCT_UUID)
+        if "ec2" == hypervisor_uuid[0:3]:
+            return True
+        # Both DMI product_uuid and product_serial start with 'ec2'
+        dmi_uuid = util.load_file(DMI_PRODUCT_UUID).lower()
+        dmi_serial = util.load_file(DMI_PRODUCT_SERIAL).lower()
+        if "ec2" == dmi_uuid[0:3] == dmi_serial[0:3]:
+            return True
+        return False

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -15,7 +15,7 @@ DATASOURCE_TO_CLOUD_ID = {"ec2": "aws"}
 def get_cloud_type_from_result_file(
     result_file: str = CLOUDINIT_RESULT_FILE
 ) -> str:
-    result = json.loads((util.load_file(result_file)))
+    result = json.loads(util.load_file(result_file))
     dsname = result["v1"]["datasource"].split()[0].lower()
     dsname = dsname.replace("datasource", "")
     return DATASOURCE_TO_CLOUD_ID.get(dsname, dsname)

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -5,6 +5,12 @@ from uaclient import clouds
 from uaclient import status
 from uaclient import util
 
+try:
+    from typing import Optional  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 CLOUDINIT_RESULT_FILE = "/var/lib/cloud/data/result.json"
 
 
@@ -21,7 +27,7 @@ def get_cloud_type_from_result_file(
     return DATASOURCE_TO_CLOUD_ID.get(dsname, dsname)
 
 
-def get_cloud_type() -> str:
+def get_cloud_type() -> "Optional[str]":
     if util.which("cloud-id"):
         # Present in cloud-init on >= Xenial
         out, _err = util.subp(["cloud-id"])
@@ -30,7 +36,7 @@ def get_cloud_type() -> str:
         return get_cloud_type_from_result_file()
     except FileNotFoundError:
         pass
-    return ""
+    return None
 
 
 def cloud_instance_factory() -> clouds.UAPremiumCloudInstance:

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -12,7 +12,9 @@ CLOUDINIT_RESULT_FILE = "/var/lib/cloud/data/result.json"
 DATASOURCE_TO_CLOUD_ID = {"ec2": "aws"}
 
 
-def get_cloud_type_from_result_file(result_file=CLOUDINIT_RESULT_FILE) -> str:
+def get_cloud_type_from_result_file(
+    result_file: str = CLOUDINIT_RESULT_FILE
+) -> str:
     result = json.loads((util.load_file(result_file)))
     dsname = result["v1"]["datasource"].split()[0].lower()
     dsname = dsname.replace("datasource", "")

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -1,0 +1,55 @@
+import json
+
+from uaclient import exceptions
+from uaclient import clouds
+from uaclient import status
+from uaclient import util
+
+CLOUDINIT_RESULT_FILE = "/var/lib/cloud/data/result.json"
+
+
+# Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
+DATASOURCE_TO_CLOUD_ID = {"ec2": "aws"}
+
+
+def get_cloud_type_from_result_file(result_file=CLOUDINIT_RESULT_FILE) -> str:
+    result = json.loads((util.load_file(result_file)))
+    dsname = result["v1"]["datasource"].split()[0].lower()
+    dsname = dsname.replace("datasource", "")
+    return DATASOURCE_TO_CLOUD_ID.get(dsname, dsname)
+
+
+def get_cloud_type() -> str:
+    if util.which("cloud-id"):
+        # Present in cloud-init on >= Xenial
+        out, _err = util.subp(["cloud-id"])
+        return out.strip()
+    try:
+        return get_cloud_type_from_result_file()
+    except FileNotFoundError:
+        pass
+    return ""
+
+
+def cloud_instance_factory() -> clouds.UAPremiumCloudInstance:
+    from uaclient.clouds import aws
+
+    cloud_instance_map = {"aws": aws.UAPremiumAWSInstance}
+
+    cloud_type = get_cloud_type()
+    if not cloud_type:
+        raise exceptions.UserFacingError(
+            "Unable to determine premium image platform support\n"
+            "For more information see: https://ubuntu.com/advantage"
+        )
+    cls = cloud_instance_map.get(cloud_type)
+    if not cls:
+        raise exceptions.UserFacingError(
+            status.MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE.format(
+                cloud_type=cloud_type
+            )
+        )
+    instance = cls()
+    if not instance.is_viable:
+        raise exceptions.UserFacingError(status.MESSAGE_UNSUPPORTED_PREMIUM)
+    return instance

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -47,8 +47,7 @@ def cloud_instance_factory() -> clouds.UAPremiumCloudInstance:
     cloud_type = get_cloud_type()
     if not cloud_type:
         raise exceptions.UserFacingError(
-            "Unable to determine premium image platform support\n"
-            "For more information see: https://ubuntu.com/advantage"
+            status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE
         )
     cls = cloud_instance_map.get(cloud_type)
     if not cls:

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -1,0 +1,56 @@
+import mock
+
+import pytest
+
+from uaclient.clouds.aws import UAPremiumAWSInstance
+
+M_PATH = "uaclient.clouds.aws."
+
+
+class TestUAPremiumAWSInstance:
+    @mock.patch(M_PATH + "util.readurl")
+    def test_identity_doc_from_aws_url_pkcs7(self, readurl):
+        """Return pkcs7 content from IMDS as AWS' identity doc"""
+        readurl.return_value = "pkcs7WOOT!==", {"header": "stuff"}
+        instance = UAPremiumAWSInstance()
+        assert "pkcs7WOOT!==" == instance.identity_doc
+        url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
+        assert [mock.call(url)] == readurl.call_args_list
+
+    @pytest.mark.parametrize("uuid", ("ec2", "ec2yep"))
+    @mock.patch(M_PATH + "util.load_file")
+    def test_is_viable_based_on_sys_hypervisor_uuid(self, load_file, uuid):
+        """Viable ec2 platform is determined by /sys/hypervisor/uuid prefix"""
+        load_file.return_value = uuid
+        instance = UAPremiumAWSInstance()
+        assert True is instance.is_viable
+
+    @pytest.mark.parametrize(
+        "hypervisor_uuid,prod_uuid,prod_serial,viable",
+        (
+            ("notec2", "ec2UUID", "ec2Serial", True),
+            ("notec2", "EC2UUID", "Ec2Serial", True),
+            ("notec2", "!EC2UUID", "Ec2Serial", False),
+            ("notec2", "EC2UUID", "1Ec2Serial", False),
+            ("notec2", "ec2UUID", "ec3Serial", False),
+            ("notec2", "ec3UUID", "ec2Serial", False),
+        ),
+    )
+    @mock.patch(M_PATH + "util.load_file")
+    def test_is_viable_based_on_sys_product_serial_and_uuid(
+        self, load_file, hypervisor_uuid, prod_uuid, prod_serial, viable
+    ):
+        """Platform is viable when product serial and uuid start with ec2"""
+
+        def fake_load_file(f_name):
+            if f_name == "/sys/hypervisor/uuid":
+                return hypervisor_uuid
+            if f_name == "/sys/class/dmi/id/product_uuid":
+                return prod_uuid
+            if f_name == "/sys/class/dmi/id/product_serial":
+                return prod_serial
+            raise AssertionError("Invalid load_file of {}".format(f_name))
+
+        load_file.side_effect = fake_load_file
+        instance = UAPremiumAWSInstance()
+        assert viable is instance.is_viable

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -57,6 +57,16 @@ class TestGetCloudType:
         assert "cloud9" == get_cloud_type()
         assert [mock.call()] == m_cloud_type_from_result_file.call_args_list
 
+    @mock.patch(M_PATH + "util.which", return_value=None)
+    @mock.patch(
+        M_PATH + "get_cloud_type_from_result_file",
+        side_effect=FileNotFoundError,
+    )
+    def test_fallback_if_no_cloud_type_found(
+        self, m_cloud_type_from_result_file, m_which
+    ):
+        assert "" == get_cloud_type()
+
 
 @mock.patch(M_PATH + "get_cloud_type")
 class TestCloudInstanceFactory:

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -1,6 +1,5 @@
 import json
 import mock
-import textwrap
 
 import pytest
 
@@ -75,13 +74,10 @@ class TestCloudInstanceFactory:
         m_get_cloud_type.return_value = None
         with pytest.raises(exceptions.UserFacingError) as excinfo:
             cloud_instance_factory()
-        error_msg = textwrap.dedent(
-            """\
-        Unable to determine premium image platform support
-        For more information see: https://ubuntu.com/advantage"""
-        )
         assert 1 == m_get_cloud_type.call_count
-        assert error_msg == str(excinfo.value)
+        assert status.MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE == str(
+            excinfo.value
+        )
 
     def test_raise_error_when_not_aws(self, m_get_cloud_type):
         """Raise appropriate error when unable to determine cloud_type."""

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -1,0 +1,102 @@
+import json
+import mock
+import textwrap
+
+import pytest
+
+from uaclient.clouds.identity import (
+    cloud_instance_factory,
+    get_cloud_type,
+    get_cloud_type_from_result_file,
+)
+from uaclient import exceptions
+from uaclient import status
+
+M_PATH = "uaclient.clouds.identity."
+
+
+class TestGetCloudTypeFromResultFile:
+    @pytest.mark.parametrize(
+        "ds_name,expected",
+        (
+            ("DataSourceSomeTHING", "something"),
+            ("DaTaSoUrCeMiNe", "mine"),
+            ("DataSourceEc2", "aws"),
+            ("DataSourceEc2Lookalike", "ec2lookalike"),
+        ),
+    )
+    def test_get_cloud_type_from_lowercase_v1_datasource_key(
+        self, ds_name, expected, tmpdir
+    ):
+        """The value of cloud_type is extacted from results datasource key.
+
+        ec2 gets mapped to aws"""
+        results = {"v1": {"datasource": ds_name}}
+        result_file = tmpdir.join("result.json")
+        result_file.write(json.dumps(results))
+        cloud_type = get_cloud_type_from_result_file(result_file.strpath)
+        assert cloud_type == expected
+
+
+class TestGetCloudType:
+    @mock.patch(M_PATH + "util.which", return_value="/usr/bin/cloud-id")
+    @mock.patch(M_PATH + "util.subp", return_value=("somecloud\n", ""))
+    def test_use_cloud_id_when_available(self, m_subp, m_which):
+        """Use cloud-id utility to discover cloud type."""
+        assert "somecloud" == get_cloud_type()
+        assert [mock.call("cloud-id")] == m_which.call_args_list
+
+    @mock.patch(
+        M_PATH + "get_cloud_type_from_result_file", return_value="cloud9"
+    )
+    @mock.patch(M_PATH + "util.which", return_value=None)
+    def test_fallback_to_get_cloud_type_from_result_file(
+        self, m_subp, m_cloud_type_from_result_file
+    ):
+        """Use cloud-id utility to discover cloud type."""
+        assert "cloud9" == get_cloud_type()
+        assert [mock.call()] == m_cloud_type_from_result_file.call_args_list
+
+
+@mock.patch(M_PATH + "get_cloud_type")
+class TestCloudInstanceFactory:
+    def test_raise_error_when_unable_to_get_cloud_type(self, m_get_cloud_type):
+        """Raise appropriate error when unable to determine cloud_type."""
+        m_get_cloud_type.return_value = None
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            cloud_instance_factory()
+        error_msg = textwrap.dedent(
+            """\
+        Unable to determine premium image platform support
+        For more information see: https://ubuntu.com/advantage"""
+        )
+        assert 1 == m_get_cloud_type.call_count
+        assert error_msg == str(excinfo.value)
+
+    def test_raise_error_when_not_aws(self, m_get_cloud_type):
+        """Raise appropriate error when unable to determine cloud_type."""
+        m_get_cloud_type.return_value = "nonaws"
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            cloud_instance_factory()
+        error_msg = status.MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE.format(
+            cloud_type="nonaws"
+        )
+        assert error_msg == str(excinfo.value)
+
+    @mock.patch("uaclient.clouds.aws.UAPremiumAWSInstance")
+    def test_raise_error_when_not_viable_aws_premium(
+        self, m_aws_instance, m_get_cloud_type
+    ):
+        """Raise appropriate error when the AWS instance is not viable."""
+        m_get_cloud_type.return_value = "aws"
+
+        def fake_aws_instance():
+            instance = mock.Mock()
+            instance.is_viable = False
+            return instance
+
+        m_aws_instance.side_effect = fake_aws_instance
+        with pytest.raises(exceptions.UserFacingError) as excinfo:
+            cloud_instance_factory()
+        error_msg = status.MESSAGE_UNSUPPORTED_PREMIUM
+        assert error_msg == str(excinfo.value)

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -28,7 +28,7 @@ class TestGetCloudTypeFromResultFile:
     def test_get_cloud_type_from_lowercase_v1_datasource_key(
         self, ds_name, expected, tmpdir
     ):
-        """The value of cloud_type is extacted from results datasource key.
+        """The value of cloud_type is extracted from results datasource key.
 
         ec2 gets mapped to aws"""
         results = {"v1": {"datasource": ds_name}}

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -65,7 +65,7 @@ class TestGetCloudType:
     def test_fallback_if_no_cloud_type_found(
         self, m_cloud_type_from_result_file, m_which
     ):
-        assert "" == get_cloud_type()
+        assert get_cloud_type() is None
 
 
 @mock.patch(M_PATH + "get_cloud_type")

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -106,8 +106,8 @@ class UAContractClient(serviceclient.UAServiceClient):
         )
         return resource_response
 
-    def request_premium_aws_attach(self, pkcs7: str):
-        """Requests machine attach for premium images on AWS.
+    def request_premium_aws_contract_token(self, pkcs7: str):
+        """Requests contract token for premium images on AWS.
 
         @param pkcs7: string obtained from AWS metadata service from
             http://169.254.169.254/latest/dynamic/instance-identity/pkcs7

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -22,6 +22,7 @@ API_V1_RESOURCES = "/v1/resources"
 API_V1_TMPL_RESOURCE_MACHINE_ACCESS = (
     "/v1/resources/{resource}/context/machines/{machine}"
 )
+API_V1_PREMIUM_AWS_TOKEN = "/v1/clouds/aws/token"
 
 
 class ContractAPIError(util.UrlError):
@@ -104,6 +105,22 @@ class UAContractClient(serviceclient.UAServiceClient):
             API_V1_RESOURCES + "?" + urllib.parse.urlencode(query_params)
         )
         return resource_response
+
+    def request_premium_aws_attach(self, pkcs7: str):
+        """Requests machine attach for premium images on AWS.
+
+        @param pkcs7: string obtained from AWS metadata service from
+            http://169.254.169.254/latest/dynamic/instance-identity/pkcs7
+            from this instance.
+
+        @return: Dict of the JSON response containing the contract-token.
+        """
+        data = {"pkcs7": pkcs7}
+        response, _headers = self.request_url(
+            API_V1_PREMIUM_AWS_TOKEN, data=data
+        )
+        self.cfg.write_cache("contract-token", response)
+        return response
 
     def request_resource_machine_access(
         self,

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -14,6 +14,17 @@ class UserFacingError(Exception):
         self.msg = msg
 
 
+class AlreadyAttachedError(UserFacingError):
+    """An exception to be raised when a command needs an unattached system."""
+
+    def __init__(self, cfg):
+        super().__init__(
+            status.MESSAGE_ALREADY_ATTACHED.format(
+                account_name=cfg.accounts[0]["name"]
+            )
+        )
+
+
 class NonRootUserError(UserFacingError):
     """An exception to be raised when a user needs to be root."""
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -10,12 +10,16 @@ class UserFacingError(Exception):
         should be emitted before exiting non-zero.
     """
 
+    exit_code = 1
+
     def __init__(self, msg: str) -> None:
         self.msg = msg
 
 
 class AlreadyAttachedError(UserFacingError):
     """An exception to be raised when a command needs an unattached system."""
+
+    exit_code = 0
 
     def __init__(self, cfg):
         super().__init__(

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -145,6 +145,9 @@ Minimum kernel version required: {min_kernel}"""
 MESSAGE_UNENTITLED_TMPL = """\
 This subscription is not entitled to {title}.
 For more information see: https://ubuntu.com/advantage"""
+MESSAGE_UNSUPPORTED_PREMIUM = """\
+Platform not supported by premium image
+For more information see: https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -129,6 +129,8 @@ MESSAGE_ALREADY_DISABLED_TMPL = """\
 {title} is not currently enabled\nSee: sudo ua status"""
 MESSAGE_ENABLED_FAILED_TMPL = "Could not enable {title}."
 MESSAGE_ENABLED_TMPL = "{title} enabled"
+MESSAGE_ALREADY_ATTACHED = """\
+This machine is already attached to '{account_name}'."""
 MESSAGE_ALREADY_ENABLED_TMPL = """\
 {title} is already enabled.\nSee: sudo ua status"""
 MESSAGE_INAPPLICABLE_ARCH_TMPL = """\

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -150,6 +150,9 @@ For more information see: https://ubuntu.com/advantage"""
 MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE = """\
 Premium image support is not available on {cloud_type}.
 See: https://ubuntu.com/advantage"""
+MESSAGE_UNSUPPORTED_PREMIUM = """\
+Premium image support is not available on this image type.
+See: https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -147,9 +147,9 @@ Minimum kernel version required: {min_kernel}"""
 MESSAGE_UNENTITLED_TMPL = """\
 This subscription is not entitled to {title}.
 For more information see: https://ubuntu.com/advantage"""
-MESSAGE_UNSUPPORTED_PREMIUM = """\
-Platform not supported by premium image
-For more information see: https://ubuntu.com/advantage"""
+MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE = """\
+Premium image support is not available on {cloud_type}.
+See: https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -147,6 +147,9 @@ Minimum kernel version required: {min_kernel}"""
 MESSAGE_UNENTITLED_TMPL = """\
 This subscription is not entitled to {title}.
 For more information see: https://ubuntu.com/advantage"""
+MESSAGE_UNABLE_TO_DETERMINE_CLOUD_TYPE = """\
+Unable to determine premium image platform support
+For more information see: https://ubuntu.com/advantage"""
 MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE = """\
 Premium image support is not available on {cloud_type}.
 See: https://ubuntu.com/advantage"""

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -19,6 +19,7 @@ from uaclient import status
 
 M_PATH = "uaclient.cli."
 
+# Also used in test_cli_attach_premium.py
 BASIC_MACHINE_TOKEN = {
     "machineTokenInfo": {
         "contractInfo": {

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -10,7 +10,11 @@ from uaclient.cli import (
     attach_parser,
     get_parser,
 )
-from uaclient.exceptions import NonRootUserError, UserFacingError
+from uaclient.exceptions import (
+    AlreadyAttachedError,
+    NonRootUserError,
+    UserFacingError,
+)
 from uaclient import status
 
 M_PATH = "uaclient.cli."
@@ -45,13 +49,8 @@ class TestActionAttach:
         account_name = "test_account"
         cfg = FakeConfig.for_attached_machine(account_name=account_name)
 
-        ret = action_attach(mock.MagicMock(), cfg)
-
-        assert 0 == ret
-        expected_msg = "This machine is already attached to '{}'.".format(
-            account_name
-        )
-        assert expected_msg in capsys.readouterr()[0]
+        with pytest.raises(AlreadyAttachedError):
+            action_attach(mock.MagicMock(), cfg)
 
     def test_token_is_a_required_argument(self, _m_getuid):
         """When missing the required token argument, raise a UserFacingError"""

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -9,19 +9,9 @@ from uaclient.cli import (
 )
 from uaclient.exceptions import AlreadyAttachedError, NonRootUserError
 from uaclient.testing.fakes import FakeConfig
+from uaclient.tests.test_cli_attach import BASIC_MACHINE_TOKEN
 
 M_PATH = "uaclient.cli."
-
-BASIC_MACHINE_TOKEN = {
-    "machineTokenInfo": {
-        "contractInfo": {
-            "name": "mycontract",
-            "id": "contract-1",
-            "resourceEntitlements": [],
-        },
-        "accountInfo": {"id": "acct-1", "name": "accountName"},
-    }
-}
 
 
 @mock.patch(M_PATH + "os.getuid")

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -9,10 +9,7 @@ from uaclient.cli import (
     attach_premium_parser,
     get_parser,
 )
-from uaclient.exceptions import (
-    AlreadyAttachedError,
-    NonRootUserError,
-)
+from uaclient.exceptions import AlreadyAttachedError, NonRootUserError
 
 M_PATH = "uaclient.cli."
 

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -1,7 +1,5 @@
 import mock
 
-from uaclient.testing.fakes import FakeConfig
-
 import pytest
 
 from uaclient.cli import (
@@ -10,6 +8,7 @@ from uaclient.cli import (
     get_parser,
 )
 from uaclient.exceptions import AlreadyAttachedError, NonRootUserError
+from uaclient.testing.fakes import FakeConfig
 
 M_PATH = "uaclient.cli."
 

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -1,0 +1,118 @@
+import mock
+
+from uaclient.testing.fakes import FakeConfig
+
+import pytest
+
+from uaclient.cli import (
+    UA_AUTH_TOKEN_URL,
+    action_attach_premium,
+    attach_premium_parser,
+    get_parser,
+)
+from uaclient.exceptions import NonRootUserError, UserFacingError
+from uaclient import status
+
+M_PATH = "uaclient.cli."
+
+BASIC_MACHINE_TOKEN = {
+    "machineTokenInfo": {
+        "contractInfo": {
+            "name": "mycontract",
+            "id": "contract-1",
+            "resourceEntitlements": [],
+        },
+        "accountInfo": {"id": "acct-1", "name": "accountName"},
+    }
+}
+
+
+@mock.patch(M_PATH + "os.getuid")
+def test_non_root_users_are_rejected(getuid):
+    """Check that a UID != 0 will receive a message and exit non-zero"""
+    getuid.return_value = 1
+
+    cfg = FakeConfig()
+    with pytest.raises(NonRootUserError):
+        action_attach_premium(mock.MagicMock(), cfg)
+
+
+# For all of these tests we want to appear as root, so mock on the class
+@mock.patch(M_PATH + "os.getuid", return_value=0)
+class TestActionAttach:
+    def test_already_attached(self, _m_getuid, capsys):
+        """Check that an already-attached machine emits message and exits 0"""
+        account_name = "test_account"
+        cfg = FakeConfig.for_attached_machine(account_name=account_name)
+
+        ret = action_attach_premium(mock.MagicMock(), cfg)
+
+        assert 0 == ret
+        expected_msg = "This machine is already attached to '{}'.".format(
+            account_name
+        )
+        assert expected_msg in capsys.readouterr()[0]
+
+    @mock.patch(M_PATH + "contract.request_updated_contract")
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_premium_aws_contract_token"
+    )
+    @mock.patch(M_PATH + "action_status")
+    def test_happy_path_on_aws(
+        self,
+        action_status,
+        contract_aws_token,
+        request_updated_contract,
+        _m_getuid,
+    ):
+        """A mock-heavy test for the happy path on Premium AWS without args"""
+        # TODO: Improve this test with less general mocking and more
+        # post-conditions
+        token = "contract-token"
+        args = mock.MagicMock(token=token)
+        cfg = FakeConfig()
+
+        def fake_aws_contract_token(contract_token):
+            return {"contractToken": "myPKCS7-token"}
+
+        contract_aws_token.side_effect = fake_aws_contract_token
+
+        def fake_request_updated_contract(cfg, contract_token, allow_enable):
+            cfg.write_cache("machine-token", BASIC_MACHINE_TOKEN)
+            return BASIC_MACHINE_TOKEN
+
+        request_updated_contract.side_effect = fake_request_updated_contract
+
+        m_identity = mock.Mock()
+        m_identity.get_cloud_type.return_value = "aws"
+
+        def fake_instance_factory():
+            m_instance = mock.Mock()
+            m_instance.identity_doc = "mypkcs7"
+            return m_instance
+
+        instance = mock.Mock()
+        m_identity.cloud_instance_factory.side_effect = fake_instance_factory
+        ret = action_attach_premium(args, cfg, identity=m_identity)
+
+
+        assert 0 == ret
+        assert 1 == action_status.call_count
+        assert [mock.call("mypkcs7")] == contract_aws_token.call_args_list
+        expected_calls = [mock.call(cfg, 'myPKCS7-token', allow_enable=True)]
+        assert expected_calls == request_updated_contract.call_args_list
+
+
+class TestParser:
+    def test_attach_premium_parser_updates_parser_config(self):
+        """Update the parser configuration for 'attach-premium'."""
+        m_parser = attach_premium_parser(mock.Mock())
+        assert "ua attach-premium [flags]" == m_parser.usage
+        assert "attach-premium" == m_parser.prog
+        assert "Flags" == m_parser._optionals.title
+
+        full_parser = get_parser()
+        with mock.patch("sys.argv", ["ua", "attach-premium"]):
+            args = full_parser.parse_args()
+        assert "attach-premium" == args.command
+        assert "action_attach_premium" == args.action.__name__


### PR DESCRIPTION
Provide a new attach-premium subcommand that will crawl AWS premium
metadata and provide that to new aws ua-contacts backend route to
allow for easy attach of premium images without having to obtain a
token from ubuntu.com/advantage