### PR TITLE
premium: aws handle contract error for non-premium pkcs7 identity

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -349,9 +349,9 @@ def _attach_with_token(
 def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
     """Detect cloud_type and request a contract token from identity info.
 
-    :param cfg: Parsed configuration dictionary
+    :param cfg: a ``config.UAConfig`` instance
 
-    :raise NonPremiumImageError: When not on a premium image type. Exits 0.
+    :raise NonPremiumImageError: When not on a premium image type.
     :raise UserFacingError: On unexpected connectivity issues to contract
         server or inability to access identity doc from metadata service.
 

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -346,28 +346,48 @@ def _attach_with_token(
     return 0
 
 
-@assert_not_attached
-@assert_root
-def action_attach_premium(args, cfg):
+def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
+    """Detect cloud_type and request a contract token from identity info.
+
+    :param cfg: Parsed configuration dictionary
+
+    :raise NonPremiumImageError: When not on a premium image type. Exits 0.
+    :raise UserFacingError: On unexpected connectivity issues to contract
+        server or inability to access identity doc from metadata service.
+
+    :return: contract token obtained from identity doc
+    """
     cloud_type = identity.get_cloud_type()
     if cloud_type not in ("aws",):  # TODO(avoid hard-coding supported types)
-        print(
+        raise exceptions.NonPremiumImageError(
             ua_status.MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE.format(
                 cloud_type=cloud_type
             )
         )
-        return 0
-    # TODO(Clean up the attach_premium flow a bit and add error handling)
     instance = identity.cloud_instance_factory()
     contract_client = contract.UAContractClient(cfg)
     pkcs7 = instance.identity_doc
-    # TODO(Need to handle errors due to non-premium ec2 images)
-    contractTokenResponse = contract_client.request_premium_aws_contract_token(
-        pkcs7
-    )
-    return _attach_with_token(
-        cfg, token=contractTokenResponse["contractToken"], allow_enable=True
-    )
+    try:
+        # TODO(make this logic cloud-agnostic if possible)
+        tokenResponse = contract_client.request_premium_aws_contract_token(
+            pkcs7
+        )
+    except contract.ContractAPIError as e:
+        if contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e:
+            raise exceptions.NonPremiumImageError(
+                ua_status.MESSAGE_UNSUPPORTED_PREMIUM
+            )
+        raise e
+    return tokenResponse["contractToken"]
+
+
+@assert_not_attached
+@assert_root
+def action_attach_premium(args, cfg):
+    token = _get_contract_token_from_cloud_identity(cfg)
+    if token is None:
+        return 0
+    return _attach_with_token(cfg, token=token, allow_enable=True)
 
 
 @assert_not_attached

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -352,8 +352,10 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
     :param cfg: a ``config.UAConfig`` instance
 
     :raise NonPremiumImageError: When not on a premium image type.
-    :raise UserFacingError: On unexpected connectivity issues to contract
+    :raise UrlError: On unexpected connectivity issues to contract
         server or inability to access identity doc from metadata service.
+    :raise ContractAPIError: On unexpected errors when talking to the contract
+        server.
 
     :return: contract token obtained from identity doc
     """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -385,8 +385,6 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
 @assert_root
 def action_attach_premium(args, cfg):
     token = _get_contract_token_from_cloud_identity(cfg)
-    if token is None:
-        return 0
     return _attach_with_token(cfg, token=token, allow_enable=True)
 
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -14,6 +14,7 @@ except ImportError:
     pass
 
 API_ERROR_INVALID_TOKEN = "invalid token"
+API_ERROR_MISSING_INSTANCE_INFORMATION = "missing instance information"
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
 API_V1_TMPL_CONTEXT_MACHINE_TOKEN_REFRESH = (
     "/v1/contracts/{contract}/context/machines/{machine}"

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -20,7 +20,6 @@ class NonPremiumImageError(UserFacingError):
     """Raised when machine doesn't appear to be premium/pro"""
 
     exit_code = 0
-    pass
 
 
 class AlreadyAttachedError(UserFacingError):

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -16,6 +16,13 @@ class UserFacingError(Exception):
         self.msg = msg
 
 
+class NonPremiumImageError(UserFacingError):
+    """Raised when machine doesn't appear to be premium/pro"""
+
+    exit_code = 0
+    pass
+
+
 class AlreadyAttachedError(UserFacingError):
     """An exception to be raised when a command needs an unattached system."""
 

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -145,9 +145,11 @@ class TestActionAttachPremium:
         _m_getuid,
     ):
         """Noop when _get_contract_token_from_cloud_identity finds no token"""
-        get_contract_token_from_cloud_identity.return_value = None
+        exc = NonPremiumImageError("msg")
+        get_contract_token_from_cloud_identity.side_effect = exc
 
-        assert 0 == action_attach_premium(mock.MagicMock(), FakeConfig())
+        with pytest.raises(NonPremiumImageError):
+            action_attach_premium(mock.MagicMock(), FakeConfig())
         assert 0 == request_updated_contract.call_count
 
     @mock.patch(M_PATH + "contract.request_updated_contract")

--- a/uaclient/tests/test_cli_attach_premium.py
+++ b/uaclient/tests/test_cli_attach_premium.py
@@ -6,10 +6,18 @@ from uaclient.cli import (
     action_attach_premium,
     attach_premium_parser,
     get_parser,
+    _get_contract_token_from_cloud_identity,
 )
-from uaclient.exceptions import AlreadyAttachedError, NonRootUserError
+from uaclient.contract import ContractAPIError
+from uaclient.exceptions import (
+    AlreadyAttachedError,
+    NonRootUserError,
+    NonPremiumImageError,
+)
+from uaclient import status
 from uaclient.testing.fakes import FakeConfig
 from uaclient.tests.test_cli_attach import BASIC_MACHINE_TOKEN
+from uaclient import util
 
 M_PATH = "uaclient.cli."
 
@@ -24,10 +32,103 @@ def test_non_root_users_are_rejected(getuid):
         action_attach_premium(mock.MagicMock(), cfg)
 
 
+class TestGetContractTokenFromCloudIdentity:
+    def fake_instance_factory(self):
+        m_instance = mock.Mock()
+        m_instance.identity_doc = "pkcs7-validated-by-backend"
+        return m_instance
+
+    @pytest.mark.parametrize("cloud_type", ("awslookalike", "azure", "!aws"))
+    @mock.patch("uaclient.clouds.identity.get_cloud_type")
+    def test_non_aws_cloud_type_raises_error(
+        self, m_get_cloud_type, cloud_type
+    ):
+        """Non-aws clouds will error."""
+        m_get_cloud_type.return_value = cloud_type
+        with pytest.raises(NonPremiumImageError) as excinfo:
+            _get_contract_token_from_cloud_identity(FakeConfig())
+        assert status.MESSAGE_UNSUPPORTED_PREMIUM_CLOUD_TYPE.format(
+            cloud_type=cloud_type
+        ) == str(excinfo.value)
+
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_premium_aws_contract_token"
+    )
+    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
+    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    def test_aws_cloud_type_non_premium_returns_no_token(
+        self,
+        _get_cloud_type,
+        cloud_instance_factory,
+        request_premium_aws_contract_token,
+    ):
+        """AWS clouds on non-premium images not return a token."""
+
+        cloud_instance_factory.side_effect = self.fake_instance_factory
+        request_premium_aws_contract_token.side_effect = ContractAPIError(
+            util.UrlError(
+                "Server error", code=500, url="http://me", headers={}
+            ),
+            error_response={"message": "missing instance information"},
+        )
+        with pytest.raises(NonPremiumImageError) as excinfo:
+            _get_contract_token_from_cloud_identity(FakeConfig())
+        assert status.MESSAGE_UNSUPPORTED_PREMIUM == str(excinfo.value)
+
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_premium_aws_contract_token"
+    )
+    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
+    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    def test_raise_unexpected_errors(
+        self,
+        _get_cloud_type,
+        cloud_instance_factory,
+        request_premium_aws_contract_token,
+    ):
+        """Any unexpected errors will be raised."""
+
+        cloud_instance_factory.side_effect = self.fake_instance_factory
+        unexpected_error = ContractAPIError(
+            util.UrlError(
+                "Server error", code=500, url="http://me", headers={}
+            ),
+            error_response={"message": "something unexpected"},
+        )
+        request_premium_aws_contract_token.side_effect = unexpected_error
+
+        with pytest.raises(ContractAPIError) as excinfo:
+            _get_contract_token_from_cloud_identity(FakeConfig())
+        assert unexpected_error == excinfo.value
+
+    @mock.patch(
+        M_PATH + "contract.UAContractClient.request_premium_aws_contract_token"
+    )
+    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
+    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    def test_return_token_from_contract_server_using_identity_doc(
+        self,
+        _get_cloud_type,
+        cloud_instance_factory,
+        request_aws_contract_token,
+    ):
+        """Return token from the contract server using the identity."""
+
+        cloud_instance_factory.side_effect = self.fake_instance_factory
+
+        def fake_aws_contract_token(contract_token):
+            return {"contractToken": "myPKCS7-token"}
+
+        request_aws_contract_token.side_effect = fake_aws_contract_token
+
+        cfg = FakeConfig()
+        assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(cfg)
+
+
 # For all of these tests we want to appear as root, so mock on the class
 @mock.patch(M_PATH + "os.getuid", return_value=0)
