### PR TITLE
d/rules: don't install the apt hook

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,6 @@ override_dh_gencontrol:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
-	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
The hook only reports for esm-infra, not for esm-apps.  We don't have
time to address that before the deadline we are working towards, so drop
it to avoid an inconsistent user experience.

(Note that for xenial and later, the hook only reports when entitlements
are enabled, so this will retain the unattached/un-enabled behaviour we
already have.)