### PR TITLE
Makefile: pass -U in `make testdeps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ test:
 	@tox
 
 testdeps:
-	pip install -U tox
+	pip install -U six
+	pip install tox
 
 travis-deb-install:
 	git fetch --unshallow

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	@tox
 
 testdeps:
-	pip install tox
+	pip install -U tox
 
 travis-deb-install:
 	git fetch --unshallow


### PR DESCRIPTION
We are current experiencing failures in tox environment setup due to
conflicting versions of packages.  The conflicts are Travis-specific
because the Python environment there has some (stale) Python packages
installed already.  If we only install the packages that _aren't_
present in the Travis environment, we wind up with errors.  If we ensure
that we're running the latest version of all packages, we have a much
better chance of success, and there's no particular reason to prefer the
Travis-pre-installed versions over the latest PyPI versions.

Fixes #987