### PR TITLE
premium: add retry decorator around aws.identity_doc to handle failure

### DIFF
--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -1,5 +1,8 @@
+from urllib.error import HTTPError
+
 from uaclient.clouds import UAPremiumCloudInstance
 from uaclient import util
+
 
 IMDS_URL = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
 SYS_HYPERVISOR_PRODUCT_UUID = "/sys/hypervisor/uuid"
@@ -8,7 +11,11 @@ DMI_PRODUCT_UUID = "/sys/class/dmi/id/product_uuid"
 
 
 class UAPremiumAWSInstance(UAPremiumCloudInstance):
-    @property
+
+    # mypy does not handle @property around inner decorators
+    # https://github.com/python/mypy/issues/1362
+    @property  # type: ignore
+    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self):
         response, _headers = util.readurl(IMDS_URL)
         return response


### PR DESCRIPTION
Since metadata services could go down intermittently for maintenance,
add a retry decorator that acceepts a list of sleep times to use when
catching an exception.

Add this retry decorator and a simple backoff of three retries at
1s 2s and 5s to attempt to allow for short downtimes of
the indetity_doc route for AWS.