### PR TITLE
Constrain PyYAML for all releases

### DIFF
--- a/tools/constraints-bionic.txt
+++ b/tools/constraints-bionic.txt
@@ -4,3 +4,4 @@ py==1.5.2
 pycodestyle==2.3.1
 pytest==3.3.2
 pytest-cov==2.5.1
+pyyaml==3.12

--- a/tools/constraints-disco.txt
+++ b/tools/constraints-disco.txt
@@ -4,3 +4,4 @@ py==1.7.0
 pycodestyle==2.4.0
 pytest==3.10.1
 pytest-cov==2.6.0
+pyyaml==3.13

--- a/tools/constraints-eoan.txt
+++ b/tools/constraints-eoan.txt
@@ -4,3 +4,4 @@ py==1.8.0
 pycodestyle==2.5.0
 pytest==3.10.1
 pytest-cov==2.7.1
+pyyaml==5.1.2

--- a/tools/constraints-trusty.txt
+++ b/tools/constraints-trusty.txt
@@ -1,8 +1,8 @@
-pyyaml==3.10
 flake8==2.1.0
 pep8==1.4.6
 py==1.4.20
 pytest==2.5.1
+pyyaml==3.10
 
 # pytest-cov isn't available in trusty; the package build tests don't require
 # it, but including it here allows us to keep a consistent test command in

--- a/tools/constraints-xenial.txt
+++ b/tools/constraints-xenial.txt
@@ -4,3 +4,4 @@ pep8==1.7.0
 py==1.4.31
 pytest==2.8.7
 pytest-cov==2.2.1
+pyyaml==3.11


### PR DESCRIPTION
This is #959 but for `master` instead of the `trusty-auto-attach` branch.