### PR TITLE
azure-pro: add azure pro image auto-attach support

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -356,22 +356,18 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
         server or inability to access identity doc from metadata service.
     :raise ContractAPIError: On unexpected errors when talking to the contract
         server.
+    :raise NonAutoAttachImageError: If this cloud type does not have
+        auto-attach support.
 
     :return: contract token obtained from identity doc
     """
     cloud_type = identity.get_cloud_type()
-    if cloud_type not in ("aws",):  # TODO(avoid hard-coding supported types)
-        raise exceptions.NonAutoAttachImageError(
-            ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
-                cloud_type=cloud_type
-            )
-        )
     instance = identity.cloud_instance_factory()
     contract_client = contract.UAContractClient(cfg)
-    pkcs7 = instance.identity_doc
     try:
-        # TODO(make this logic cloud-agnostic if possible)
-        tokenResponse = contract_client.request_aws_contract_token(pkcs7)
+        tokenResponse = contract_client.request_auto_attach_contract_token(
+            cloud_type=cloud_type, instance_doc=instance.identity_doc
+        )
     except contract.ContractAPIError as e:
         if contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e:
             raise exceptions.NonAutoAttachImageError(

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,10 +1,16 @@
 import abc
 
+try:
+    from typing import Any, Dict  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 
 class AutoAttachCloudInstance(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
-    def identity_doc(self) -> str:
+    def identity_doc(self) -> "Dict[str, Any]":
         """Return the identity document representing this cloud instance"""
         pass
 

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -18,7 +18,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self):
         response, _headers = util.readurl(IMDS_URL)
-        return response
+        return {"pkcs7": response}
 
     @property
     def is_viable(self):

--- a/uaclient/clouds/azure.py
+++ b/uaclient/clouds/azure.py
@@ -1,0 +1,46 @@
+import os
+
+from urllib.error import HTTPError
+
+from uaclient.clouds import AutoAttachCloudInstance
+from uaclient import util
+
+
+IMDS_BASE_URL = "http://169.254.169.254/metadata/"
+IMDS_URLS = {
+    "compute": IMDS_BASE_URL + "instance/compute?api-version=2019-06-04",
+    "pkcs7": IMDS_BASE_URL + "attested/document?api-version=2019-06-04",
+}
+
+SYS_HYPERVISOR_PRODUCT_UUID = "/sys/hypervisor/uuid"
+DMI_CHASSIS_ASSET_TAG = "/sys/class/dmi/id/chassis_asset_tag"
+AZURE_CHASSIS_ASSET_TAG = "7783-7084-3265-9085-8269-3286-77"
+
+
+class UAAutoAttachAzureInstance(AutoAttachCloudInstance):
+
+    # mypy does not handle @property around inner decorators
+    # https://github.com/python/mypy/issues/1362
+    @property  # type: ignore
+    @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
+    def identity_doc(self):
+        response = {}
+        for key, url in sorted(IMDS_URLS.items()):
+            url_response, _headers = util.readurl(
+                url, headers={"Metadata": True}
+            )
+            if key == "pkcs7":
+                response[key] = url_response["signature"]
+            else:
+                response[key] = url_response
+        return response
+
+    @property
+    def is_viable(self):
+        """This machine is a viable AzureInstance"""
+        chassis_asset_tag = util.load_file(DMI_CHASSIS_ASSET_TAG)
+        if AZURE_CHASSIS_ASSET_TAG == chassis_asset_tag.strip():
+            return True
+        if os.path.exists("/var/lib/cloud/seed/azure/ovf-env.xml"):
+            return True
+        return False

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -41,8 +41,12 @@ def get_cloud_type() -> "Optional[str]":
 
 def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
     from uaclient.clouds import aws
+    from uaclient.clouds import azure
 
-    cloud_instance_map = {"aws": aws.UAAutoAttachAWSInstance}
+    cloud_instance_map = {
+        "aws": aws.UAAutoAttachAWSInstance,
+        "azure": azure.UAAutoAttachAzureInstance,
+    }
 
     cloud_type = get_cloud_type()
     if not cloud_type:
@@ -51,7 +55,7 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
         )
     cls = cloud_instance_map.get(cloud_type)
     if not cls:
-        raise exceptions.UserFacingError(
+        raise exceptions.NonAutoAttachImageError(
             status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
                 cloud_type=cloud_type
             )

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -16,7 +16,7 @@ class TestUAAutoAttachAWSInstance:
         """Return pkcs7 content from IMDS as AWS' identity doc"""
         readurl.return_value = "pkcs7WOOT!==", {"header": "stuff"}
         instance = UAAutoAttachAWSInstance()
