### PR TITLE
repo: don't raise exception in application_status if aptURL missing

### DIFF
--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -101,7 +101,10 @@ class RepoEntitlement(base.UAEntitlement):
         )
         repo_url = directives.get("aptURL")
         if not repo_url:
-            raise exceptions.MissingAptURLDirective(self.name)
+            return (
+                ApplicationStatus.DISABLED,
+                "{} does not have an aptURL directive".format(self.title),
+            )
         protocol, repo_path = repo_url.split("://")
         policy = apt.run_apt_command(
             ["apt-cache", "policy"], status.MESSAGE_APT_POLICY_FAILED

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -461,7 +461,9 @@ class TestApplicationStatus:
         # Make aptURL missing
         entitlement = entitlement_factory(RepoTestEntitlement, directives={})
 
-        with pytest.raises(exceptions.MissingAptURLDirective) as excinfo:
-            entitlement.application_status()
+        application_status, explanation = entitlement.application_status()
 
-        assert "repotest" in str(excinfo.value)
+        assert status.ApplicationStatus.DISABLED == application_status
+        assert (
+            "Repo Test Class does not have an aptURL directive" == explanation
+        )


### PR DESCRIPTION
Instead report the service as disabled, as without an aptURL it's very
unlikely that we could have enabled it.