### PR TITLE
pkg: introduce a separate ubuntu-advantage-pro package v. 20.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-advantage-tools (20.1) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (20.1) xenial; urgency=medium
 
   * Release 20.1:
     - azure-pro, support for azure ubuntu pro auto-attach:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,24 @@
+ubuntu-advantage-tools (20.2) UNRELEASED; urgency=medium
+
+  * d/templates: add a debconf note on upgrade from pre-ubuntu pro package
+  * d/control: create a separate ubuntu-advantage-pro package which
+      delivers the tooling and scripts necessary to auto-attach pro machines
+      This change breaks/replaces ubuntu-advantage-tools <= 20.1
+  * d/maintscript: rm_conffile /etc/init/ua-auto-attach.conf from ua-tools pkg
+  * d/postint: remove stale systemd symlinks which have migrated to ubuntu-pro
+  * d/rules: only install the apt hook on trusty
+  * d/rules: provide --no-start to debhelper to avoid auto-attach on pkg install
+  * Release 20.2:
+    - ubuntu-pro:
+      + azure: fix detection of DatasourceAzureNet as azure on trusty
+      + generalize identity_doc to return dict instead of string
+      + auto-attach: any 4XX errors during auto-attach are the result of non-Pro
+      + auto-attach: handle 403 errors raised by contract server for invalid vms
+    - attach: persist any status config changes after attach failures
+    - output: add messaging using a different subscription if attached
+
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 20 Feb 2020 11:13:15 -0700
+
 ubuntu-advantage-tools (20.1) xenial; urgency=medium
 
   * Release 20.1:

--- a/debian/control
+++ b/debian/control
@@ -34,3 +34,9 @@ Description: management tools for Ubuntu Advantage
  .
  Subscribers to Ubuntu Advantage will find helpful tools for accessing
  services in this package.
+
+Package: ubuntu-advantage-pro
+Architecture: any
+Depends: ubuntu-advantage-tools
+Description: utilities and services for Ubuntu Pro images
+ FIXME

--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,9 @@ Description: management tools for Ubuntu Advantage
 
 Package: ubuntu-advantage-pro
 Architecture: any
-Depends: ubuntu-advantage-tools
+Depends: ubuntu-advantage-tools (>=20.2)
+Replaces: ubuntu-advantage-tools (<<20.2)
+Breaks: ubuntu-advantage-tools (<<20.2)
 Description: utilities and services for Ubuntu Pro images
- FIXME
+ The Ubuntu Pro package delivers additional utilities for use on authorised
+ Ubuntu Pro machines.

--- a/debian/postinst
+++ b/debian/postinst
@@ -21,6 +21,11 @@ ESM_INFRA_APT_PREF_FILE_TRUSTY="/etc/apt/preferences.d/ubuntu-esm-infra-trusty"
 MYARCH="$(dpkg --print-architecture)"
 ESM_SUPPORTED_ARCHS="i386 amd64"
 
