### PR TITLE
tox.ini: run behave with --verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
     mypy: mypy --python-version 3.6 uaclient/ features/
     mypy: mypy --python-version 3.7 uaclient/ features/
     black: black --check --diff uaclient/ features/ setup.py
-    behave: behave {posargs}
+    behave: behave --verbose {posargs}
 
 [flake8]
 # E251: Older versions of flake8 et al don't permit the


### PR DESCRIPTION
This is required to get full tracebacks, which are very useful for
debugging.