-        assert "pkcs7WOOT!==" == instance.identity_doc
+        assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
         url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
         assert [mock.call(url)] == readurl.call_args_list
 
@@ -47,7 +47,7 @@ class TestUAAutoAttachAWSInstance:
                 instance.identity_doc
             assert 704 == excinfo.value.code
         else:
-            assert "pkcs7WOOT!==" == instance.identity_doc
+            assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
 
         expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
         assert expected_sleep_calls == sleep.call_args_list

--- a/uaclient/clouds/tests/test_azure.py
+++ b/uaclient/clouds/tests/test_azure.py
@@ -1,0 +1,115 @@
+import logging
+import mock
+from io import BytesIO
+from urllib.error import HTTPError
+
+import pytest
+
+from uaclient.clouds.azure import IMDS_BASE_URL, UAAutoAttachAzureInstance
+
+M_PATH = "uaclient.clouds.azure."
+
+
+class TestUAAutoAttachAzureInstance:
+    @mock.patch(M_PATH + "util.readurl")
+    def test_identity_doc_from_azure_url_pkcs7(self, readurl):
+        """Return attested signature and compute info as Azure identity doc"""
+
+        def fake_readurl(url, headers):
+            if "attested/document" in url:
+                return {"signature": "attestedWOOT!==="}, {"header": "stuff"}
+            elif "instance/compute" in url:
+                return {"computekey": "computeval"}, {"header": "stuff"}
+            else:
+                raise AssertionError("Unexpected URL provided %s" % url)
+
+        readurl.side_effect = fake_readurl
+        instance = UAAutoAttachAzureInstance()
+        assert {
+            "compute": {"computekey": "computeval"},
+            "pkcs7": "attestedWOOT!===",
+        } == instance.identity_doc
+        url1 = IMDS_BASE_URL + "instance/compute?api-version=2019-06-04"
+        url2 = IMDS_BASE_URL + "attested/document?api-version=2019-06-04"
+        assert [
+            mock.call(url1, headers={"Metadata": True}),
+            mock.call(url2, headers={"Metadata": True}),
+        ] == readurl.call_args_list
+
+    @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
+    @pytest.mark.parametrize("fail_count,exception", ((3, False), (4, True)))
+    @mock.patch(M_PATH + "util.time.sleep")
+    @mock.patch(M_PATH + "util.readurl")
+    def test_retry_backoff_on_failed_identity_doc(
+        self, readurl, sleep, fail_count, exception, caplog_text
+    ):
+        """Retries backoff before failing to get Azure.identity_doc"""
+
+        def fake_someurlerrors(url, headers):
+            if readurl.call_count <= fail_count:
+                raise HTTPError(
+                    "http://me",
+                    700 + readurl.call_count,
+                    "funky error msg",
+                    None,
+                    BytesIO(),
+                )
+            if "attested" in url:
+                return {"signature": "attestedWOOT!==="}, {"header": "stuff"}
+            elif "compute" in url:
+                return {"computekey": "computeval"}, {"header": "stuff"}
+            raise AssertionError("Unexpected url requested {}".format(url))
+
+        readurl.side_effect = fake_someurlerrors
+        instance = UAAutoAttachAzureInstance()
+        if exception:
+            with pytest.raises(HTTPError) as excinfo:
+                instance.identity_doc
+            assert 704 == excinfo.value.code
+        else:
+            assert {
+                "pkcs7": "attestedWOOT!===",
+                "compute": {"computekey": "computeval"},
+            } == instance.identity_doc
+
+        expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
+        assert expected_sleep_calls == sleep.call_args_list
+        expected_logs = [
+            "HTTP Error 701: funky error msg Retrying 3 more times.",
+            "HTTP Error 702: funky error msg Retrying 2 more times.",
+            "HTTP Error 703: funky error msg Retrying 1 more times.",
+        ]
+        logs = caplog_text()
+        for log in expected_logs:
+            assert log in logs
+
+    @pytest.mark.parametrize(
+        "chassis_asset_tag,ovf_env_exists,viable",
+        (
+            ("7783-7084-3265-9085-8269-3286-77", False, True),
+            ("6783-7084-3265-9085-8269-3286-77", True, True),
+            ("6783-7084-3265-9085-8269-3286-77", False, False),
+        ),
+    )
+    @mock.patch(M_PATH + "os.path.exists")
+    @mock.patch(M_PATH + "util.load_file")
+    def test_is_viable_based_on_dmi_chassis_asset_tag_or_ovf_env(
+        self, load_file, m_exists, chassis_asset_tag, ovf_env_exists, viable
+    ):
+        """Platform viable if chassis asset tag matches or ovf.env exists."""
+
+        def fake_exists(f_name):
+            if f_name == "/var/lib/cloud/seed/azure/ovf-env.xml":
+                return ovf_env_exists
+            raise AssertionError("Invalid os.path.exist of {}".format(f_name))
+
+        m_exists.side_effect = fake_exists
+
+        def fake_load_file(f_name):
+            if f_name == "/sys/class/dmi/id/chassis_asset_tag":
+                return chassis_asset_tag
+            raise AssertionError("Invalid load_file of {}".format(f_name))
+
+        load_file.side_effect = fake_load_file
+        instance = UAAutoAttachAzureInstance()
+        assert viable is instance.is_viable

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -79,13 +79,14 @@ class TestCloudInstanceFactory:
             excinfo.value
         )
 
