### PR TITLE
testing: simplify FakeConfig to only leverage tmpdir fixture

### DIFF
--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,8 +1,5 @@
-import json
-
 from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
-from uaclient.util import DatetimeAwareJSONDecoder, DatetimeAwareJSONEncoder
 
 try:
     from typing import Any, Dict, Optional  # noqa: F401
@@ -37,47 +34,18 @@ class FakeContractClient(UAContractClient):
 
 
 class FakeConfig(UAConfig):
-    def __init__(self, cache_contents: "Dict[str, Any]" = None) -> None:
-        self._cache_contents = {}
-        if cache_contents:
-            self._cache_contents = {
-                k: json.dumps(v, cls=DatetimeAwareJSONEncoder)
-                for k, v in cache_contents.items()
-            }
-
-        super().__init__({})
-
-    def _perform_delete(self, cache_path: str) -> None:
-        pass
-
-    def delete_cache_key(self, key: str) -> None:
-        super().delete_cache_key(key)
-        if key in self._cache_contents:
-            del self._cache_contents[key]
-
-    def read_cache(self, key: str, silent: bool = False) -> "Optional[str]":
-        value = self._cache_contents.get(key)
-        if value:
-            value = json.loads(value, cls=DatetimeAwareJSONDecoder)
-        return value
-
-    def write_cache(
-        self, key: str, content: "Any", private: bool = True
-    ) -> None:
-        content = json.dumps(content, cls=DatetimeAwareJSONEncoder)
-        if private:
-            self._cache_contents[key] = content
-        else:
-            self._cache_contents["public-" + key] = content
+    def __init__(self, data_dir: str) -> None:
+        super().__init__({"data_dir": data_dir})
 
     @classmethod
     def for_attached_machine(
         cls,
+        data_dir: str,
         account_name: str = "test_account",
         machine_token: "Dict[str, Any]" = None,
     ):
-        value = {
-            "machine-token": {
+        if not machine_token:
+            machine_token = {
                 "availableResources": [],
                 "machineToken": "not-null",
                 "machineTokenInfo": {
@@ -89,7 +57,6 @@ class FakeConfig(UAConfig):
                     },
                 },
             }
-        }
-        if machine_token:
-            value["machine-token"] = machine_token
-        return cls(value)
+        config = cls(data_dir)
+        config.write_cache("machine-token", machine_token)
+        return config

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -139,12 +139,12 @@ class TestAssertRoot:
 # Test multiple uids, to be sure that the root checking is absent
 @pytest.mark.parametrize("uid", [0, 1000])
 class TestAssertAttached:
-    def test_assert_attached_when_attached(self, capsys, uid):
+    def test_assert_attached_when_attached(self, capsys, uid, tmpdir):
         @assert_attached()
         def test_function(args, cfg):
             return mock.sentinel.success
 
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             ret = test_function(mock.Mock(), cfg)
@@ -154,12 +154,12 @@ class TestAssertAttached:
         out, _err = capsys.readouterr()
         assert "" == out.strip()
 
-    def test_assert_attached_when_unattached(self, uid):
+    def test_assert_attached_when_unattached(self, uid, tmpdir):
         @assert_attached()
         def test_function(args, cfg):
             pass
 
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             with pytest.raises(UnattachedError):
@@ -168,23 +168,23 @@ class TestAssertAttached:
 
 @pytest.mark.parametrize("uid", [0, 1000])
 class TestAssertNotAttached:
-    def test_when_attached(self, uid):
+    def test_when_attached(self, uid, tmpdir):
         @assert_not_attached
         def test_function(args, cfg):
             pass
 
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             with pytest.raises(AlreadyAttachedError):
                 test_function(mock.Mock(), cfg)
 
-    def test_when_not_attached(self, capsys, uid):
+    def test_when_not_attached(self, capsys, uid, tmpdir):
         @assert_not_attached
         def test_function(args, cfg):
             return mock.sentinel.success
 
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             ret = test_function(mock.Mock(), cfg)

