### PR TITLE
Makefile: in testdeps, upgrade six before installing tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test:
 	@tox
 
 testdeps:
+	pip install -U six
 	pip install tox
 
 travis-deb-install:


### PR DESCRIPTION
We're currently seeing test failures because the version of six
pre-installed in the Travis virtualenv is too old, and it isn't upgraded
of its own accord.

Fixes #987