### PR TITLE
azure-pro: fix detection of DatasourceAzureNet as azure on trusty

### DIFF
--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -15,7 +15,7 @@ CLOUDINIT_RESULT_FILE = "/var/lib/cloud/data/result.json"
 
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
-DATASOURCE_TO_CLOUD_ID = {"ec2": "aws"}
+DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws"}
 
 
 def get_cloud_type_from_result_file(

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -21,6 +21,7 @@ class TestGetCloudTypeFromResultFile:
             ("DataSourceSomeTHING", "something"),
             ("DaTaSoUrCeMiNe", "mine"),
             ("DataSourceEc2", "aws"),
+            ("DataSourceAzureNet", "azure"),
             ("DataSourceEc2Lookalike", "ec2lookalike"),
         ),
     )


### PR DESCRIPTION
Sync commit from trusty-auto-attach to master

Fixes: #977