### PR TITLE
entitlements: rely solely on contract server for repo_url

### DIFF
--- a/uaclient/entitlements/cc.py
+++ b/uaclient/entitlements/cc.py
@@ -9,9 +9,6 @@ class CommonCriteriaEntitlement(repo.RepoEntitlement):
     name = "cc-eal"
     title = "CC EAL2"
     description = "Common Criteria EAL2 Provisioning Packages"
-    repo_url = (
-        "https://private-ppa.launchpad.net/ubuntu-advantage/commoncriteria"
-    )
     repo_key_file = "ubuntu-cc-keyring.gpg"
     packages = ["ubuntu-commoncriteria"]
     messaging = {

--- a/uaclient/entitlements/cis.py
+++ b/uaclient/entitlements/cis.py
@@ -7,9 +7,5 @@ class CISEntitlement(repo.RepoEntitlement):
     name = "cis-audit"
     title = "CIS Audit"
     description = "Center for Internet Security Audit Tools"
-    repo_url = (
-        "https://private-ppa.launchpad.net/ubuntu-advantage/"
-        "security-benchmarks"
-    )
     repo_key_file = "ubuntu-securitybenchmarks-keyring.gpg"
     packages = ["ubuntu-cisbenchmark-16.04"]

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -8,7 +8,6 @@ class ESMInfraEntitlement(repo.RepoEntitlement):
     title = "ESM Infra"
     origin = "UbuntuESM"
     description = "UA Infra: Extended Security Maintenance"
-    repo_url = "https://esm.ubuntu.com"
     repo_key_file = "ubuntu-advantage-esm-infra-trusty.gpg"
     repo_pin_priority = "never"
     disable_apt_auth_only = True  # Only remove apt auth files when disabling

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -63,7 +63,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
         "post_enable": ["A reboot is required to complete the install"]
     }
     origin = "UbuntuFIPS"
-    repo_url = "https://esm.ubuntu.com/fips"
     repo_key_file = "ubuntu-fips-keyring.gpg"
     static_affordances = (
         ("Cannot install FIPS on a container", util.is_container, False),
@@ -82,7 +81,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
     }
     origin = "UbuntuFIPSUpdates"
     description = "Uncertified security updates to FIPS modules"
-    repo_url = "https://esm.ubuntu.com/fips-updates"
     repo_key_file = "ubuntu-fips-updates-keyring.gpg"
     static_affordances = (
         (

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -45,11 +45,6 @@ class RepoEntitlement(base.UAEntitlement):
 
     @property
     @abc.abstractmethod
-    def repo_url(self) -> str:
-        pass
-
-    @property
-    @abc.abstractmethod
     def repo_key_file(self) -> str:
         pass
 
@@ -106,7 +101,7 @@ class RepoEntitlement(base.UAEntitlement):
         )
         repo_url = directives.get("aptURL")
         if not repo_url:
-            repo_url = self.repo_url
+            raise exceptions.MissingAptURLDirective(self.name)
         protocol, repo_path = repo_url.split("://")
         policy = apt.run_apt_command(
             ["apt-cache", "policy"], status.MESSAGE_APT_POLICY_FAILED
@@ -189,7 +184,7 @@ class RepoEntitlement(base.UAEntitlement):
             )
         repo_url = directives.get("aptURL")
         if not repo_url:
-            repo_url = self.repo_url
+            raise exceptions.MissingAptURLDirective(self.name)
         repo_suites = directives.get("suites")
         if not repo_suites:
             raise exceptions.UserFacingError(
@@ -267,9 +262,9 @@ class RepoEntitlement(base.UAEntitlement):
             "machine-access-{}".format(self.name)
         ).get("entitlement", {})
         access_directives = entitlement.get("directives", {})
-        repo_url = access_directives.get("aptURL", self.repo_url)
+        repo_url = access_directives.get("aptURL")
         if not repo_url:
-            repo_url = self.repo_url
+            raise exceptions.MissingAptURLDirective(self.name)
         if self.disable_apt_auth_only:
             # We only remove the repo from the apt auth file, because ESM
             # is a special-case: we want to be able to report on the

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -32,7 +32,6 @@ class RepoTestEntitlement(RepoEntitlement):
     name = "repotest"
     title = "Repo Test Class"
     description = "Repo entitlement for testing"
-    repo_url = "http://example.com/ubuntu"
     repo_key_file = "test.gpg"
 
 
@@ -444,3 +443,25 @@ class TestRemoveAptConfig:
 
         expected_call = mock.call(["apt-get", "update"], mock.ANY)
         assert expected_call in m_run_apt_command.call_args_list
+
+    def test_missing_aptURL(self, entitlement_factory):
+        # Make aptURL missing
+        entitlement = entitlement_factory(RepoTestEntitlement, directives={})
+
+        with pytest.raises(exceptions.MissingAptURLDirective) as excinfo:
+            entitlement.remove_apt_config()
+
+        assert "repotest" in str(excinfo.value)
+
+
+class TestApplicationStatus:
+    # TODO: Write tests for all functionality
+
+    def test_missing_aptURL(self, entitlement_factory):
+        # Make aptURL missing
+        entitlement = entitlement_factory(RepoTestEntitlement, directives={})
+
+        with pytest.raises(exceptions.MissingAptURLDirective) as excinfo:
+            entitlement.application_status()
+
+        assert "repotest" in str(excinfo.value)

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -29,6 +29,17 @@ class AlreadyAttachedError(UserFacingError):
         )
 
 
+class MissingAptURLDirective(UserFacingError):
+    """An exception for when the contract server doesn't include aptURL"""
+
+    def __init__(self, entitlement_name):
+        super().__init__(
+            status.MESSAGE_MISSING_APT_URL_DIRECTIVE.format(
+                entitlement_name=entitlement_name
+            )
+        )
+
+
 class NonRootUserError(UserFacingError):
     """An exception to be raised when a user needs to be root."""
 

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -159,6 +159,8 @@ See: https://ubuntu.com/advantage"""
 MESSAGE_UNATTACHED = """\
 This machine is not attached to a UA subscription.
 See https://ubuntu.com/advantage"""
+MESSAGE_MISSING_APT_URL_DIRECTIVE = """\
+Ubuntu Advantage server provided no aptURL directive for {entitlement_name}"""
 
 STATUS_UNATTACHED_TMPL = "{name: <14}{available: <11}{description}"
 


### PR DESCRIPTION
Before this commit, we had a hard-coded default that we would use if the
contract server failed to provide us with an aptURL directive.  The
logic for that default becomes more complex with xenial/bionic, because
the URLs have changed.

Instead of introducing more complexity into the client, we instead drop
that defaulting, with the assumption that the contract server will
always provide an aptURL directive.