### PR TITLE
Feature/call detach route

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -320,9 +320,7 @@ def action_detach(args, cfg):
     contract_client = contract.UAContractClient(cfg)
     machine_token = cfg.machine_token["machineToken"]
     contract_id = cfg.machine_token["machineTokenInfo"]["contractInfo"]["id"]
-    contract_client.request_machine_token_update(
-        machine_token, contract_id, detach=True
-    )
+    contract_client.detach_machine_from_contract(machine_token, contract_id)
     cfg.delete_cache()
     print(ua_status.MESSAGE_DETACH_SUCCESS)
     return 0

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -317,6 +317,12 @@ def action_detach(args, cfg):
         return 1
     for ent in to_disable:
         ent.disable(silent=True)
+    contract_client = contract.UAContractClient(cfg)
+    machine_token = cfg.machine_token["machineToken"]
+    contract_id = cfg.machine_token["machineTokenInfo"]["contractInfo"]["id"]
+    contract_client.request_machine_token_update(
+        machine_token, contract_id, detach=True
+    )
     cfg.delete_cache()
     print(ua_status.MESSAGE_DETACH_SUCCESS)
     return 0

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -16,7 +16,7 @@ except ImportError:
 
 API_ERROR_INVALID_TOKEN = "invalid token"
 API_V1_CONTEXT_MACHINE_TOKEN = "/v1/context/machines/token"
