### PR TITLE
aws: handle missing SYS_HYPERVISOR_PRODUCT_UUID

### DIFF
--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -23,9 +23,14 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     @property
     def is_viable(self):
         """This machine is a viable AWSInstance"""
-        hypervisor_uuid = util.load_file(SYS_HYPERVISOR_PRODUCT_UUID)
-        if "ec2" == hypervisor_uuid[0:3]:
-            return True
+        try:
+            hypervisor_uuid = util.load_file(SYS_HYPERVISOR_PRODUCT_UUID)
+            if "ec2" == hypervisor_uuid[0:3]:
+                return True
+        except FileNotFoundError:
+            # SYS_HYPERVISOR_PRODUCT_UUID isn't present on all EC2 instance
+            # types, fall through
+            pass
         # Both DMI product_uuid and product_serial start with 'ec2'
         dmi_uuid = util.load_file(DMI_PRODUCT_UUID).lower()
         dmi_serial = util.load_file(DMI_PRODUCT_SERIAL).lower()

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -72,7 +72,9 @@ class TestUAAutoAttachAWSInstance:
         "hypervisor_uuid,prod_uuid,prod_serial,viable",
         (
             ("notec2", "ec2UUID", "ec2Serial", True),
+            (None, "ec2UUID", "ec2Serial", True),
             ("notec2", "EC2UUID", "Ec2Serial", True),
+            (None, "EC2UUID", "Ec2Serial", True),
             ("notec2", "!EC2UUID", "Ec2Serial", False),
             ("notec2", "EC2UUID", "1Ec2Serial", False),
             ("notec2", "ec2UUID", "ec3Serial", False),
@@ -87,7 +89,9 @@ class TestUAAutoAttachAWSInstance:
 
         def fake_load_file(f_name):
             if f_name == "/sys/hypervisor/uuid":
-                return hypervisor_uuid
+                if hypervisor_uuid is not None:
+                    return hypervisor_uuid
+                raise FileNotFoundError()
             if f_name == "/sys/class/dmi/id/product_uuid":
                 return prod_uuid
             if f_name == "/sys/class/dmi/id/product_serial":


### PR DESCRIPTION
On some AWS instance types, it doesn't exist.  We have the fallback
logic for those cases already, but we need to ignore FileNotFoundError
to get to it.

Fixes #946.