### PR TITLE
util: use `dpkg --print-architecture` in get_platform_info

### DIFF
--- a/uaclient/entitlements/tests/test_livepatch.py
+++ b/uaclient/entitlements/tests/test_livepatch.py
@@ -446,6 +446,7 @@ class TestLivepatchEntitlementEnable:
 
     @pytest.mark.parametrize("caplog_text", [logging.DEBUG], indirect=True)
     @pytest.mark.parametrize("apt_update_success", (True, False))
+    @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.apt.run_apt_command")
     @mock.patch("uaclient.util.which", return_value=False)
@@ -458,6 +459,7 @@ class TestLivepatchEntitlementEnable:
         m_which,
         m_run_apt,
         m_subp,
+        _m_get_platform_info,
         capsys,
         caplog_text,
         entitlement,
@@ -498,6 +500,7 @@ class TestLivepatchEntitlementEnable:
         ]
         assert expected_calls == m_which.call_args_list
 
+    @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp", return_value=("snapd", ""))
     @mock.patch(
         "uaclient.util.which", side_effect=lambda cmd: cmd == "/usr/bin/snap"
@@ -505,7 +508,14 @@ class TestLivepatchEntitlementEnable:
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_installs_only_livepatch_snap_when_absent_but_snapd_present(
-        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
+        self,
+        m_can_enable,
+        m_app_status,
+        m_which,
+        m_subp,
+        _m_get_platform_info,
+        capsys,
+        entitlement,
     ):
         """Install canonical-livepatch snap when not present on the system."""
         application_status = status.ApplicationStatus.ENABLED
@@ -549,12 +559,20 @@ class TestLivepatchEntitlementEnable:
         )
         assert expected_msg == excinfo.value.msg
 
+    @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.which", return_value="/found/livepatch")
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_does_not_install_livepatch_snap_when_present(
-        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
+        self,
+        m_can_enable,
+        m_app_status,
+        m_which,
+        m_subp,
+        _m_get_platform_info,
+        capsys,
+        entitlement,
     ):
         """Do not attempt to install livepatch snap when it is present."""
         application_status = status.ApplicationStatus.ENABLED
@@ -563,12 +581,20 @@ class TestLivepatchEntitlementEnable:
         assert self.mocks_config == m_subp.call_args_list
         assert ("Canonical livepatch enabled.\n", "") == capsys.readouterr()
 
+    @mock.patch("uaclient.util.get_platform_info")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.which", return_value="/found/livepatch")
     @mock.patch(M_PATH + "LivepatchEntitlement.application_status")
     @mock.patch(M_PATH + "LivepatchEntitlement.can_enable", return_value=True)
     def test_enable_does_not_disable_inactive_livepatch_snap_when_present(
-        self, m_can_enable, m_app_status, m_which, m_subp, capsys, entitlement
+        self,
+        m_can_enable,
+        m_app_status,
+        m_which,
+        m_subp,
+        _m_get_platform_info,
+        capsys,
+        entitlement,
     ):
         """Do not attempt to disable livepatch snap when it is inactive."""
 

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -284,12 +284,14 @@ class TestGetPlatformInfo:
 
         with mock.patch("uaclient.util.parse_os_release") as m_parse:
             with mock.patch("uaclient.util.os.uname") as m_uname:
-                m_parse.return_value = parse_dict
-                # (sysname, nodename, release, version, machine)
-                m_uname.return_value = posix.uname_result(
-                    ("", "", "kernel-ver", "", "arm64")
-                )
-                assert expected == util.get_platform_info()
+                with mock.patch("uaclient.util.subp") as m_subp:
+                    m_parse.return_value = parse_dict
+                    # (sysname, nodename, release, version, machine)
+                    m_uname.return_value = posix.uname_result(
+                        ("", "", "kernel-ver", "", "aarch64")
+                    )
+                    m_subp.return_value = ("arm64\n", "")
+                    assert expected == util.get_platform_info()
 
 
 class TestApplySeriesOverrides:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -333,7 +333,8 @@ def get_platform_info() -> "Dict[str, str]":
 
     uname = os.uname()
     platform_info["kernel"] = uname.release
-    platform_info["arch"] = uname.machine
+    out, _err = subp(["dpkg", "--print-architecture"])
+    platform_info["arch"] = out.strip()
 
     return platform_info
 


### PR DESCRIPTION
As well as adding some patches that were missing (and started causing failures once `get_platform_info` was invoking `util.subp`).

Fixes #914