### PR TITLE
attach: persist any status config changes after attach failures

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -329,9 +329,11 @@ def _attach_with_token(
         with util.disable_log_to_console():
             logging.exception(exc)
         print(ua_status.MESSAGE_ATTACH_FAILURE)
+        cfg.status()  # Persist updated status in the event of partial attach
         return 1
     except exceptions.UserFacingError as exc:
         logging.warning(exc.msg)
+        cfg.status()  # Persist updated status in the event of partial attach
         return 1
     contract_name = cfg.machine_token["machineTokenInfo"]["contractInfo"][
         "name"

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -115,6 +115,7 @@ class UAConfig:
 
         self._entitlements = {}
         contractInfo = machine_token["machineTokenInfo"]["contractInfo"]
+
         ent_by_name = dict(
             (e["type"], e) for e in contractInfo["resourceEntitlements"]
         )


### PR DESCRIPTION
There can be cases where auto-enablement of a service results in an
error. Or, intermittent connectivity to ua-contracts routes end up
resulting in an error during `ua attach`.

In the event that attach succeeds, but auto-enablement actions fail
status needs to be persisted to reflect whether attach succeeded and
any services have been successfully enabled.

Fixes: #952