### PR TITLE
auto-attach: handle 403 errors raised by contract server for invalid vms

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -368,7 +368,13 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
             instance=instance
         )
     except contract.ContractAPIError as e:
-        if contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e:
+        if (
+            e.code == 403
+            or contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e
+        ):
+            import pdb
+
+            pdb.set_trace()
             raise exceptions.NonAutoAttachImageError(
                 ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
             )

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -368,13 +368,7 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
             instance=instance
         )
     except contract.ContractAPIError as e:
-        if (
-            e.code == 403
-            or contract.API_ERROR_MISSING_INSTANCE_INFORMATION in e
-        ):
-            import pdb
-
-            pdb.set_trace()
+        if e.code and 400 <= e.code < 500:
             raise exceptions.NonAutoAttachImageError(
                 ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
             )

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -15,7 +15,6 @@ except ImportError:
     pass
 
 API_ERROR_INVALID_TOKEN = "invalid token"
-API_ERROR_MISSING_INSTANCE_INFORMATION = "missing instance information"
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
 API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE = (
     "/v1/contracts/{contract}/context/machines/{machine}"

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -56,7 +56,7 @@ class TestGetContractTokenFromCloudIdentity:
     @pytest.mark.parametrize(
         "http_msg,http_code,http_response",
         (
-            ("Server error", 500, {"message": "missing instance information"}),
+            ("Not found", 404, {"message": "missing instance information"}),
             (
                 "Forbidden",
                 403,
@@ -83,9 +83,9 @@ class TestGetContractTokenFromCloudIdentity:
         cloud_instance_factory.side_effect = self.fake_instance_factory
         request_auto_attach_contract_token.side_effect = ContractAPIError(
             util.UrlError(
-                "Server error", code=500, url="http://me", headers={}
+                http_msg, code=http_code, url="http://me", headers={}
             ),
-            error_response={"message": "missing instance information"},
+            error_response=http_response,
         )
         with pytest.raises(NonAutoAttachImageError) as excinfo:
             _get_contract_token_from_cloud_identity(FakeConfig())

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -53,6 +53,17 @@ class TestGetContractTokenFromCloudIdentity:
             cloud_type=cloud_type
         ) == str(excinfo.value)
 
+    @pytest.mark.parametrize(
+        "http_msg,http_code,http_response",
+        (
+            ("Server error", 500, {"message": "missing instance information"}),
+            (
+                "Forbidden",
+                403,
+                {"message": "forbidden: cannot verify signing certificate"},
+            ),
+        ),
+    )
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
@@ -63,8 +74,11 @@ class TestGetContractTokenFromCloudIdentity:
         _get_cloud_type,
         cloud_instance_factory,
         request_auto_attach_contract_token,
+        http_msg,
+        http_code,
+        http_response,
     ):
-        """AWS clouds on non-auto-attach images not return a token."""
+        """VMs running on non-auto-attach images do not return a token."""
 
         cloud_instance_factory.side_effect = self.fake_instance_factory
         request_auto_attach_contract_token.side_effect = ContractAPIError(


### PR DESCRIPTION
Note that some errors from the contracts server don't set HTTP status and raise 403.

Errors like API_ERROR_MISSING_INSTANCE_INFORMATION for AWS resulted in 500s on the server and have now been changed per https://github.com/CanonicalLtd/ua-contracts/pull/517/files to return HTTP status code 404

Fixes #939