### PR TITLE
contract: handle unexpected errors when processing contract deltas

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -294,13 +294,19 @@ def request_updated_contract(
                 new_access,
                 allow_enable=allow_enable,
             )
-        except exceptions.UserFacingError as e:
+        except exceptions.UserFacingError:
             with util.disable_log_to_console():
-                logging.exception(str(e))
+                logging.exception(
+                    "Failed to process contract delta for {name}:"
+                    " {delta}".format(name=name, delta=new_access)
+                )
             user_errors.append(status.MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES)
-        except Exception as e:
+        except Exception:
             with util.disable_log_to_console():
-                logging.exception(str(e))
+                logging.exception(
+                    "Unexpected error processing contract delta for {name}:"
+                    " {delta}".format(name=name, delta=new_access)
+                )
             user_errors.insert(  # Highest priority error comes first
                 0,
                 status.MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -295,17 +295,19 @@ def request_updated_contract(
                 allow_enable=allow_enable,
             )
         except exceptions.UserFacingError as e:
-            user_errors.append(e)
+            with util.disable_log_to_console():
+                logging.exception(str(e))
+            user_errors.append(status.MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES)
         except Exception as e:
             with util.disable_log_to_console():
                 logging.exception(str(e))
-            raise exceptions.UserFacingError(
-                "Unexpected error handling Ubuntu Advantage contract changes"
+            user_errors.append(
+                status.MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
+                    operation="attach"
+                )
             )
     if user_errors:
-        raise exceptions.UserFacingError(
-            status.MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES
-        )
+        raise exceptions.UserFacingError(user_errors[0])
 
 
 def get_available_resources(cfg) -> "List[Dict]":

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -301,10 +301,11 @@ def request_updated_contract(
         except Exception as e:
             with util.disable_log_to_console():
                 logging.exception(str(e))
-            user_errors.append(
+            user_errors.insert(  # Highest priority error comes first
+                0,
                 status.MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
                     operation="attach"
-                )
+                ),
             )
     if user_errors:
         raise exceptions.UserFacingError(user_errors[0])

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -7,6 +7,10 @@ any of our dependencies installed.
 
 DEFAULT_CONFIG_FILE = "/etc/ubuntu-advantage/uaclient.conf"
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
+BUG_URL = (
+    "https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/"
+    "+filebug"
+)
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,

--- a/uaclient/defaults.py
+++ b/uaclient/defaults.py
@@ -7,10 +7,6 @@ any of our dependencies installed.
 
 DEFAULT_CONFIG_FILE = "/etc/ubuntu-advantage/uaclient.conf"
 BASE_CONTRACT_URL = "https://contracts.canonical.com"
-BUG_URL = (
-    "https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/"
-    "+filebug"
-)
 
 CONFIG_DEFAULTS = {
     "contract_url": BASE_CONTRACT_URL,

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,6 +1,8 @@
 import enum
 import sys
 
+from uaclient import defaults
+
 try:
     from typing import Any, Dict  # noqa: F401
 except ImportError:
@@ -191,6 +193,13 @@ To obtain a token please visit: https://ubuntu.com/advantage"""
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} '{name}'
 For a list of services see: sudo ua status"""
+MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL = (
+    """\
+Unexpected error(s) occurred during {operation}
+For more details, see the log: /var/log/ubuntu-advantage.log
+Please file a bug at: """
+    + defaults.BUG_URL
+)
 MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
 To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -1,8 +1,6 @@
 import enum
 import sys
 
-from uaclient import defaults
-
 try:
     from typing import Any, Dict  # noqa: F401
 except ImportError:
@@ -193,13 +191,10 @@ To obtain a token please visit: https://ubuntu.com/advantage"""
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} '{name}'
 For a list of services see: sudo ua status"""
-MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL = (
-    """\
+MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL = """\
 Unexpected error(s) occurred during {operation}
 For more details, see the log: /var/log/ubuntu-advantage.log
-Please file a bug at: """
-    + defaults.BUG_URL
-)
+To file a bug run: ubuntu-bug ubuntu-advantage-tools"""
 MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\
 To use '{name}' you need an Ubuntu Advantage subscription
 Personal and community subscriptions are available at no charge

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -263,17 +263,31 @@ class TestRequestUpdatedContract:
         assert "Broken ent1 route" == str(exc.value)
 
     @pytest.mark.parametrize(
-        "error_instance, ux_error_msg",
+        "first_error, second_error, ux_error_msg",
         (
             (
                 exceptions.UserFacingError(
                     "Ubuntu Advantage server provided no aptKey directive for"
                     " esm-infra"
                 ),
+                None,
                 MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES,
             ),
             (
                 RuntimeError("some APT error"),
+                None,
+                MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
+                    operation="attach"
+                ),
+            ),
+            # Order high-priority RuntimeError as second_error to ensure it
+            # is raised as primary error_msg
+            (
+                exceptions.UserFacingError(
+                    "Ubuntu Advantage server provided no aptKey directive for"
+                    " esm-infra"
+                ),
+                RuntimeError("some APT error"),  # High-priority ordered 2
                 MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
                     operation="attach"
                 ),
@@ -288,16 +302,23 @@ class TestRequestUpdatedContract:
         client,
         get_machine_id,
         process_entitlement_delta,
-        error_instance,
+        first_error,
+        second_error,
         ux_error_msg,
     ):
         """Unexpected errors from process_entitlement_delta are raised.
 
         Remaining entitlements are processed regardless of error and error is
         raised at the end.
