### PR TITLE
pkg: provide --no-start to debhelper to avoid auto-attach on pkg install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,8 @@ APT_PKG_DEPS="apt (>= 1.8.1), apt-utils (>= 1.8.1), libapt-pkg5.90 (>= 1.8.1)"
 endif
 
 %:
-	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild
+	dh $@ --with python3,bash-completion,systemd --buildsystem=pybuild \
+		--no-start
 
 override_dh_auto_build:
 	dh_auto_build


### PR DESCRIPTION
Previously, installation of ubuntu-advantage-tools would automatically
reload systemd and trigger auto-attach on supported platforms.

Avoid that side-effect by providing --no-start to dh during package
build.

Fixes: #948
