### PR TITLE
azure-pro: generalize contract.request_contract_token and identity_doc

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,6 +44,7 @@ override_dh_gencontrol:
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/ubuntu-advantage-tools
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}
+	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -368,10 +368,11 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
         )
     instance = identity.cloud_instance_factory()
     contract_client = contract.UAContractClient(cfg)
-    pkcs7 = instance.identity_doc
     try:
         # TODO(make this logic cloud-agnostic if possible)
-        tokenResponse = contract_client.request_aws_contract_token(pkcs7)
+        tokenResponse = contract_client.request_auto_attach_contract_token(
+            cloud_type=cloud_type, instance_doc=instance.identity_doc
+        )
     except contract.ContractAPIError as e:
         if contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e:
             raise exceptions.NonAutoAttachImageError(

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -356,20 +356,15 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
         server or inability to access identity doc from metadata service.
     :raise ContractAPIError: On unexpected errors when talking to the contract
         server.
+    :raise NonAutoAttachImageError: If this cloud type does not have
+        auto-attach support.
 
     :return: contract token obtained from identity doc
     """
     cloud_type = identity.get_cloud_type()
-    if cloud_type not in ("aws",):  # TODO(avoid hard-coding supported types)
-        raise exceptions.NonAutoAttachImageError(
-            ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
-                cloud_type=cloud_type
-            )
-        )
     instance = identity.cloud_instance_factory()
     contract_client = contract.UAContractClient(cfg)
     try:
-        # TODO(make this logic cloud-agnostic if possible)
         tokenResponse = contract_client.request_auto_attach_contract_token(
             cloud_type=cloud_type, instance_doc=instance.identity_doc
         )

--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,10 +1,16 @@
 import abc
 
+try:
+    from typing import Any, Dict  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 
 class AutoAttachCloudInstance(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
-    def identity_doc(self) -> str:
+    def identity_doc(self) -> "Dict[str, Any]":
         """Return the identity document representing this cloud instance"""
         pass
 

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -18,7 +18,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self):
         response, _headers = util.readurl(IMDS_URL)
-        return response
+        return {"pkcs7": response}
 
     @property
     def is_viable(self):

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -51,7 +51,7 @@ def cloud_instance_factory() -> clouds.AutoAttachCloudInstance:
         )
     cls = cloud_instance_map.get(cloud_type)
     if not cls:
-        raise exceptions.UserFacingError(
+        raise exceptions.NonAutoAttachImageError(
             status.MESSAGE_UNSUPPORTED_AUTO_ATTACH_CLOUD_TYPE.format(
                 cloud_type=cloud_type
             )

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -16,7 +16,7 @@ class TestUAAutoAttachAWSInstance:
         """Return pkcs7 content from IMDS as AWS' identity doc"""
         readurl.return_value = "pkcs7WOOT!==", {"header": "stuff"}
         instance = UAAutoAttachAWSInstance()
-        assert "pkcs7WOOT!==" == instance.identity_doc
+        assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
         url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
         assert [mock.call(url)] == readurl.call_args_list
 
@@ -47,7 +47,7 @@ class TestUAAutoAttachAWSInstance:
                 instance.identity_doc
             assert 704 == excinfo.value.code
         else:
-            assert "pkcs7WOOT!==" == instance.identity_doc
+            assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
 
         expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
         assert expected_sleep_calls == sleep.call_args_list

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -23,7 +23,7 @@ API_V1_RESOURCES = "/v1/resources"
 API_V1_TMPL_RESOURCE_MACHINE_ACCESS = (
     "/v1/resources/{resource}/context/machines/{machine}"
 )
-API_V1_AUTO_ATTACH_AWS_TOKEN = "/v1/clouds/aws/token"
+API_V1_AUTO_ATTACH_CLOUD_TOKEN = "/v1/clouds/{cloud_type}/token"
 
 
 class ContractAPIError(util.UrlError):
@@ -103,18 +103,23 @@ class UAContractClient(serviceclient.UAServiceClient):
         )
         return resource_response
 
-    def request_aws_contract_token(self, pkcs7: str):
-        """Requests contract token for auto-attach images on AWS.
+    def request_auto_attach_contract_token(
+        self, cloud_type: "Optional[str]", instance_doc: "Dict[str, Any]"
+    ):
+        """Requests contract token for auto-attach images for Pro clouds.
 