-API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE = (
+API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE = (
     "/v1/contracts/{contract}/context/machines/{machine}"
 )
 API_V1_RESOURCES = "/v1/resources"
@@ -162,16 +162,19 @@ class UAContractClient(serviceclient.UAServiceClient):
 
         @return: Dict of the JSON response containing refreshed machine-token
         """
-        method = "DELETE" if detach else "POST"
-        data = self._get_platform_data(machine_id)
         headers = self.headers()
         headers.update({"Authorization": "Bearer {}".format(machine_token)})
-        url = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
+        data = self._get_platform_data(machine_id)
+        url = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE.format(
             contract=contract_id, machine=data["machineId"]
         )
-        response, headers = self.request_url(
-            url, headers=headers, method=method, data=data
-        )
+        kwargs = {"headers": headers}
+        if detach:
+            kwargs["method"] = "DELETE"
+        else:
+            kwargs["method"] = "POST"
+            kwargs["data"] = data
+        response, headers = self.request_url(url, **kwargs)
         if headers.get("expires"):
             response["expires"] = headers["expires"]
         if not detach:

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -122,8 +122,12 @@ class UAContractClient(serviceclient.UAServiceClient):
         return response
 
     def request_machine_token_update(
-        self, machine_token, contract_id, machine_id=None
-    ):
+        self,
+        machine_token: str,
+        contract_id: str,
+        machine_id: str = None,
+        detach: bool = False,
+    ) -> "Dict":
         """Request machine token refresh from contract server.
 
         @param machine_token: The machine token needed to talk to
@@ -131,16 +135,21 @@ class UAContractClient(serviceclient.UAServiceClient):
         @param contract_id: Unique contract id provided by contract service.
         @param machine_id: Optional unique system machine id. When absent,
             contents of /etc/machine-id will be used.
+        @param detach: Boolean set True if detaching this machine from the
+            active contract. Default is False.
 
         @return: Dict of the JSON response containing refreshed machine-token
         """
+        method = "DELETE" if detach else "POST"
         data = self._get_platform_data(machine_id)
         headers = self.headers()
         headers.update({"Authorization": "Bearer {}".format(machine_token)})
         url = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
             contract=contract_id, machine=data["machineId"]
         )
-        response, headers = self.request_url(url, headers=headers, data=data)
+        response, headers = self.request_url(
+            url, headers=headers, method=method, data=data
+        )
         if headers.get("expires"):
             response["expires"] = headers["expires"]
         self.cfg.write_cache("machine-token", response)

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -122,6 +122,28 @@ class UAContractClient(serviceclient.UAServiceClient):
         return response
 
     def request_machine_token_update(
+        self, machine_token: str, contract_id: str, machine_id: str = None
+    ) -> "Dict":
+        """Update existing machine-token for an attached machine."""
+        return self._request_machine_token_update(
+            machine_token=machine_token,
+            contract_id=contract_id,
+            machine_id=machine_id,
+            detach=False,
+        )
+
+    def detach_machine_from_contract(
+        self, machine_token: str, contract_id: str, machine_id: str = None
+    ) -> "Dict":
+        """Report the attached machine should be detached from the contract."""
+        return self._request_machine_token_update(
+            machine_token=machine_token,
+            contract_id=contract_id,
+            machine_id=machine_id,
+            detach=True,
+        )
+
+    def _request_machine_token_update(
         self,
         machine_token: str,
         contract_id: str,
@@ -152,7 +174,8 @@ class UAContractClient(serviceclient.UAServiceClient):
         )
         if headers.get("expires"):
             response["expires"] = headers["expires"]
-        self.cfg.write_cache("machine-token", response)
+        if not detach:
+            self.cfg.write_cache("machine-token", response)
         return response
 
     def _get_platform_data(self, machine_id):

--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,5 +1,5 @@
 from uaclient.contract import (
-    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE,
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE,
     UAContractClient,
 )
 
@@ -9,7 +9,7 @@ class FakeContractClient(UAContractClient):
     _requests = []
     _responses = {}
 
-    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
+    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE.format(
         contract="cid", machine="mid"
     )
 

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -64,7 +64,7 @@ class TestActionDetach:
         #                   to be disabled by the action
         m_getuid.return_value = 0
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         fake_client = FakeContractClient(cfg)
         m_client.return_value = fake_client
 
@@ -113,7 +113,6 @@ class TestActionDetach:
         m_entitlements.ENTITLEMENT_CLASSES = []
 
         fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        fake_client._responses = {"chad": {}}
         m_client.return_value = fake_client
 
         cfg = mock.MagicMock()
@@ -130,7 +129,6 @@ class TestActionDetach:
         m_entitlements.ENTITLEMENT_CLASSES = []
 
         fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        fake_client._responses = {"chad": {}}
         m_client.return_value = fake_client
 
         action_detach(mock.MagicMock(), mock.MagicMock())
@@ -153,7 +151,6 @@ class TestActionDetach:
         m_entitlements.ENTITLEMENT_CLASSES = []
 
         fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        fake_client._responses = {"chad": {}}
         m_client.return_value = fake_client
 
         ret = action_detach(mock.MagicMock(), mock.MagicMock())
@@ -206,7 +203,6 @@ class TestActionDetach:
         m_entitlements.ENTITLEMENT_CLASSES = classes
 
         fake_client = FakeContractClient(FakeConfig.for_attached_machine())
-        fake_client._responses = {"chad": {}}
         m_client.return_value = fake_client
 
         action_detach(mock.MagicMock(), mock.MagicMock())

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -6,6 +6,7 @@ import pytest
 from uaclient.cli import action_detach, detach_parser, get_parser
 from uaclient import exceptions
 from uaclient import status
+from uaclient.testing.fakes import FakeContractClient
 
 
 def entitlement_cls_mock_factory(can_disable, name=None):
@@ -42,8 +43,10 @@ class TestActionDetach:
         [(True, False, True), (False, False, False), (None, True, True)],
     )
     @mock.patch("uaclient.cli.entitlements")
+    @mock.patch("uaclient.contract.UAContractClient")
     def test_entitlements_disabled_appropriately(
         self,
+        m_client,
         m_entitlements,
         m_getuid,
         m_prompt,
@@ -60,6 +63,11 @@ class TestActionDetach:
         #   expect_disable: whether or not the enabled entitlement is expected
         #                   to be disabled by the action
         m_getuid.return_value = 0
+
+        cfg = FakeConfig.for_attached_machine()
+        fake_client = FakeContractClient(cfg)
+        m_client.return_value = fake_client
+
         if prompt_response is not None:
             m_prompt.return_value = prompt_response
         else:
@@ -72,7 +80,7 @@ class TestActionDetach:
         ]
 
         args = mock.MagicMock(assume_yes=assume_yes)
-        return_code = action_detach(args, FakeConfig.for_attached_machine())
+        return_code = action_detach(args, cfg)
 
         # Check that can_disable is called correctly
         for ent_cls in m_entitlements.ENTITLEMENT_CLASSES:
@@ -97,9 +105,16 @@ class TestActionDetach:
             assert 1 == return_code
 
     @mock.patch("uaclient.cli.entitlements")
-    def test_config_cache_deleted(self, m_entitlements, m_getuid, _m_prompt):
+    @mock.patch("uaclient.contract.UAContractClient")
+    def test_config_cache_deleted(
+        self, m_client, m_entitlements, m_getuid, _m_prompt, FakeConfig
+    ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []
+
+        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
+        fake_client._responses = {"chad": {}}
+        m_client.return_value = fake_client
 
         cfg = mock.MagicMock()
         action_detach(mock.MagicMock(), cfg)
@@ -107,11 +122,16 @@ class TestActionDetach:
         assert [mock.call()] == cfg.delete_cache.call_args_list
 
     @mock.patch("uaclient.cli.entitlements")
+    @mock.patch("uaclient.contract.UAContractClient")
     def test_correct_message_emitted(
-        self, m_entitlements, m_getuid, _m_prompt, capsys
+        self, m_client, m_entitlements, m_getuid, _m_prompt, capsys, FakeConfig
     ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []
+
+        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
+        fake_client._responses = {"chad": {}}
+        m_client.return_value = fake_client
 
         action_detach(mock.MagicMock(), mock.MagicMock())
 
@@ -120,9 +140,21 @@ class TestActionDetach:
         assert status.MESSAGE_DETACH_SUCCESS + "\n" == out
 
     @mock.patch("uaclient.cli.entitlements")
-    def test_returns_zero(self, m_entitlements, m_getuid, _m_prompt):
+    @mock.patch("uaclient.contract.UAContractClient")
+    def test_returns_zero(
+        self,
+        m_client,
+        m_entitlements,
+        m_getuid,
+        _m_prompt,
+        FakeConfig,
+    ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []
+
+        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
+        fake_client._responses = {"chad": {}}
+        m_client.return_value = fake_client
 
         ret = action_detach(mock.MagicMock(), mock.MagicMock())
 
@@ -158,17 +190,25 @@ class TestActionDetach:
         ],
     )
     @mock.patch("uaclient.cli.entitlements")
+    @mock.patch("uaclient.contract.UAContractClient")
     def test_informational_message_emitted(
         self,
+        m_client,
         m_entitlements,
         m_getuid,
         _m_prompt,
         capsys,
         classes,
         expected_message,
+        FakeConfig,
     ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = classes
+
+        fake_client = FakeContractClient(FakeConfig.for_attached_machine())
+        fake_client._responses = {"chad": {}}
+        m_client.return_value = fake_client
+
         action_detach(mock.MagicMock(), mock.MagicMock())
 
         out, _err = capsys.readouterr()

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -64,7 +64,7 @@ class TestActionDetach:
         #                   to be disabled by the action
         m_getuid.return_value = 0
 
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
         fake_client = FakeContractClient(cfg)
         m_client.return_value = fake_client
 

--- a/uaclient/tests/test_cli_detach.py
+++ b/uaclient/tests/test_cli_detach.py
@@ -140,12 +140,7 @@ class TestActionDetach:
     @mock.patch("uaclient.cli.entitlements")
     @mock.patch("uaclient.contract.UAContractClient")
     def test_returns_zero(
-        self,
-        m_client,
-        m_entitlements,
-        m_getuid,
-        _m_prompt,
-        FakeConfig,
+        self, m_client, m_entitlements, m_getuid, _m_prompt, FakeConfig
     ):
         m_getuid.return_value = 0
         m_entitlements.ENTITLEMENT_CLASSES = []

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -47,7 +47,7 @@ class TestUAContractClient:
         request_url,
         detach,
         expected_http_method,
-        tmpdir,
+        FakeConfig,
     ):
         """POST or DELETE to ua-contracts and write machine-token cache.
 
@@ -56,7 +56,7 @@ class TestUAContractClient:
         get_platform_info.return_value = {"arch": "arch", "kernel": "kernel"}
         get_machine_id.return_value = "machineId"
         request_url.return_value = ("newtoken", {})
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         client = UAContractClient(cfg)
         kwargs = {"machine_token": "mToken", "contract_id": "cId"}
         if detach is not None:

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -40,7 +40,7 @@ class TestUAContractClient:
     )
     @mock.patch("uaclient.contract.util.get_machine_id")
     @mock.patch("uaclient.contract.util.get_platform_info")