+
+        Unexpected exceptions take priority over the handled UserFacingErrors.
         """
         # Fail first and succeed second call to process_entitlement_delta
-        process_entitlement_delta.side_effect = (error_instance, None)
+        process_entitlement_delta.side_effect = (
+            first_error,
+            second_error,
+            None,
+        )
 
         # resourceEntitlements specifically ordered reverse alphabetically
         # to ensure proper sorting for process_contract_delta calls below
@@ -307,6 +328,7 @@ class TestRequestUpdatedContract:
                 "contractInfo": {
                     "id": "cid",
                     "resourceEntitlements": [
+                        {"entitled": False, "type": "ent3"},
                         {"entitled": False, "type": "ent2"},
                         {"entitled": True, "type": "ent1"},
                     ],
@@ -333,7 +355,7 @@ class TestRequestUpdatedContract:
 
         with pytest.raises(exceptions.UserFacingError) as exc:
             assert None is request_updated_contract(cfg)
-        assert 2 == process_entitlement_delta.call_count
+        assert 3 == process_entitlement_delta.call_count
         assert ux_error_msg == str(exc.value)
 
     @mock.patch(M_PATH + "process_entitlement_delta")

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -336,22 +336,20 @@ class TestRequestUpdatedContract:
             },
         }
 
-        def fake_contract_client(cfg):
-            client = FakeContractClient(cfg)
-            client._responses = {
-                self.refresh_route: machine_token,
-                self.access_route_ent1: {
-                    "entitlement": {
-                        "entitled": True,
-                        "type": "ent1",
-                        "new": "newval",
-                    }
-                },
-            }
-            return client
-
-        client.side_effect = fake_contract_client
         cfg = FakeConfig.for_attached_machine(machine_token=machine_token)
+        fake_client = FakeContractClient(cfg)
+        fake_client._responses = {
+            self.refresh_route: machine_token,
+            self.access_route_ent1: {
+                "entitlement": {
+                    "entitled": True,
+                    "type": "ent1",
+                    "new": "newval",
+                }
+            },
+        }
+
+        client.return_value = fake_client
 
         with pytest.raises(exceptions.UserFacingError) as exc:
             assert None is request_updated_contract(cfg)


### PR DESCRIPTION
Continue to process all entitlements if hitting unexpected errors
during service enablement during attach or refresh. Previously,
if UA client hit APT failures during enablement of repo-based services
the UA client would exit with a traceback and avoid enabling any remaining
services.

Now, log any unexpected failures and only raise it once all service deltas
have been processed. Unexpected errors will now alert the user with a
message to check /var/log/ubuntu-advantage.log and file a bug.

Fixes: #953