### PR TITLE
add test for behavior of attaching an invalid_token

### DIFF
--- a/features/attach_invalidtoken.feature
+++ b/features/attach_invalidtoken.feature
@@ -1,0 +1,15 @@
+Feature: Command behaviour when trying to attach a machine to an Ubuntu
+         Advantage subscription using an invalid token
+
+    Scenario: Attach command in a trusty lxd container
+       Given a trusty lxd container with ubuntu-advantage-tools installed
+        When I run `ua attach INVALID_TOKEN` with sudo
+        Then I will see the following on stderr:
+            """
+            Invalid token. See https://ubuntu.com/advantage
+            """
+        When I run `ua attach INVALID_TOKEN` as non-root
+        Then I will see the following on stderr:
+             """
+             This command must be run as root (try using sudo)
+             """


### PR DESCRIPTION
it adds a new feature file when it tries to attach a machine to an UA subscription using an invalid_token