-class TestActionAttach:
-    def test_already_attached(self, _m_getuid, capsys):
+class TestActionAttachPremium:
+    def test_already_attached(self, _m_getuid):
         """Check that an attached machine raises AlreadyAttachedError."""
         account_name = "test_account"
         cfg = FakeConfig.for_attached_machine(account_name=account_name)
@@ -36,32 +137,34 @@ class TestActionAttach:
             action_attach_premium(mock.MagicMock(), cfg)
 
     @mock.patch(M_PATH + "contract.request_updated_contract")
-    @mock.patch(
-        M_PATH + "contract.UAContractClient.request_premium_aws_contract_token"
-    )
-    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
-    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
-    @mock.patch(M_PATH + "action_status")
-    def test_happy_path_on_aws(
+    @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
+    def test_happy_path_on_aws_non_premium(
         self,
-        action_status,
-        get_cloud_type,
-        cloud_instance_factory,
-        contract_aws_token,
+        get_contract_token_from_cloud_identity,
         request_updated_contract,
         _m_getuid,
     ):
-        """A mock-heavy test for the happy path on Premium AWS without args"""
+        """Noop when _get_contract_token_from_cloud_identity finds no token"""
+        get_contract_token_from_cloud_identity.return_value = None
+
+        assert 0 == action_attach_premium(mock.MagicMock(), FakeConfig())
+        assert 0 == request_updated_contract.call_count
+
+    @mock.patch(M_PATH + "contract.request_updated_contract")
+    @mock.patch(M_PATH + "_get_contract_token_from_cloud_identity")
+    @mock.patch(M_PATH + "action_status")
+    def test_happy_path_on_aws_premium(
+        self,
+        action_status,
+        get_contract_token_from_cloud_identity,
+        request_updated_contract,
+        _m_getuid,
+    ):
+        """A mock-heavy test for the happy path on Premium AWS"""
         # TODO: Improve this test with less general mocking and more
         # post-conditions
-        token = "contract-token"
-        args = mock.MagicMock(token=token)
         cfg = FakeConfig()
-
-        def fake_aws_contract_token(contract_token):
-            return {"contractToken": "myPKCS7-token"}
-
-        contract_aws_token.side_effect = fake_aws_contract_token
+        get_contract_token_from_cloud_identity.return_value = "myPKCS7-token"
 
         def fake_request_updated_contract(cfg, contract_token, allow_enable):
             cfg.write_cache("machine-token", BASIC_MACHINE_TOKEN)
@@ -69,18 +172,8 @@ class TestActionAttach:
 
         request_updated_contract.side_effect = fake_request_updated_contract
 
-        def fake_instance_factory():
-            m_instance = mock.Mock()
-            m_instance.identity_doc = "mypkcs7"
-            return m_instance
-
-        cloud_instance_factory.side_effect = fake_instance_factory
-        ret = action_attach_premium(args, cfg)
-
+        ret = action_attach_premium(mock.MagicMock(), cfg)
         assert 0 == ret
-        assert 1 == get_cloud_type.call_count
-        assert 1 == action_status.call_count
-        assert [mock.call("mypkcs7")] == contract_aws_token.call_args_list
         expected_calls = [mock.call(cfg, "myPKCS7-token", allow_enable=True)]
         assert expected_calls == request_updated_contract.call_args_list
 


### PR DESCRIPTION
Contracts server returns the api error "missing instance information"
when non-premium identity docs are sent to the aws token request route.
Handle this error and emit a message about being a non-premium image.

Also refactor attach_premium function to be a bit easier to test.