### PR TITLE
clouds: generalize identity_doc to return dict instead of string

### DIFF
--- a/uaclient/clouds/__init__.py
+++ b/uaclient/clouds/__init__.py
@@ -1,10 +1,16 @@
 import abc
 
+try:
+    from typing import Any, Dict  # noqa: F401
+except ImportError:
+    # typing isn't available on trusty, so ignore its absence
+    pass
+
 
 class AutoAttachCloudInstance(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
-    def identity_doc(self) -> str:
+    def identity_doc(self) -> "Dict[str, Any]":
         """Return the identity document representing this cloud instance"""
         pass
 

--- a/uaclient/clouds/aws.py
+++ b/uaclient/clouds/aws.py
@@ -24,7 +24,7 @@ class UAAutoAttachAWSInstance(AutoAttachCloudInstance):
     @util.retry(HTTPError, retry_sleeps=[1, 2, 5])
     def identity_doc(self) -> "Dict[str, Any]":
         response, _headers = util.readurl(IMDS_URL)
-        return response
+        return {"pkcs7": response}
 
     @property
     def cloud_type(self) -> str:

--- a/uaclient/clouds/tests/test_aws.py
+++ b/uaclient/clouds/tests/test_aws.py
@@ -20,7 +20,7 @@ class TestUAAutoAttachAWSInstance:
         """Return pkcs7 content from IMDS as AWS' identity doc"""
         readurl.return_value = "pkcs7WOOT!==", {"header": "stuff"}
         instance = UAAutoAttachAWSInstance()
-        assert "pkcs7WOOT!==" == instance.identity_doc
+        assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
         url = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
         assert [mock.call(url)] == readurl.call_args_list
 
@@ -51,7 +51,7 @@ class TestUAAutoAttachAWSInstance:
                 instance.identity_doc
             assert 704 == excinfo.value.code
         else:
-            assert "pkcs7WOOT!==" == instance.identity_doc
+            assert {"pkcs7": "pkcs7WOOT!=="} == instance.identity_doc
 
         expected_sleep_calls = [mock.call(1), mock.call(2), mock.call(5)]
         assert expected_sleep_calls == sleep.call_args_list


### PR DESCRIPTION
AutoAttachCloudInstance.identity_doc now returns a dict to allow
for different clouds to return more complex identity data during
auto-attach.

(This contains pieces that were missed in the previous merge into master.)