### PR TITLE
ux: catch any unexpected tracebacks and report a user-friendly message

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -596,6 +596,11 @@ def main_error_handler(func):
                 logging.exception(exc.msg)
             print("{}".format(exc.msg), file=sys.stderr)
             sys.exit(exc.exit_code)
+        except Exception:
+            with util.disable_log_to_console():
+                logging.exception("Unhandled exception, please file a bug")
+            print(ua_status.MESSAGE_UNEXPECTED_ERROR, file=sys.stderr)
+            sys.exit(1)
 
     return wrapper
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -303,11 +303,7 @@ def request_updated_contract(
                     " {delta}".format(name=name, delta=new_entitlement)
                 )
     if unexpected_error:
-        raise exceptions.UserFacingError(
-            status.MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
-                operation="attach"
-            )
-        )
+        raise exceptions.UserFacingError(status.MESSAGE_UNEXPECTED_ERROR)
     elif delta_error:
         raise exceptions.UserFacingError(
             status.MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -191,8 +191,8 @@ To obtain a token please visit: https://ubuntu.com/advantage"""
 MESSAGE_INVALID_SERVICE_OP_FAILURE_TMPL = """\
 Cannot {operation} '{name}'
 For a list of services see: sudo ua status"""
-MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL = """\
-Unexpected error(s) occurred during {operation}
+MESSAGE_UNEXPECTED_ERROR = """\
+Unexpected error(s) occurred.
 For more details, see the log: /var/log/ubuntu-advantage.log
 To file a bug run: ubuntu-bug ubuntu-advantage-tools"""
 MESSAGE_ENABLE_FAILURE_UNATTACHED_TMPL = """\

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -230,30 +230,50 @@ class TestRequireValidEntitlementName:
 
 
 class TestMain:
+    @pytest.mark.parametrize(
+        "exception,expected_error_msg,expected_log",
+        (
+            (
+                KeyboardInterrupt,
+                "Interrupt received; exiting.\n",
+                "KeyboardInterrupt",
+            ),
+            (
+                TypeError("'NoneType' object is not subscriptable"),
+                status.MESSAGE_UNEXPECTED_ERROR + "\n",
+                "Unhandled exception, please file a bug",
+            ),
+        ),
+    )
     @mock.patch("uaclient.cli.setup_logging")
     @mock.patch("uaclient.cli.get_parser")
-    def test_keyboard_interrupt_handled_gracefully(
+    def test_errors_handled_gracefully(
         self,
         m_get_parser,
         _m_setup_logging,
         capsys,
         logging_sandbox,
         caplog_text,
+        exception,
+        expected_error_msg,
+        expected_log,
     ):
         m_args = m_get_parser.return_value.parse_args.return_value
-        m_args.action.side_effect = KeyboardInterrupt
+        m_args.action.side_effect = exception
 
         with pytest.raises(SystemExit) as excinfo:
-            main(["some", "args"])
+            with mock.patch("sys.argv", ["/usr/bin/ua", "subcmd"]):
+                main()
 
         exc = excinfo.value
         assert 1 == exc.code
 
         out, err = capsys.readouterr()
         assert "" == out
-        assert "Interrupt received; exiting.\n" == err
+        assert expected_error_msg == err
         error_log = caplog_text()
         assert "Traceback (most recent call last):" in error_log
+        assert expected_log in error_log
 
     @pytest.mark.parametrize(
         "exception,expected_exit_code",

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -21,7 +21,7 @@ from uaclient.status import (
     MESSAGE_CONTRACT_EXPIRED_ERROR,
     MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES,
     MESSAGE_ATTACH_INVALID_TOKEN,
-    MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL,
+    MESSAGE_UNEXPECTED_ERROR,
 )
 
 from uaclient.testing.fakes import FakeContractClient
@@ -269,13 +269,7 @@ class TestRequestUpdatedContract:
                 None,
                 MESSAGE_ATTACH_FAILURE_DEFAULT_SERVICES,
             ),
-            (
-                RuntimeError("some APT error"),
-                None,
-                MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
-                    operation="attach"
-                ),
-            ),
+            (RuntimeError("some APT error"), None, MESSAGE_UNEXPECTED_ERROR),
             # Order high-priority RuntimeError as second_error to ensure it
             # is raised as primary error_msg
             (
@@ -284,9 +278,7 @@ class TestRequestUpdatedContract:
                     " esm-infra"
                 ),
                 RuntimeError("some APT error"),  # High-priority ordered 2
-                MESSAGE_UNEXPECTED_ERROR_DURING_OP_TMPL.format(
-                    operation="attach"
-                ),
+                MESSAGE_UNEXPECTED_ERROR,
             ),
         ),
     )


### PR DESCRIPTION
In the event that client hits an unexpected error, tracebacks at the
CLI don't help most users. We want to prompt users to inspect
/var/log/ubuntu-advantage.log if possible and file a bug with
ubuntu-bug ubuntu-advantage-tools

Fixes: #643