-    def test_request_machine_token_update(
+    def test__request_machine_token_update(
         self,
         get_platform_info,
         get_machine_id,
@@ -61,8 +61,9 @@ class TestUAContractClient:
         kwargs = {"machine_token": "mToken", "contract_id": "cId"}
         if detach is not None:
             kwargs["detach"] = detach
-        client.request_machine_token_update(**kwargs)
-        assert "newtoken" == cfg.read_cache("machine-token")
+        client._request_machine_token_update(**kwargs)
+        if not detach:  # Then we have written the updated cache
+            assert "newtoken" == cfg.read_cache("machine-token")
         assert [
             mock.call(
                 "/v1/contracts/cId/context/machines/machineId",

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -37,13 +37,13 @@ class TestUAContractClient:
     @mock.patch("uaclient.contract.util.get_machine_id")
     @mock.patch("uaclient.contract.util.get_platform_info")
     def test_request_machine_token_update_default(
-        self, get_platform_info, get_machine_id, request_url
+        self, get_platform_info, get_machine_id, request_url, tmpdir
     ):
         """POST to ua-contract server and persist response to cache."""
         get_platform_info.return_value = {"arch": "arch", "kernel": "kernel"}
         get_machine_id.return_value = "machineId"
         request_url.return_value = ("newtoken", {})
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
         client = UAContractClient(cfg)
         client.request_machine_token_update("mToken", "cId")
         assert "newtoken" == cfg.read_cache("machine-token")

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -7,7 +7,7 @@ import urllib
 from uaclient.contract import (
     API_V1_CONTEXT_MACHINE_TOKEN,
     API_V1_RESOURCES,
-    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE,
+    API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE,
     API_V1_TMPL_RESOURCE_MACHINE_ACCESS,
     ContractAPIError,
     UAContractClient,
@@ -64,22 +64,23 @@ class TestUAContractClient:
         client._request_machine_token_update(**kwargs)
         if not detach:  # Then we have written the updated cache
             assert "newtoken" == cfg.read_cache("machine-token")
+        params = {
+            "headers": {
+                "user-agent": "UA-Client/{}".format(get_version()),
+                "accept": "application/json",
+                "content-type": "application/json",
+                "Authorization": "Bearer mToken",
+            },
+            "method": expected_http_method,
+        }
+        if expected_http_method != "DELETE":
+            params["data"] = {
+                "machineId": "machineId",
+                "architecture": "arch",
+                "os": {"kernel": "kernel"},
+            }
         assert [
-            mock.call(
-                "/v1/contracts/cId/context/machines/machineId",
-                headers={
-                    "user-agent": "UA-Client/{}".format(get_version()),
-                    "accept": "application/json",
-                    "content-type": "application/json",
-                    "Authorization": "Bearer mToken",
-                },
-                method=expected_http_method,
-                data={
-                    "machineId": "machineId",
-                    "architecture": "arch",
-                    "os": {"kernel": "kernel"},
-                },
-            )
+            mock.call("/v1/contracts/cId/context/machines/machineId", **params)
         ] == request_url.call_args_list
 
 
@@ -193,7 +194,7 @@ class TestGetAvailableResources:
 
 class TestRequestUpdatedContract:
 
-    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE.format(
+    refresh_route = API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE.format(
         contract="cid", machine="mid"
     )
     access_route_ent1 = API_V1_TMPL_RESOURCE_MACHINE_ACCESS.format(


### PR DESCRIPTION
Add a new Add a detach param to UAContractClient.detach_machine_from_contract method.

This method shares the same code for request_machine_token_update with the exception that
it uses an HTTP DELETE instead of a POST with form data. Both methods will leverage the private method _request_machine_token which accepts a detach=True|False boolean.

Rename API_V1_TMPL_CONTEXT_MACHINE_TOKEN_UPDATE to   API_V1_TMPL_CONTEXT_MACHINE_TOKEN_RESOURCE to more appropriately describe the
route.

Fixes: #936 