-    def test_raise_error_when_not_aws(self, m_get_cloud_type):
+    @pytest.mark.parametrize("cloud_type", ("awslookalike", "!azure", "!aws"))
+    def test_raise_error_when_not_aws(self, m_get_cloud_type, cloud_type):
         """Raise appropriate error when unable to determine cloud_type."""
-        m_get_cloud_type.return_value = "nonaws"
+        m_get_cloud_type.return_value = cloud_type
         with pytest.raises(exceptions.UserFacingError) as excinfo:
             cloud_instance_factory()
         error_msg = status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
-            cloud_type="nonaws"
+            cloud_type=cloud_type
         )
         assert error_msg == str(excinfo.value)
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -23,7 +23,7 @@ API_V1_RESOURCES = "/v1/resources"
 API_V1_TMPL_RESOURCE_MACHINE_ACCESS = (
     "/v1/resources/{resource}/context/machines/{machine}"
 )
-API_V1_AUTO_ATTACH_AWS_TOKEN = "/v1/clouds/aws/token"
+API_V1_AUTO_ATTACH_CLOUD_TOKEN = "/v1/clouds/{cloud_type}/token"
 
 
 class ContractAPIError(util.UrlError):
@@ -103,18 +103,23 @@ class UAContractClient(serviceclient.UAServiceClient):
         )
         return resource_response
 
-    def request_aws_contract_token(self, pkcs7: str):
-        """Requests contract token for auto-attach images on AWS.
+    def request_auto_attach_contract_token(
+        self, cloud_type: "Optional[str]", instance_doc: "Dict[str, Any]"
+    ):
+        """Requests contract token for auto-attach images for Pro clouds.
 
