### PR TITLE
esm: restore trusty apt pinning behavior

### DIFF
--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -1,9 +1,15 @@
 from uaclient.entitlements import repo
+from uaclient import util
+
+try:
+    from typing import Optional  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
 
 
 class ESMBaseEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/esm"
-    # TODO: Restore repo_pin_priority = "never" for trusty
 
 
 class ESMAppsEntitlement(ESMBaseEntitlement):
@@ -20,4 +26,15 @@ class ESMInfraEntitlement(ESMBaseEntitlement):
     title = "ESM Infra"
     description = "UA Infra: Extended Security Maintenance"
     repo_key_file = "ubuntu-advantage-esm-infra-trusty.gpg"
-    # TODO: Restore disable_apt_auth_only for trusty
+
+    @property
+    def repo_pin_priority(self) -> "Optional[str]":
+        """Only trusty esm-infra should peform repo pinning"""
+        if "trusty" == util.get_platform_info()["series"]:
+            return "never"
+        return None  # No pinning on >= trusty
+
+    @property
+    def disable_apt_auth_only(self) -> bool:
+        """Only trusty esm-infra should remove apt auth files upon disable"""
+        return bool("trusty" == util.get_platform_info()["series"])

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -29,10 +29,14 @@ class RepoEntitlement(base.UAEntitlement):
     origin = None  # type: Optional[str]
 
     # Optional repo pin priority in subclass
-    repo_pin_priority = None  # type: Union[int, str, None]
+    @property
+    def repo_pin_priority(self) -> "Union[int, str, None]":
+        return None
 
     # disable_apt_auth_only (ESM) to only remove apt auth files on disable
-    disable_apt_auth_only = False  # Set True on ESM to only remove apt auth
+    @property
+    def disable_apt_auth_only(self) -> bool:
+        return False  # Set True on ESM to only remove apt auth
 
     # Any custom messages to emit pre or post enable or disable operations;
     # currently post_enable is used in CommonCriteria
@@ -271,9 +275,9 @@ class RepoEntitlement(base.UAEntitlement):
         if not repo_url:
             raise exceptions.MissingAptURLDirective(self.name)
         if self.disable_apt_auth_only:
-            # We only remove the repo from the apt auth file, because ESM
+            # We only remove the repo from the apt auth file, because ESM-infra
             # is a special-case: we want to be able to report on the
-            # available ESM updates even when it's disabled
+            # available ESM-infra updates even when it's disabled
             apt.remove_repo_from_apt_auth_file(repo_url)
             apt.restore_commented_apt_list_file(repo_filename)
         else:

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -275,9 +275,9 @@ class RepoEntitlement(base.UAEntitlement):
         if not repo_url:
             raise exceptions.MissingAptURLDirective(self.name)
         if self.disable_apt_auth_only:
-            # We only remove the repo from the apt auth file, because ESM-infra
+            # We only remove the repo from the apt auth file, because ESM Infra
             # is a special-case: we want to be able to report on the
-            # available ESM-infra updates even when it's disabled
+            # available ESM Infra updates even when it's disabled
             apt.remove_repo_from_apt_auth_file(repo_url)
             apt.restore_commented_apt_list_file(repo_filename)
         else:

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -155,7 +155,7 @@ class TestESMInfraEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         assert 0 == m_add_pinning.call_count
         assert subp_calls == m_subp.call_args_list
