### PR TITLE
ua premium: add upstart  and systemd boot scripts to automatically attach premium images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ travis-deb-install:
 	git fetch --unshallow
 	sudo apt-get update
 	sudo apt-get build-dep -y ubuntu-advantage-tools
-	sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools
+	sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools dh-systemd
 	# Missing build-deps
 	sudo apt-get install -y --install-recommends libapt-pkg-dev python3-mock python3-pytest
 

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends: bash-completion,
                python3-mock,
                python3-pytest,
                python3-setuptools,
-               python3-yaml
+               python3-yaml,
+               dh-systemd
 Standards-Version: 4.3.0
 Homepage: https://buy.ubuntu.com
 Vcs-Git: https://github.com/CanonicalLtd/ubuntu-advantage-script.git

--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:
-	dh $@ --with python3,bash-completion --buildsystem=pybuild
+	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild
 
 override_dh_auto_build:
 	dh_auto_build

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import glob
 import setuptools
 
-from uaclient import defaults, version
+from uaclient import defaults, util, version
 
 NAME = "ubuntu-advantage-tools"
 
@@ -20,6 +20,21 @@ def _get_version():
     return major_minor
 
 
+def _get_data_files():
+    data_files = [
+        ("/etc/apt/apt.conf.d", ["apt.conf.d/51ubuntu-advantage-esm"]),
+        ("/etc/ubuntu-advantage", ["uaclient.conf"]),
+        ("/usr/share/keyrings", glob.glob("keyrings/*")),
+        (defaults.CONFIG_DEFAULTS["data_dir"], []),
+    ]
+    rel_major, _rel_minor = util.get_platform_info()["release"].split(".", 1)
+    if rel_major == "14":
+        data_files.append(("/etc/init", glob.glob("upstart/*")))
+    else:
+        data_files.append(("/lib/systemd/system", glob.glob("systemd/*")))
+    return data_files
+
+
 setuptools.setup(
     name=NAME,
     version=_get_version(),
@@ -33,12 +48,7 @@ setuptools.setup(
             "features.*",
         ]
     ),
-    data_files=[
-        ("/etc/apt/apt.conf.d", ["apt.conf.d/51ubuntu-advantage-esm"]),
-        ("/etc/ubuntu-advantage", ["uaclient.conf"]),
-        ("/usr/share/keyrings", glob.glob("keyrings/*")),
-        (defaults.CONFIG_DEFAULTS["data_dir"], []),
-    ],
+    data_files=_get_data_files(),
     install_requires=INSTALL_REQUIRES,
     extras_require=dict(test=TEST_REQUIRES),
     author="Ubuntu Server Team",

--- a/systemd/ua-premium.service
+++ b/systemd/ua-premium.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Ubuntu Advantage premium attach
+After=cloud-final.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ua attach-premium
+TimeoutSec=0

--- a/upstart/ua-premium.conf
+++ b/upstart/ua-premium.conf
@@ -1,0 +1,14 @@
+# ua-premium - Ubuntu Advantage Premium attach
+
+# This task is run on boot to automatically attach vms to Ubuntu Advantage
+# for select premium images. The machine does not get attached if the
+# image is not considered a premium image type.
+
+description    "Ubuntu Advantage premium attach"
+
+# Only start once cloud-init finishes detecting the DataSource on trusty
+start on file FILE=/var/lib/cloud/data/result.json
+
+task
+# Attempt to attach-premium action. Does nothing if machine is already attached
+exec /usr/bin/ua attach-premium


### PR DESCRIPTION
Add upstart script and systemd unit which will wait for cloud-init to complete before attempting to run ua attach-premium on a machine.

On non-premium images, `ua attach-premium` exits 0 and logs that attach a platform is not detected as a premium image.

On attached machines after reboot, `ua attach-premium` logs a message that the machine is already attached and exits 0.