+SYSTEMD_WANTS_AUTO_ATTACH_LINK="/etc/systemd/system/multi-user.target.wants/ua-auto-attach.service"
+SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH="/var/lib/systemd/deb-systemd-helper-enabled/ua-auto-attach.service.dsh-also"
+SYSTEMD_HELPER_ENABLED_WANTS_LINK="/var/lib/systemd/deb-systemd-helper-enabled/multi-user.target.wants/ua-auto-attach.service"
+
+
 unconfigure_esm() {
     rm -f $APT_TRUSTED_KEY_DIR/ubuntu-esm*gpg  # Remove previous esm keys
     rm -f $APT_TRUSTED_KEY_DIR/$ESM_INFRA_KEY_TRUSTY
@@ -81,6 +86,10 @@ case "$1" in
       # We broke package compatibility in 20.2 for any image with 19.7
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "20.2~"; then
           if dpkg --compare-versions "$PREVIOUS_PKG_VER" ge-nl "19.7~"; then
+              # Drop stale symlinks for migrated auto-attach-service
+              rm -f $SYSTEMD_WANTS_AUTO_ATTACH_LINK
+              rm -f $SYSTEMD_HELPER_ENABLED_AUTO_ATTACH_DSH
+              rm -f $SYSTEMD_HELPER_ENABLED_WANTS_LINK
               # Use debconf to alert the user to the additional
               # ubuntu-advantage-pro package that should be installed
               . /usr/share/debconf/confmodule

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,6 +4,7 @@ set -e
 
 . /etc/os-release  # For VERSION_ID
 
+
 APT_TRUSTED_KEY_DIR="/etc/apt/trusted.gpg.d"
 UA_KEYRING_DIR="/usr/share/keyrings/"
 
@@ -74,6 +75,18 @@ case "$1" in
       if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "19.5~"; then
           # Remove all publicly-readable files
           find /var/lib/ubuntu-advantage/ -maxdepth 1 -type f -delete
+      fi
+
+      # Are we upgrading from a previously release Ubuntu Advantage Pro pkg?
+      # We broke package compatibility in 20.2 for any image with 19.7
+      if dpkg --compare-versions "$PREVIOUS_PKG_VER" lt-nl "20.2~"; then
+          if dpkg --compare-versions "$PREVIOUS_PKG_VER" ge-nl "19.7~"; then
+              # Use debconf to alert the user to the additional
+              # ubuntu-advantage-pro package that should be installed
+              . /usr/share/debconf/confmodule
+              db_input high ubuntu-advantage-tools/suggest_pro_pkg || true
+              db_go
+          fi
       fi
 
       # CACHE_DIR is no longer present or used since 19.1

--- a/debian/rules
+++ b/debian/rules
@@ -49,6 +49,18 @@ ifeq (${VERSION_ID},"14.04")
 	make -C apt-hook DESTDIR=$(CURDIR)/debian/ubuntu-advantage-tools install
 endif
 
+ifeq (${VERSION_ID},"14.04")
+	# Move ua-auto-attach.conf to ubuntu-advantage-pro
+	mkdir -p debian/ubuntu-advantage-pro/etc/init
+	mv debian/ubuntu-advantage-tools/etc/init/ua-auto-attach.conf debian/ubuntu-advantage-pro/etc/init/
+	rmdir debian/ubuntu-advantage-tools/etc/init
+else
+	# Move ua-auto-attach.service to ubuntu-advantage-pro
+	mkdir -p debian/ubuntu-advantage-pro/lib/systemd/system
+	mv debian/ubuntu-advantage-tools/lib/systemd/system/ua-auto-attach.service debian/ubuntu-advantage-pro/lib/systemd/system
+	cd debian/ubuntu-advantage-tools && rmdir -p lib/systemd/system
+endif
+
 override_dh_auto_clean:
 	dh_auto_clean
 	make clean

--- a/debian/ubuntu-advantage-tools.maintscript
+++ b/debian/ubuntu-advantage-tools.maintscript
@@ -2,3 +2,4 @@ rm_conffile /etc/update-motd.d/99-esm 19.1~ ubuntu-advantage-tools
 rm_conffile /etc/update-motd.d/80-esm 19.1~ ubuntu-advantage-tools
 rm_conffile /etc/update-motd.d/80-livepatch 19.1~ ubuntu-advantage-tools
 rm_conffile /etc/cron.daily/ubuntu-advantage-tools 19.1~ ubuntu-advantage-tools
+rm_conffile /etc/init/ua-auto-attach.conf 20.2~ ubuntu-advantage-tools

--- a/debian/ubuntu-advantage-tools.templates
+++ b/debian/ubuntu-advantage-tools.templates
@@ -1,0 +1,6 @@
+Template: ubuntu-advantage-tools/suggest_pro_pkg
+Type: note
+Description: Ubuntu Pro support now requires ubuntu-advantage-pro
+ To install run the following:
+ .
+ sudo apt-get install ubuntu-advantage-pro

--- a/uaclient/version.py
+++ b/uaclient/version.py
@@ -8,7 +8,7 @@ import os.path
 from subprocess import check_output
 
 
-__VERSION__ = "20.1"
+__VERSION__ = "20.2"
 PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 


### PR DESCRIPTION
In 20.2, a separate ubuntu-advantage-pro package will deliver the systemd or upstart unit which performs the Ubuntu Pro auto-attach.

Package separation of ua-pro from ua-tools allows the ubuntu-advantage-tools package to avoid complexity in determining whether a platform is certified as Ubuntu Pro before running the systemd or upstart auto-attach functionality on boot.

By delivering the systemd or upstart units in a separate deb package, both the init scripts and ubuntu-advantage-tools package can remain simple because the auto-attach features will only be
present and "active" when ubuntu-advantage-pro package is installed, which will only be on Ubuntu Pro images.

Due to the migration of upstart units and systemd services out of ubuntu-advantage-tools package,
the following changes have been made to make this breaking package upgrade cleaner:
* ubuntu-advantage.maintscript performs an rm_conffile /etc/init/ua-auto-attach.conf 
* postinst to cleanup stale systemd symlinks when upgrading from 19.7-20.1 (versions on Pro images)
* postinst to emit a debconf note during attended upgrade to alert about the need to install ubuntu-advantage-pro if upgrading from a known ubuntu-advantage-tools version on Ubuntu Pro

Fixes #974