--- a/uaclient/tests/test_cli_attach.py
+++ b/uaclient/tests/test_cli_attach.py
@@ -70,11 +70,11 @@ ENTITLED_MACHINE_TOKEN["machineTokenInfo"]["contractInfo"][
 
 
 @mock.patch(M_PATH + "os.getuid")
-def test_non_root_users_are_rejected(getuid):
+def test_non_root_users_are_rejected(getuid, tmpdir):
     """Check that a UID != 0 will receive a message and exit non-zero"""
     getuid.return_value = 1
 
-    cfg = FakeConfig()
+    cfg = FakeConfig(tmpdir.strpath)
     with pytest.raises(NonRootUserError):
         action_attach(mock.MagicMock(), cfg)
 
@@ -82,20 +82,22 @@ def test_non_root_users_are_rejected(getuid):
 # For all of these tests we want to appear as root, so mock on the class
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionAttach:
-    def test_already_attached(self, _m_getuid, capsys):
+    def test_already_attached(self, _m_getuid, capsys, tmpdir):
         """Check that an already-attached machine emits message and exits 0"""
         account_name = "test_account"
-        cfg = FakeConfig.for_attached_machine(account_name=account_name)
+        cfg = FakeConfig.for_attached_machine(
+            tmpdir.strpath, account_name=account_name
+        )
 
         with pytest.raises(AlreadyAttachedError):
             action_attach(mock.MagicMock(), cfg)
 
-    def test_token_is_a_required_argument(self, _m_getuid):
+    def test_token_is_a_required_argument(self, _m_getuid, tmpdir):
         """When missing the required token argument, raise a UserFacingError"""
         args = mock.MagicMock()
         args.token = None
         with pytest.raises(UserFacingError) as e:
-            action_attach(args, FakeConfig())
+            action_attach(args, FakeConfig(tmpdir.strpath))
         assert status.MESSAGE_ATTACH_REQUIRES_TOKEN == str(e.value)
 
     @pytest.mark.parametrize(
@@ -120,11 +122,12 @@ class TestActionAttach:
         error_str,
         expected_log,
         caplog_text,
+        tmpdir,
     ):
         """If auto-enable of a service fails, attach status is updated."""
         token = "contract-token"
         args = mock.MagicMock(token=token)
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
         cfg.status()  # persist unattached status
         # read persisted status cache from disk
         orig_unattached_status = cfg.read_cache("status-cache")
@@ -149,14 +152,14 @@ class TestActionAttach:
     )
     @mock.patch(M_PATH + "action_status")
     def test_happy_path_with_token_arg(
-        self, action_status, contract_machine_attach, _m_getuid
+        self, action_status, contract_machine_attach, _m_getuid, tmpdir
     ):
         """A mock-heavy test for the happy path with the contract token arg"""
         # TODO: Improve this test with less general mocking and more
         # post-conditions
         token = "contract-token"
         args = mock.MagicMock(token=token)
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
 
         def fake_contract_attach(contract_token):
             cfg.write_cache("machine-token", BASIC_MACHINE_TOKEN)
@@ -174,7 +177,7 @@ class TestActionAttach:
     @pytest.mark.parametrize("auto_enable", (True, False))
     @mock.patch("uaclient.contract.get_available_resources")
     def test_auto_enable_passed_through_to_request_updated_contract(
-        self, _m_getuid, _m_get_available_resources, auto_enable
+        self, _m_getuid, _m_get_available_resources, auto_enable, tmpdir
     ):
         args = mock.MagicMock(auto_enable=auto_enable)
 
@@ -184,7 +187,7 @@ class TestActionAttach:
 
         with mock.patch(M_PATH + "contract.request_updated_contract") as m_ruc:
             m_ruc.side_effect = fake_contract_updates
-            action_attach(args, FakeConfig())
+            action_attach(args, FakeConfig(tmpdir.strpath))
 
         expected_call = mock.call(mock.ANY, mock.ANY, allow_enable=auto_enable)
         assert [expected_call] == m_ruc.call_args_list

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -45,12 +45,12 @@ class TestDisable:
         ],
     )
     def test_invalid_service_error_message(
-        self, m_getuid, uid, expected_error_template
+        self, m_getuid, uid, expected_error_template, tmpdir
     ):
         """Check invalid service name results in custom error message."""
         m_getuid.return_value = uid
 
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "bogus"
@@ -68,12 +68,12 @@ class TestDisable:
         ],
     )
     def test_unattached_error_message(
-        self, m_getuid, uid, expected_error_template
+        self, m_getuid, uid, expected_error_template, tmpdir
     ):
         """Check that root user gets unattached message."""
         m_getuid.return_value = uid
 
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "esm-infra"

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -10,11 +10,11 @@ from uaclient.testing.fakes import FakeConfig
 
 @mock.patch("uaclient.cli.os.getuid")
 class TestActionEnable:
-    def test_non_root_users_are_rejected(self, getuid):
+    def test_non_root_users_are_rejected(self, getuid, tmpdir):
         """Check that a UID != 0 will receive a message and exit non-zero"""
         getuid.return_value = 1
 
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
         with pytest.raises(exceptions.NonRootUserError):
             action_enable(mock.MagicMock(), cfg)
 
@@ -26,12 +26,12 @@ class TestActionEnable:
         ],
     )
     def test_unattached_error_message(
-        self, m_getuid, uid, expected_error_template
+        self, m_getuid, uid, expected_error_template, tmpdir
     ):
         """Check that root user gets unattached message."""
 
         m_getuid.return_value = uid
-        cfg = FakeConfig()
+        cfg = FakeConfig(tmpdir.strpath)
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "esm-infra"
@@ -48,12 +48,12 @@ class TestActionEnable:
         ],
     )
     def test_invalid_service_error_message(
-        self, m_getuid, uid, expected_error_template
+        self, m_getuid, uid, expected_error_template, tmpdir
     ):
         """Check invalid service name results in custom error message."""
 
         m_getuid.return_value = uid
-        cfg = FakeConfig.for_attached_machine()
+        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "bogus"


### PR DESCRIPTION
Once landed this FakeConfig tmp data_dir support will be used in both of the PRs:
#994 and #985 
