### PR TITLE
Cleanup/drop machine access

### DIFF
--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -116,9 +116,7 @@ class UAConfig:
         self._entitlements = {}
         contractInfo = machine_token["machineTokenInfo"]["contractInfo"]
         tokens_by_name = dict(
-            # Handle Upper-case and lower-case keys until the following issue
-            # is fixed: ua-contracts #645
-            (e.get("Type", e.get("type")), e.get("Token", e.get("token")))
+            (e["type"], e["token"])
             for e in machine_token.get("resourceTokens", [])
         )
         ent_by_name = dict(

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -116,7 +116,9 @@ class UAConfig:
         self._entitlements = {}
         contractInfo = machine_token["machineTokenInfo"]["contractInfo"]
         tokens_by_name = dict(
-            (e["Type"], e["Token"])
+            # Handle Upper-case and lower-case keys until the following issue
+            # is fixed: ua-contracts #645
+            (e.get("Type", e.get("type")), e.get("Token", e.get("token")))
             for e in machine_token.get("resourceTokens", [])
         )
         ent_by_name = dict(

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -115,19 +115,19 @@ class UAConfig:
 
         self._entitlements = {}
         contractInfo = machine_token["machineTokenInfo"]["contractInfo"]
-
+        tokens_by_name = dict(
+            (e["Type"], e["Token"])
+            for e in machine_token.get("resourceTokens", [])
+        )
         ent_by_name = dict(
             (e["type"], e) for e in contractInfo["resourceEntitlements"]
         )
         for entitlement_name, ent_value in ent_by_name.items():
-            entitlement_cfg = {}
-            if ent_value.get("entitled"):
-                entitlement_cfg = self.read_cache(
-                    "machine-access-{}".format(entitlement_name), silent=True
-                )
-            if not entitlement_cfg:
-                # Fallback to machine-token info on unentitled
-                entitlement_cfg = {"entitlement": ent_value}
+            entitlement_cfg = {"entitlement": ent_value}
+            if entitlement_name in tokens_by_name:
+                entitlement_cfg["resourceToken"] = tokens_by_name[
+                    entitlement_name
+                ]
             util.apply_series_overrides(entitlement_cfg)
             self._entitlements[entitlement_name] = entitlement_cfg
         return self._entitlements

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -174,8 +174,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         response, headers = self.request_url(url, headers=headers, data=data)
         if headers.get("expires"):
             response["expires"] = headers["expires"]
-        # Clear UAConfig._entitlements cache because we are refreshing
-        self.cfg.delete_cache_key("machine-token")
         self.cfg.write_cache("machine-token", response)
         return response
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -174,6 +174,8 @@ class UAContractClient(serviceclient.UAServiceClient):
         response, headers = self.request_url(url, headers=headers, data=data)
         if headers.get("expires"):
             response["expires"] = headers["expires"]
+        # Clear UAConfig._entitlements cache because we are refreshing
+        self.cfg.delete_cache_key("machine-token")
         self.cfg.write_cache("machine-token", response)
         return response
 
@@ -281,18 +283,11 @@ def request_updated_contract(
             )
     delta_error = False
     unexpected_error = False
-    for name, entitlement in sorted(cfg.entitlements.items()):
-        if entitlement["entitlement"].get("entitled"):
-            # Obtain each entitlement's accessContext for this machine
-            new_access = contract_client.request_resource_machine_access(
-                new_token["machineToken"], name
-            )
-        else:
-            new_access = entitlement
+    for name, new_entitlement in sorted(cfg.entitlements.items()):
         try:
             process_entitlement_delta(
                 orig_entitlements.get(name, {}),
-                new_access,
+                new_entitlement,
                 allow_enable=allow_enable,
             )
         except exceptions.UserFacingError:
@@ -300,14 +295,14 @@ def request_updated_contract(
             with util.disable_log_to_console():
                 logging.exception(
                     "Failed to process contract delta for {name}:"
-                    " {delta}".format(name=name, delta=new_access)
+                    " {delta}".format(name=name, delta=new_entitlement)
                 )
         except Exception:
             unexpected_error = True
             with util.disable_log_to_console():
                 logging.exception(
                     "Unexpected error processing contract delta for {name}:"
-                    " {delta}".format(name=name, delta=new_access)
+                    " {delta}".format(name=name, delta=new_entitlement)
                 )
     if unexpected_error:
         raise exceptions.UserFacingError(

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -267,9 +267,7 @@ class RepoEntitlement(base.UAEntitlement):
         repo_filename = self.repo_list_file_tmpl.format(
             name=self.name, series=series
         )
-        entitlement = self.cfg.read_cache(
-            "machine-access-{}".format(self.name)
-        ).get("entitlement", {})
+        entitlement = self.cfg.entitlements[self.name].get("entitlement", {})
         access_directives = entitlement.get("directives", {})
         repo_url = access_directives.get("aptURL")
         if not repo_url:

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -3,29 +3,34 @@ import pytest
 from uaclient import config
 
 try:
-    from typing import Any, Dict, List, Optional  # noqa
+    from typing import Any, Dict, List  # noqa
 except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
 
 
 def machine_token(
-    type: str,
+    entitlement_type: str,
     *,
     affordances: "Dict[str, Any]" = None,
     directives: "Dict[str, Any]" = None,
-    entitled: "Optional[bool]" = True,
+    entitled: bool = True,
     obligations: "Dict[str, Any]" = None,
     suites: "List[str]" = None
 ) -> "Dict[str, Any]":
     return {
-        "resourceTokens": [{"Type": type, "Token": "%s-token" % type}],
+        "resourceTokens": [
+            {
+                "Type": entitlement_type,
+                "Token": "{}-token".format(entitlement_type),
+            }
+        ],
         "machineToken": "blah",
         "machineTokenInfo": {
             "contractInfo": {
                 "resourceEntitlements": [
                     machine_access(
-                        type,
+                        entitlement_type,
                         affordances=affordances,
                         directives=directives,
                         entitled=entitled,
@@ -39,11 +44,11 @@ def machine_token(
 
 
 def machine_access(
-    type: str,
+    entitlement_type: str,
     *,
     affordances: "Dict[str, Any]" = None,
     directives: "Dict[str, Any]" = None,
-    entitled: "Optional[bool]" = True,
+    entitled: bool = True,
     obligations: "Dict[str, Any]" = None,
     suites: "List[str]" = None
 ) -> "Dict[str, Any]":
@@ -55,14 +60,14 @@ def machine_access(
         obligations = {"enableByDefault": True}
     if directives is None:
         directives = {
-            "aptURL": "http://{}".format(type.upper()),
+            "aptURL": "http://{}".format(entitlement_type.upper()),
             "aptKey": "APTKEY",
             "suites": suites,
         }
     return {
         "obligations": obligations,
-        "type": type,
-        "entitled": True,
+        "type": entitlement_type,
+        "entitled": entitled,
         "directives": directives,
         "affordances": affordances,
     }

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -21,8 +21,8 @@ def machine_token(
     return {
         "resourceTokens": [
             {
-                "Type": entitlement_type,
-                "Token": "{}-token".format(entitlement_type),
+                "type": entitlement_type,
+                "token": "{}-token".format(entitlement_type),
             }
         ],
         "machineToken": "blah",

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -84,7 +84,14 @@ def entitlement_factory(tmpdir):
     entitlement.
     """
 
-    def factory_func(cls, *, affordances=None, directives=None, suites=None):
+    def factory_func(
+        cls,
+        *,
+        affordances: "Dict[str, Any]" = None,
+        directives: "Dict[str, Any]" = None,
+        entitled: bool = True,
+        suites: "List[str]" = None
+    ):
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
         cfg.write_cache(
             "machine-token",
@@ -92,6 +99,7 @@ def entitlement_factory(tmpdir):
                 cls.name,
                 affordances=affordances,
                 directives=directives,
+                entitled=entitled,
                 suites=suites,
             ),
         )

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -12,36 +12,28 @@ from uaclient import apt
 from uaclient import config
 from uaclient import status
 from uaclient.entitlements.cc import CC_README, CommonCriteriaEntitlement
+from uaclient.entitlements.tests.conftest import machine_token
 
 M_REPOPATH = "uaclient.entitlements.repo."
 
-CC_MACHINE_TOKEN = {
-    "machineToken": "blah",
-    "machineTokenInfo": {
-        "contractInfo": {
-            "resourceEntitlements": [{"type": "cc-eal", "entitled": True}]
-        }
-    },
-}
-
 
 CC_RESOURCE_ENTITLED = {
-    "resourceToken": "TOKEN",
-    "entitlement": {
-        "obligations": {"enableByDefault": False},
-        "type": "cc-eal",
-        "entitled": True,
-        "directives": {
-            "aptURL": "http://CC",
-            "aptKey": "APTKEY",
-            "suites": ["xenial"],
-        },
-        "affordances": {
-            "architectures": ["x86_64", "ppc64le", "s390x"],
-            "series": ["xenial"],
-        },
+    "obligations": {"enableByDefault": False},
+    "type": "cc-eal",
+    "entitled": True,
+    "directives": {
+        "aptURL": "http://CC",
+        "aptKey": "APTKEY",
+        "suites": ["xenial"],
+    },
+    "affordances": {
+        "architectures": ["x86_64", "ppc64le", "s390x"],
+        "series": ["xenial"],
     },
 }
+
+CC_MACHINE_TOKEN = machine_token(**CC_RESOURCE_ENTITLED)
+
 
 PLATFORM_INFO_SUPPORTED = MappingProxyType(
     {
@@ -168,7 +160,7 @@ class TestCommonCriteriaEntitlementEnable:
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list",
                 "http://CC",
-                "TOKEN",
+                "%s-token" % entitlement.name,
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -16,23 +16,20 @@ from uaclient.entitlements.tests.conftest import machine_token
 
 M_REPOPATH = "uaclient.entitlements.repo."
 
-
-CC_RESOURCE_ENTITLED = {
-    "obligations": {"enableByDefault": False},
-    "entitlement_type": "cc-eal",
-    "entitled": True,
-    "directives": {
+CC_MACHINE_TOKEN = machine_token(
+    entitlement_type="cc-eal",
+    obligations={"enableByDefault": False},
+    entitled=True,
+    directives={
         "aptURL": "http://CC",
         "aptKey": "APTKEY",
         "suites": ["xenial"],
     },
-    "affordances": {
+    affordances={
         "architectures": ["x86_64", "ppc64le", "s390x"],
         "series": ["xenial"],
     },
-}
-
-CC_MACHINE_TOKEN = machine_token(**CC_RESOURCE_ENTITLED)
+)
 
 
 PLATFORM_INFO_SUPPORTED = MappingProxyType(

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -19,7 +19,7 @@ M_REPOPATH = "uaclient.entitlements.repo."
 
 CC_RESOURCE_ENTITLED = {
     "obligations": {"enableByDefault": False},
-    "type": "cc-eal",
+    "entitlement_type": "cc-eal",
     "entitled": True,
     "directives": {
         "aptURL": "http://CC",
@@ -78,7 +78,6 @@ class TestCommonCriteriaEntitlementUserFacingStatus:
         m_platform_info.return_value = unsupported_info
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
         cfg.write_cache("machine-token", CC_MACHINE_TOKEN)
-        cfg.write_cache("machine-access-cc-eal", CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
         uf_status, uf_status_details = entitlement.user_facing_status()
         assert status.UserFacingStatus.INAPPLICABLE == uf_status
@@ -95,7 +94,6 @@ class TestCommonCriteriaEntitlementCanEnable:
         m_platform_info.return_value = PLATFORM_INFO_SUPPORTED
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
         cfg.write_cache("machine-token", CC_MACHINE_TOKEN)
-        cfg.write_cache("machine-access-cc-eal", CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
         uf_status, uf_status_details = entitlement.user_facing_status()
         assert status.UserFacingStatus.INACTIVE == uf_status
@@ -146,7 +144,6 @@ class TestCommonCriteriaEntitlementEnable:
         m_platform_info.side_effect = fake_platform
         cfg = config.UAConfig(cfg={"data_dir": tmpdir.strpath})
         cfg.write_cache("machine-token", CC_MACHINE_TOKEN)
-        cfg.write_cache("machine-access-cc-eal", CC_RESOURCE_ENTITLED)
         entitlement = CommonCriteriaEntitlement(cfg)
 
         with mock.patch("uaclient.apt.add_auth_apt_repo") as m_add_apt:
@@ -160,7 +157,7 @@ class TestCommonCriteriaEntitlementEnable:
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-cc-eal-xenial.list",
                 "http://CC",
-                "%s-token" % entitlement.name,
+                "{}-token".format(entitlement.name),
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -63,7 +63,7 @@ class TestCISEntitlementEnable:
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list",
                 "http://CIS-AUDIT",
-                "%s-token" % entitlement.name,
+                "{}-token".format(entitlement.name),
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -63,7 +63,7 @@ class TestCISEntitlementEnable:
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-cis-audit-xenial.list",
                 "http://CIS-AUDIT",
-                "TOKEN",
+                "%s-token" % entitlement.name,
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -131,7 +131,7 @@ class TestESMInfraEntitlementEnable:
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
-                "%s-token" % entitlement.name,
+                "{}-token".format(entitlement.name),
                 ["trusty"],
                 entitlement.repo_key_file,
             )
@@ -229,7 +229,7 @@ class TestESMInfraEntitlementEnable:
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
-                "%s-token" % entitlement.name,
+                "{}-token".format(entitlement.name),
                 ["trusty"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_esm.py
+++ b/uaclient/entitlements/tests/test_esm.py
@@ -131,7 +131,7 @@ class TestESMInfraEntitlementEnable:
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
-                "TOKEN",
+                "%s-token" % entitlement.name,
                 ["trusty"],
                 entitlement.repo_key_file,
             )
@@ -229,7 +229,7 @@ class TestESMInfraEntitlementEnable:
                     entitlement.name
                 ),
                 "http://{}".format(entitlement.name.upper()),
-                "TOKEN",
+                "%s-token" % entitlement.name,
                 ["trusty"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -87,7 +87,7 @@ class TestFIPSEntitlementEnable:
                     entitlement.name
                 ),
                 repo_url,
-                "%s-token" % entitlement.name,
+                "{}-token".format(entitlement.name),
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import itertools
 import mock
+from functools import partial
 
 import pytest
 
@@ -24,9 +25,14 @@ M_GETPLATFORM = M_REPOPATH + "util.get_platform_info"
 
 
 @pytest.fixture(params=[FIPSEntitlement, FIPSUpdatesEntitlement])
-def entitlement(request, entitlement_factory):
+def fips_entitlement_factory(request, entitlement_factory):
     """Parameterized fixture so we apply all tests to both FIPS and Updates"""
-    return entitlement_factory(request.param)
+    return partial(entitlement_factory, request.param)
+
+
+@pytest.fixture
+def entitlement(fips_entitlement_factory):
+    return fips_entitlement_factory()
 
 
 class TestFIPSEntitlementCanEnable:
@@ -138,19 +144,10 @@ class TestFIPSEntitlementEnable:
         "uaclient.util.get_platform_info", return_value={"series": "xenial"}
     )
     def test_enable_returns_false_on_missing_suites_directive(
-        self, m_platform_info, m_add_apt, entitlement
+        self, m_platform_info, m_add_apt, fips_entitlement_factory
     ):
         """When directives do not contain suites returns false."""
-        # Unset suites directive
-        token = entitlement.cfg.read_cache("machine-token")
-        entitlement_cfg = entitlement.cfg.entitlements[entitlement.name].get(
-            "entitlement"
-        )
-        entitlement_cfg["directives"]["suites"] = []
-        token["machineTokenInfo"]["contractInfo"]["resourceEntitlements"] = [
-            entitlement_cfg
-        ]
-        entitlement.cfg.write_cache("machine-token", token)
+        entitlement = fips_entitlement_factory(suites=[])
 
         with mock.patch.object(entitlement, "can_enable", return_value=True):
             with pytest.raises(exceptions.UserFacingError) as excinfo:

--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 import mock
+from functools import partial
 from types import MappingProxyType
 
 try:
@@ -46,26 +47,13 @@ DEFAULT_AFFORDANCES = {
 
 @pytest.fixture
 def livepatch_entitlement_factory(entitlement_factory):
-    def factory_func(
-        entitled: bool = True,
-        affordances: "Dict[str, Any]" = None,
-        suites: "List[str]" = None,
-    ):
-        if not affordances:
-            affordances = DEFAULT_AFFORDANCES
-        directives = {
-            "caCerts": "",
-            "remoteServer": "https://alt.livepatch.com",
-        }
-        return entitlement_factory(
-            LivepatchEntitlement,
-            affordances=affordances,
-            directives=directives,
-            entitled=entitled,
-            suites=suites,
-        )
-
-    return factory_func
+    directives = {"caCerts": "", "remoteServer": "https://alt.livepatch.com"}
+    return partial(
+        entitlement_factory,
+        LivepatchEntitlement,
+        affordances=DEFAULT_AFFORDANCES,
+        directives=directives,
+    )
 
 
 @pytest.fixture

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -81,7 +81,7 @@ class TestUserFacingStatus:
     @mock.patch(M_PATH + "util.get_platform_info")
     def test_unavailable_on_unentitled(self, m_platform_info, entitlement):
         """When unentitled, return UNAVAILABLE."""
-        no_entitlements = copy.deepcopy(machine_token(RepoTestEntitlement))
+        no_entitlements = copy.deepcopy(machine_token("blah"))
         # delete all enttlements
         no_entitlements["machineTokenInfo"]["contractInfo"][
             "resourceEntitlements"
@@ -155,7 +155,7 @@ class TestProcessContractDeltas:
             {"entitlement": {"entitled": True}},
             {
                 "entitlement": {"obligations": {"enableByDefault": False}},
-                "resourceToken": "TOKEN",
+                "resourceToken": "repotest-token",
             },
         )
         assert [] == m_remove_apt_config.call_args_list
@@ -183,7 +183,7 @@ class TestProcessContractDeltas:
             {"entitlement": {"entitled": True}},
             {
                 "entitlement": {"obligations": {"enableByDefault": True}},
-                "resourceToken": "TOKEN",
+                "resourceToken": "repotest-token",
             },
             allow_enable=True,
         )
@@ -213,7 +213,7 @@ class TestProcessContractDeltas:
             {"entitlement": {"entitled": True}},
             {
                 "entitlement": {"obligations": {"enableByDefault": True}},
-                "resourceToken": "TOKEN",
+                "resourceToken": "repotest-token",
             },
             allow_enable=False,
         )
@@ -242,7 +242,7 @@ class TestProcessContractDeltas:
             {"entitlement": {"entitled": True}},
             {
                 "entitlement": {"obligations": {"enableByDefault": False}},
-                "resourceToken": "TOKEN",
+                "resourceToken": "repotest-token",
             },
         )
         assert [mock.call()] == m_remove_apt_config.call_args_list
@@ -280,7 +280,7 @@ class TestProcessContractDeltas:
                     "obligations": {"enableByDefault": False},
                     "directives": {"aptURL": "http://new"},
                 },
-                "resourceToken": "TOKEN",
+                "resourceToken": "repotest-token",
             },
         )
         assert [mock.call()] == m_remove_apt_config.call_args_list
@@ -407,7 +407,7 @@ class TestRepoEnable:
             mock.call(
                 "/etc/apt/sources.list.d/ubuntu-repotest-xenial.list",
                 "http://REPOTEST",
-                "TOKEN",
+                "repotest-token",
                 ["xenial"],
                 entitlement.repo_key_file,
             )

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,5 +1,4 @@
 from uaclient.contract import (
-    API_V1_CONTEXT_MACHINE_TOKEN,
     API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE,
     UAContractClient,
 )
@@ -31,6 +30,4 @@ class FakeContractClient(UAContractClient):
         response = self._responses.get(path)
         if isinstance(response, Exception):
             raise response
-        if path in (self.refresh_route, API_V1_CONTEXT_MACHINE_TOKEN):
-            self.cfg.write_cache("machine-token", response)
         return response, {"header1": ""}

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,10 +1,18 @@
-from uaclient.contract import UAContractClient
+from uaclient.contract import (
+    API_V1_CONTEXT_MACHINE_TOKEN,
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE,
+    UAContractClient,
+)
 
 
 class FakeContractClient(UAContractClient):
 
     _requests = []
     _responses = {}
+
+    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
+        contract="cid", machine="mid"
+    )
 
     def __init___(self, cfg, responses=None):
         super().__init__(cfg)
@@ -20,7 +28,9 @@ class FakeContractClient(UAContractClient):
         }
         self._requests.append(request)
         # Return a response if we have one or empty
-        response = self._responses.get(path, {})
+        response = self._responses.get(path)
         if isinstance(response, Exception):
             raise response
+        if path in (self.refresh_route, API_V1_CONTEXT_MACHINE_TOKEN):
+            self.cfg.write_cache("machine-token", response)
         return response, {"header1": ""}

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -68,8 +68,8 @@ class TestEntitlements:
         }
         assert expected == cfg.entitlements
 
-    def test_entitlements_use_machine_access_when_present(self, tmpdir):
-        """Return specific machine-access info if present."""
+    def test_entitlements_uses_resource_token_from_machine_token(self, tmpdir):
+        """Include entitlement-specicific resourceTokens from machine_token"""
         cfg = UAConfig({"data_dir": tmpdir.strpath})
         token = {
             "availableResources": ALL_RESOURCES_AVAILABLE,
@@ -81,28 +81,20 @@ class TestEntitlements:
                     ]
                 }
             },
+            "resourceTokens": [
+                {"Type": "entitlement1", "Token": "ent1-token"},
+                {"Type": "entitlement2", "Token": "ent2-token"},
+            ],
         }
         cfg.write_cache("machine-token", token)
-        cfg.write_cache(
-            "machine-access-entitlement1",
-            {
-                "entitlement": {
-                    "type": "entitlement1",
-                    "entitled": True,
-                    "more": "data",
-                }
-            },
-        )
         expected = {
             "entitlement1": {
-                "entitlement": {
-                    "entitled": True,
-                    "type": "entitlement1",
-                    "more": "data",
-                }
+                "entitlement": {"entitled": True, "type": "entitlement1"},
+                "resourceToken": "ent1-token",
             },
             "entitlement2": {
-                "entitlement": {"entitled": True, "type": "entitlement2"}
+                "entitlement": {"entitled": True, "type": "entitlement2"},
+                "resourceToken": "ent2-token",
             },
         }
         assert expected == cfg.entitlements

--- a/uaclient/tests/test_config.py
+++ b/uaclient/tests/test_config.py
@@ -82,8 +82,8 @@ class TestEntitlements:
                 }
             },
             "resourceTokens": [
-                {"Type": "entitlement1", "Token": "ent1-token"},
-                {"Type": "entitlement2", "Token": "ent2-token"},
+                {"type": "entitlement1", "token": "ent1-token"},
+                {"type": "entitlement2", "token": "ent2-token"},
             ],
         }
         cfg.write_cache("machine-token", token)

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -210,10 +210,7 @@ class TestRequestUpdatedContract:
             fake_client._responses = {
                 self.refresh_route: exceptions.UserFacingError(
                     "Machine token refresh fail"
-                ),
-                self.access_route_ent1: exceptions.UserFacingError(
-                    "Broken ent1 route"
-                ),
+                )
             }
             return fake_client
 
@@ -246,23 +243,20 @@ class TestRequestUpdatedContract:
 
         def fake_contract_client(cfg):
             fake_client = FakeContractClient(cfg)
-            fake_client._responses = {
-                self.refresh_route: machine_token,
-                self.access_route_ent1: exceptions.UserFacingError(
-                    "Broken ent1 route"
-                ),
-                self.access_route_ent2: exceptions.UserFacingError(
-                    "Broken ent2 route"
-                ),
-            }
+            fake_client._responses = {self.refresh_route: machine_token}
             return fake_client
 
         client.side_effect = fake_contract_client
         cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
-        with pytest.raises(exceptions.UserFacingError) as exc:
-            request_updated_contract(cfg)
+        with mock.patch(M_PATH + "process_entitlement_delta") as m_process:
+            m_process.side_effect = (
+                exceptions.UserFacingError("broken ent1"),
+                exceptions.UserFacingError("broken ent2"),
+            )
+            with pytest.raises(exceptions.UserFacingError) as exc:
+                request_updated_contract(cfg)
 
-        assert "Broken ent1 route" == str(exc.value)
+        assert MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES == str(exc.value)
 
     @pytest.mark.parametrize(
         "first_error, second_error, ux_error_msg",
@@ -384,26 +378,20 @@ class TestRequestUpdatedContract:
                 }
             },
         }
+        new_token = copy.deepcopy(machine_token)
+        new_token["machineTokenInfo"]["contractInfo"]["resourceEntitlements"][
+            1
+        ]["new"] = "newval"
 
         def fake_contract_client(cfg):
             client = FakeContractClient(cfg)
-            # Note ent2 access route is not called
-            client._responses = {
-                self.refresh_route: machine_token,
-                self.access_route_ent1: {
-                    "entitlement": {
-                        "entitled": True,
-                        "type": "ent1",
-                        "new": "newval",
-                    }
-                },
-            }
+            client._responses = {self.refresh_route: new_token}
             return client
 
         client.side_effect = fake_contract_client
         cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
         assert None is request_updated_contract(cfg)
-        assert machine_token == cfg.read_cache("machine-token")
+        assert new_token == cfg.read_cache("machine-token")
 
         # Deltas are processed in a sorted fashion so that if enableByDefault
         # is true, the order of enablement operations is the same regardless
@@ -449,20 +437,14 @@ class TestRequestUpdatedContract:
                 }
             },
         }
+        new_token = copy.deepcopy(machine_token)
+        new_token["machineTokenInfo"]["contractInfo"]["resourceEntitlements"][
+            1
+        ]["new"] = "newval"
 
         def fake_contract_client(cfg):
             client = FakeContractClient(cfg)
-            # Note ent2 access route is not called
-            client._responses = {
-                self.refresh_route: machine_token,
-                self.access_route_ent1: {
-                    "entitlement": {
-                        "entitled": True,
-                        "type": "ent1",
-                        "new": "newval",
-                    }
-                },
-            }
+            client._responses = {self.refresh_route: new_token}
             return client
 
         client.side_effect = fake_contract_client
@@ -470,7 +452,7 @@ class TestRequestUpdatedContract:
         with pytest.raises(exceptions.UserFacingError) as exc:
             request_updated_contract(cfg)
         assert MESSAGE_CONTRACT_EXPIRED_ERROR == str(exc.value)
-        assert machine_token == cfg.read_cache("machine-token")
+        assert new_token == cfg.read_cache("machine-token")
 
         # No deltas are processed when contract is expired
         assert 0 == process_entitlement_delta.call_count


### PR DESCRIPTION
First part is to read and process service access information directly from machine-token instead of specific machine-access file.

Branch items:
 *  UAConfig.entitlements understands how to read resoureTokens list from machine-token
 * contract.request_updated_contract now pulls delta information from cfg.entitlements object
 * UAContractClient.request_machine_token_update clears cfg._entitlements cache

 The second branch drop UAContractClient.request_resource_machine_access and any callsites.