-        @param pkcs7: string obtained from AWS metadata service from
-            http://169.254.169.254/latest/dynamic/instance-identity/pkcs7
-            from this instance.
+        @param cloud_type: string representing the unique cloud for which the
+            auto-attach request is made. For example: aws or azure.
+        @param instance_doc: A dictionary of key value pairs representing
+            this instance identity information to be used as the payload
+            for the auto-attach request. Different clouds have different
+            required identity_doc fields.
 
         @return: Dict of the JSON response containing the contract-token.
         """
-        data = {"pkcs7": pkcs7}
         response, _headers = self.request_url(
-            API_V1_AUTO_ATTACH_AWS_TOKEN, data=data
+            API_V1_AUTO_ATTACH_CLOUD_TOKEN.format(cloud_type=cloud_type),
+            data=instance_doc,
         )
         self.cfg.write_cache("contract-token", response)
         return response

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -4,6 +4,7 @@ from uaclient.entitlements import repo
 class ESMBaseEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/esm"
     repo_pin_priority = "never"
+    disable_apt_auth_only = True  # Only remove apt auth files when disabling
 
 
 class ESMAppsEntitlement(ESMBaseEntitlement):
@@ -20,4 +21,3 @@ class ESMInfraEntitlement(ESMBaseEntitlement):
     title = "ESM Infra"
     description = "UA Infra: Extended Security Maintenance"
     repo_key_file = "ubuntu-advantage-esm-infra-trusty.gpg"
-    # TODO: Restore disable_apt_auth_only for trusty

--- a/uaclient/entitlements/esm.py
+++ b/uaclient/entitlements/esm.py
@@ -3,7 +3,7 @@ from uaclient.entitlements import repo
 
 class ESMBaseEntitlement(repo.RepoEntitlement):
     help_doc_url = "https://ubuntu.com/esm"
-    # TODO: Restore repo_pin_priority = "never" for trusty
+    repo_pin_priority = "never"
 
 
 class ESMAppsEntitlement(ESMBaseEntitlement):

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -38,7 +38,7 @@ class TestGetContractTokenFromCloudIdentity:
         m_instance.identity_doc = "pkcs7-validated-by-backend"
         return m_instance
 
-    @pytest.mark.parametrize("cloud_type", ("awslookalike", "azure", "!aws"))
+    @pytest.mark.parametrize("cloud_type", ("awslookalike", "azure2", "!aws"))
     @mock.patch("uaclient.clouds.identity.get_cloud_type")
     def test_non_aws_cloud_type_raises_error(
         self, m_get_cloud_type, cloud_type
@@ -52,7 +52,7 @@ class TestGetContractTokenFromCloudIdentity:
         ) == str(excinfo.value)
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -60,12 +60,12 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """AWS clouds on non-auto-attach images not return a token."""
 
         cloud_instance_factory.side_effect = self.fake_instance_factory
-        request_aws_contract_token.side_effect = ContractAPIError(
+        request_auto_attach_contract_token.side_effect = ContractAPIError(
             util.UrlError(
                 "Server error", code=500, url="http://me", headers={}
             ),
@@ -76,7 +76,7 @@ class TestGetContractTokenFromCloudIdentity:
         assert status.MESSAGE_UNSUPPORTED_AUTO_ATTACH == str(excinfo.value)
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -84,7 +84,7 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """Any unexpected errors will be raised."""
 
@@ -95,14 +95,14 @@ class TestGetContractTokenFromCloudIdentity:
             ),
             error_response={"message": "something unexpected"},
         )
-        request_aws_contract_token.side_effect = unexpected_error
+        request_auto_attach_contract_token.side_effect = unexpected_error
 
         with pytest.raises(ContractAPIError) as excinfo:
             _get_contract_token_from_cloud_identity(FakeConfig())
         assert unexpected_error == excinfo.value
 
     @mock.patch(
-        M_PATH + "contract.UAContractClient.request_aws_contract_token"
+        M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
     @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
     @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
@@ -110,16 +110,16 @@ class TestGetContractTokenFromCloudIdentity:
         self,
         _get_cloud_type,
         cloud_instance_factory,
-        request_aws_contract_token,
+        request_auto_attach_contract_token,
     ):
         """Return token from the contract server using the identity."""
 
         cloud_instance_factory.side_effect = self.fake_instance_factory
 
-        def fake_aws_contract_token(contract_token):
+        def fake_contract_token(cloud_type, instance_doc):
             return {"contractToken": "myPKCS7-token"}
 
-        request_aws_contract_token.side_effect = fake_aws_contract_token
+        request_auto_attach_contract_token.side_effect = fake_contract_token
 
         cfg = FakeConfig()
         assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(cfg)


### PR DESCRIPTION
* auto-attach: move duplicate invalid cloud_type check out of cli
* contract: generalize request_aws_contract_token for multiple cloud_types
* clouds: generalize identity_doc to return dict instead of string
