### PR TITLE
Add --assume-yes parameter to `ua detach`

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -308,7 +308,7 @@ def action_detach(args, cfg):
         print("Detach will disable the following service{}:".format(suffix))
         for ent in to_disable:
             print("    {}".format(ent.name))
-    if not util.prompt_for_confirmation():
+    if not args.assume_yes and not util.prompt_for_confirmation():
         return 1
     for ent in to_disable:
         ent.disable(silent=True)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -149,6 +149,11 @@ def detach_parser(parser):
     parser.usage = usage
     parser.prog = "detach"
     parser._optionals.title = "Flags"
+    parser.add_argument(
+        "--assume-yes",
+        action="store_true",
+        help="do not prompt for confirmation before performing the detach",
+    )
     return parser
 
 

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -36,10 +36,17 @@ class TestActionDetach:
             action_detach(mock.MagicMock(), cfg)
         assert status.MESSAGE_UNATTACHED == err.value.msg
 
-    @pytest.mark.parametrize("prompt_response", [True, False])
+    @pytest.mark.parametrize(
+        "prompt_response,expect_disable", [(True, True), (False, False)]
+    )
     @mock.patch("uaclient.cli.entitlements")
     def test_entitlements_disabled_if_can_disable_and_prompt_true(
-        self, m_entitlements, m_getuid, m_prompt, prompt_response
+        self,
+        m_entitlements,
+        m_getuid,
+        m_prompt,
+        prompt_response,
+        expect_disable,
     ):
         m_getuid.return_value = 0
         m_prompt.return_value = prompt_response
@@ -67,7 +74,7 @@ class TestActionDetach:
         ]:
             assert 0 == undisabled_cls.return_value.disable.call_count
         disabled_cls = m_entitlements.ENTITLEMENT_CLASSES[1]
-        if prompt_response:
+        if expect_disable:
             assert [
                 mock.call(silent=True)
             ] == disabled_cls.return_value.disable.call_args_list

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 import pytest
 
-from uaclient.cli import action_detach
+from uaclient.cli import action_detach, detach_parser
 from uaclient import exceptions
 from uaclient import status
 from uaclient.testing.fakes import FakeConfig
@@ -172,3 +172,17 @@ class TestActionDetach:
         out, _err = capsys.readouterr()
 
         assert expected_message in out
+
+
+class TestParser:
+    def test_detach_parser_usage(self):
+        parser = detach_parser(mock.Mock())
+        assert "ua detach [flags]" == parser.usage
+
+    def test_detach_parser_prog(self):
+        parser = detach_parser(mock.Mock())
+        assert "detach" == parser.prog
+
+    def test_detach_parser_optionals_title(self):
+        parser = detach_parser(mock.Mock())
+        assert "Flags" == parser._optionals.title

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -40,7 +40,7 @@ class TestActionDetach:
         "prompt_response,expect_disable", [(True, True), (False, False)]
     )
     @mock.patch("uaclient.cli.entitlements")
-    def test_entitlements_disabled_if_can_disable_and_prompt_true(
+    def test_entitlements_disabled_appropriately(
         self,
         m_entitlements,
         m_getuid,

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -48,6 +48,10 @@ class TestActionDetach:
         prompt_response,
         expect_disable,
     ):
+        # The two parameters:
+        #   prompt_response: the user's response to the prompt
+        #   expect_disable: whether or not the enabled entitlement is expected
+        #                   to be disabled by the action
         m_getuid.return_value = 0
         m_prompt.return_value = prompt_response
 

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 import pytest
 
-from uaclient.cli import action_detach, detach_parser
+from uaclient.cli import action_detach, detach_parser, get_parser
 from uaclient import exceptions
 from uaclient import status
 from uaclient.testing.fakes import FakeConfig
@@ -186,3 +186,17 @@ class TestParser:
     def test_detach_parser_optionals_title(self):
         parser = detach_parser(mock.Mock())
         assert "Flags" == parser._optionals.title
+
+    def test_detach_parser_accepts_and_stores_assume_yes(self):
+        full_parser = get_parser()
+        with mock.patch("sys.argv", ["ua", "detach", "--assume-yes"]):
+            args = full_parser.parse_args()
+
+        assert args.assume_yes
+
+    def test_detach_parser_defaults_to_not_assume_yes(self):
+        full_parser = get_parser()
+        with mock.patch("sys.argv", ["ua", "detach"]):
+            args = full_parser.parse_args()
+
+        assert not args.assume_yes


### PR DESCRIPTION
If passed, the confirmation prompt will be skipped.

Fixes #949 