-        @param pkcs7: string obtained from AWS metadata service from
-            http://169.254.169.254/latest/dynamic/instance-identity/pkcs7
-            from this instance.
+        @param cloud_type: string representing the unique cloud for which the
+            auto-attach request is made. For example: aws or azure.
+        @param instance_doc: A dictionary of key value pairs representing
+            this instance identity information to be used as the payload
+            for the auto-attach request. Different clouds have different
+            required identity_doc fields.
 
         @return: Dict of the JSON response containing the contract-token.
         """
-        data = {"pkcs7": pkcs7}
         response, _headers = self.request_url(
-            API_V1_AUTO_ATTACH_AWS_TOKEN, data=data
+            API_V1_AUTO_ATTACH_CLOUD_TOKEN.format(cloud_type=cloud_type),
+            data=instance_doc,
         )
         self.cfg.write_cache("contract-token", response)
         return response

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -38,7 +38,7 @@ class TestGetContractTokenFromCloudIdentity:
         m_instance.identity_doc = "pkcs7-validated-by-backend"
         return m_instance
 
-    @pytest.mark.parametrize("cloud_type", ("awslookalike", "azure", "!aws"))
+    @pytest.mark.parametrize("cloud_type", ("awslookalike", "azure2", "!aws"))
     @mock.patch("uaclient.clouds.identity.get_cloud_type")
     def test_non_aws_cloud_type_raises_error(
         self, m_get_cloud_type, cloud_type
@@ -52,7 +52,7 @@ class TestGetContractTokenFromCloudIdentity:
         ) == str(excinfo.value)
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -60,12 +60,12 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """AWS clouds on non-auto-attach images not return a token."""
 
         cloud_instance_factory.side_effect = self.fake_instance_factory
-        request_aws_contract_token.side_effect = ContractAPIError(
+        request_auto_attach_contract_token.side_effect = ContractAPIError(
             util.UrlError(
                 "Server error", code=500, url="http://me", headers={}
             ),
@@ -76,7 +76,7 @@ class TestGetContractTokenFromCloudIdentity:
         assert status.MESSAGE_UNSUPPORTED_AUTO_ATTACH == str(excinfo.value)
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -84,7 +84,7 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """Any unexpected errors will be raised."""
 
@@ -95,14 +95,14 @@ class TestGetContractTokenFromCloudIdentity:
             ),
             error_response={"message": "something unexpected"},
         )
-        request_aws_contract_token.side_effect = unexpected_error
+        request_auto_attach_contract_token.side_effect = unexpected_error
 
         with pytest.raises(ContractAPIError) as excinfo:
             _get_contract_token_from_cloud_identity(FakeConfig())
         assert unexpected_error == excinfo.value
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -110,16 +110,16 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """Return token from the contract server using the identity."""
 
         cloud_instance_factory.side_effect = self.fake_instance_factory
 
-        def fake_aws_contract_token(contract_token):
+        def fake_contract_token(cloud_type, instance_doc):
             return {"contractToken": "myPKCS7-token"}
 
-        request_aws_contract_token.side_effect = fake_aws_contract_token
+        request_auto_attach_contract_token.side_effect = fake_contract_token
 
         cfg = FakeConfig()
         assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(cfg)


### PR DESCRIPTION
# WIP will break up into separate branches
* Add azure module with UAAutoAttachAzureInstance:
   - provide identity_doc dict containing pkcs7 and compute key value
     pairs obtained from Azure attested and compute and IMDS URLs
* Refactor identity_doc method to return a dict
* Refactor aws.identity_doc to return {'pkcs7': '<pkcs7data>'}
* Refactor request_auto_attach_contract_token to support different
  cloud_types and parameterize the auto attach URL called
* Fixup cli:_get_contract_token_from_cloud_identity to call new
  contractclient.request_auto_attach_contract_token in a cloud-agnostic way