-        if entitlement.name == "esm-infra":  # Then remove apt pref pin never
+        if entitlement.name == "esm-infra":  # Remove "never" apt pref pin
             unlink_calls = [
                 mock.call(
                     "/etc/apt/preferences.d/ubuntu-{}-trusty".format(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -35,6 +35,18 @@ class RepoTestEntitlement(RepoEntitlement):
     repo_key_file = "test.gpg"
 
 
+class RepoTestEntitlementDisableAptAuthOnly(RepoTestEntitlement):
+    disable_apt_auth_only = True
+
+
+class RepoTestEntitlementRepoPinInt(RepoTestEntitlement):
+    repo_pin_priority = 1000
+
+
+class RepoTestEntitlementRepoPinNever(RepoTestEntitlement):
+    repo_pin_priority = "never"
+
+
 @pytest.fixture
 def entitlement(entitlement_factory):
     return entitlement_factory(
@@ -433,6 +445,15 @@ class TestRepoEnable:
 
 
 class TestRemoveAptConfig:
+    def test_missing_aptURL(self, entitlement_factory):
+        # Make aptURL missing
+        entitlement = entitlement_factory(RepoTestEntitlement, directives={})
+
+        with pytest.raises(exceptions.MissingAptURLDirective) as excinfo:
+            entitlement.remove_apt_config()
+
+        assert "repotest" in str(excinfo.value)
+
     @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
     @mock.patch(M_PATH + "apt.remove_apt_list_files")
     @mock.patch(M_PATH + "apt.run_apt_command")
@@ -444,14 +465,128 @@ class TestRemoveAptConfig:
         expected_call = mock.call(["apt-get", "update"], mock.ANY)
         assert expected_call in m_run_apt_command.call_args_list
 
-    def test_missing_aptURL(self, entitlement_factory):
-        # Make aptURL missing
-        entitlement = entitlement_factory(RepoTestEntitlement, directives={})
+    @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
+    @mock.patch(M_PATH + "apt.remove_apt_list_files")
+    @mock.patch(M_PATH + "apt.run_apt_command")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_disable_apt_auth_only_false_removes_all_apt_config(
+        self,
+        m_get_platform,
+        _m_run_apt_command,
+        m_remove_apt_list_files,
+        m_remove_auth_apt_repo,
+        entitlement,
+    ):
+        """Remove all APT config when disable_apt_auth_only is False"""
+        m_get_platform.return_value = {"series": "xenial"}
+        entitlement.remove_apt_config()
 
-        with pytest.raises(exceptions.MissingAptURLDirective) as excinfo:
+        # Default RepoEntitlement.disable_apt_auth_only behavior is False
+        assert False is entitlement.disable_apt_auth_only
+
+        assert [
+            mock.call("http://REPOTEST", "xenial")
+        ] == m_remove_apt_list_files.call_args_list
+        assert [
+            mock.call(
+                "/etc/apt/sources.list.d/ubuntu-repotest-xenial.list",
+                "http://REPOTEST",
+                "test.gpg",
+            )
+        ] == m_remove_auth_apt_repo.call_args_list
+
+    @mock.patch(M_PATH + "apt.remove_repo_from_apt_auth_file")
+    @mock.patch(M_PATH + "apt.restore_commented_apt_list_file")
+    @mock.patch(M_PATH + "apt.run_apt_command")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_disable_apt_auth_only_removes_authentication_for_repo(
+        self,
+        m_get_platform,
+        _m_run_apt_command,
+        m_restore_commented_apt_list_file,
+        m_remove_repo_from_apt_auth_file,
+        entitlement_factory,
+    ):
+        """Remove APT authentication for repos with disable_apt_auth_only.
+
+        Any commented APT list entries are restored to uncommented lines.
+        """
+        m_get_platform.return_value = {"series": "xenial"}
+        entitlement = entitlement_factory(
+            RepoTestEntitlementDisableAptAuthOnly,
+            affordances={"series": ["xenial"]},
+        )
+        entitlement.remove_apt_config()
+
+        assert True is entitlement.disable_apt_auth_only
+        assert [
+            mock.call("http://REPOTEST")
+        ] == m_remove_repo_from_apt_auth_file.call_args_list
+        assert [
+            mock.call("/etc/apt/sources.list.d/ubuntu-repotest-xenial.list")
+        ] == m_restore_commented_apt_list_file.call_args_list
+
+    @mock.patch(M_PATH + "apt.add_ppa_pinning")
+    @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
+    @mock.patch(M_PATH + "apt.remove_apt_list_files")
+    @mock.patch(M_PATH + "apt.run_apt_command")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_repo_pin_priority_never_configures_repo_pinning_on_remove(
+        self,
+        m_get_platform,
+        _m_run_apt_command,
+        _m_remove_apt_list_files,
+        _m_remove_auth_apt_repo,
+        m_add_ppa_pinning,
+        entitlement_factory,
+    ):
+        """Pin the repo 'never' when repo_pin_priority is never."""
+        m_get_platform.return_value = {"series": "xenial"}
+
+        entitlement = entitlement_factory(
+            RepoTestEntitlementRepoPinNever, affordances={"series": ["xenial"]}
+        )
+        assert "never" == entitlement.repo_pin_priority
+        entitlement.remove_apt_config()
+        assert [
+            mock.call(
+                "/etc/apt/preferences.d/ubuntu-repotest-xenial",
+                "http://REPOTEST",
+                None,
+                "never",
+            )
+        ] == m_add_ppa_pinning.call_args_list
+
+    @mock.patch(M_PATH + "os.unlink")
+    @mock.patch(M_PATH + "apt.remove_auth_apt_repo")
+    @mock.patch(M_PATH + "apt.remove_apt_list_files")
+    @mock.patch(M_PATH + "apt.run_apt_command")
+    @mock.patch(M_PATH + "util.get_platform_info")
+    def test_repo_pin_priority_int_removes_apt_preferences(
+        self,
+        m_get_platform,
+        _m_run_apt_command,
+        _m_remove_apt_list_files,
+        _m_remove_auth_apt_repo,
+        m_unlink,
+        entitlement_factory,
+    ):
+        """Remove apt preferences file when repo_pin_priority is an int."""
+        m_get_platform.return_value = {"series": "xenial"}
+
+        entitlement = entitlement_factory(
+            RepoTestEntitlementRepoPinInt, affordances={"series": ["xenial"]}
+        )
+
+        assert 1000 == entitlement.repo_pin_priority
+        with mock.patch(M_PATH + "os.path.exists") as m_exists:
+            m_exists.return_value = True
             entitlement.remove_apt_config()
-
-        assert "repotest" in str(excinfo.value)
+        expected_call = [
+            mock.call("/etc/apt/preferences.d/ubuntu-repotest-xenial")
+        ]
+        assert expected_call == m_exists.call_args_list
+        assert expected_call == m_unlink.call_args_list
 
 
 class TestApplicationStatus:


### PR DESCRIPTION
Differentiate ESMInfra's repo_pin_pririority and disable_apt_auth_only

Retain Xenial and Bionic behavior for ESMInfra which will behave like
ESMApps which removes any apt artifacts (preferences, auth or list
files) when ESMInfra is disabled.

Fixes: #940