### PR TITLE
uaclient: convert FakeConfig to a fixture

### DIFF
--- a/uaclient/testing/fakes.py
+++ b/uaclient/testing/fakes.py
@@ -1,11 +1,4 @@
-from uaclient.config import UAConfig
 from uaclient.contract import UAContractClient
-
-try:
-    from typing import Any, Dict, Optional  # noqa: F401
-except ImportError:
-    # typing isn't available on trusty, so ignore its absence
-    pass
 
 
 class FakeContractClient(UAContractClient):
@@ -31,32 +24,3 @@ class FakeContractClient(UAContractClient):
         if isinstance(response, Exception):
             raise response
         return response, {"header1": ""}
-
-
-class FakeConfig(UAConfig):
-    def __init__(self, data_dir: str) -> None:
-        super().__init__({"data_dir": data_dir})
-
-    @classmethod
-    def for_attached_machine(
-        cls,
-        data_dir: str,
-        account_name: str = "test_account",
-        machine_token: "Dict[str, Any]" = None,
-    ):
-        if not machine_token:
-            machine_token = {
-                "availableResources": [],
-                "machineToken": "not-null",
-                "machineTokenInfo": {
-                    "accountInfo": {"id": "acct-1", "name": account_name},
-                    "contractInfo": {
-                        "id": "cid",
-                        "name": "test_contract",
-                        "resourceEntitlements": [],
-                    },
-                },
-            }
-        config = cls(data_dir)
-        config.write_cache("machine-token", machine_token)
-        return config

--- a/uaclient/tests/test_cli.py
+++ b/uaclient/tests/test_cli.py
@@ -25,7 +25,6 @@ from uaclient.exceptions import (
     UserFacingError,
     UnattachedError,
 )
-from uaclient.testing.fakes import FakeConfig
 from uaclient import status
 from uaclient import util
 
@@ -139,12 +138,12 @@ class TestAssertRoot:
 # Test multiple uids, to be sure that the root checking is absent
 @pytest.mark.parametrize("uid", [0, 1000])
 class TestAssertAttached:
-    def test_assert_attached_when_attached(self, capsys, uid, tmpdir):
+    def test_assert_attached_when_attached(self, capsys, uid, FakeConfig):
         @assert_attached()
         def test_function(args, cfg):
             return mock.sentinel.success
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             ret = test_function(mock.Mock(), cfg)
@@ -154,12 +153,12 @@ class TestAssertAttached:
         out, _err = capsys.readouterr()
         assert "" == out.strip()
 
-    def test_assert_attached_when_unattached(self, uid, tmpdir):
+    def test_assert_attached_when_unattached(self, uid, FakeConfig):
         @assert_attached()
         def test_function(args, cfg):
             pass
 
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             with pytest.raises(UnattachedError):
@@ -168,23 +167,23 @@ class TestAssertAttached:
 
 @pytest.mark.parametrize("uid", [0, 1000])
 class TestAssertNotAttached:
-    def test_when_attached(self, uid, tmpdir):
+    def test_when_attached(self, uid, FakeConfig):
         @assert_not_attached
         def test_function(args, cfg):
             pass
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             with pytest.raises(AlreadyAttachedError):
                 test_function(mock.Mock(), cfg)
 
-    def test_when_not_attached(self, capsys, uid, tmpdir):
+    def test_when_not_attached(self, capsys, uid, FakeConfig):
         @assert_not_attached
         def test_function(args, cfg):
             return mock.sentinel.success
 
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         with mock.patch("uaclient.cli.os.getuid", return_value=uid):
             ret = test_function(mock.Mock(), cfg)

--- a/uaclient/tests/test_cli_disable.py
+++ b/uaclient/tests/test_cli_disable.py
@@ -4,7 +4,6 @@ import pytest
 from uaclient.cli import action_disable
 from uaclient import exceptions
 from uaclient import status
-from uaclient.testing.fakes import FakeConfig
 
 
 @mock.patch("uaclient.cli.os.getuid", return_value=0)
@@ -45,12 +44,12 @@ class TestDisable:
         ],
     )
     def test_invalid_service_error_message(
-        self, m_getuid, uid, expected_error_template, tmpdir
+        self, m_getuid, uid, expected_error_template, FakeConfig
     ):
         """Check invalid service name results in custom error message."""
         m_getuid.return_value = uid
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "bogus"
@@ -68,12 +67,12 @@ class TestDisable:
         ],
     )
     def test_unattached_error_message(
-        self, m_getuid, uid, expected_error_template, tmpdir
+        self, m_getuid, uid, expected_error_template, FakeConfig
     ):
         """Check that root user gets unattached message."""
         m_getuid.return_value = uid
 
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "esm-infra"

--- a/uaclient/tests/test_cli_enable.py
+++ b/uaclient/tests/test_cli_enable.py
@@ -5,16 +5,15 @@ import pytest
 from uaclient.cli import _perform_enable, action_enable
 from uaclient import exceptions
 from uaclient import status
-from uaclient.testing.fakes import FakeConfig
 
 
 @mock.patch("uaclient.cli.os.getuid")
 class TestActionEnable:
-    def test_non_root_users_are_rejected(self, getuid, tmpdir):
+    def test_non_root_users_are_rejected(self, getuid, FakeConfig):
         """Check that a UID != 0 will receive a message and exit non-zero"""
         getuid.return_value = 1
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.NonRootUserError):
             action_enable(mock.MagicMock(), cfg)
 
@@ -26,12 +25,12 @@ class TestActionEnable:
         ],
     )
     def test_unattached_error_message(
-        self, m_getuid, uid, expected_error_template, tmpdir
+        self, m_getuid, uid, expected_error_template, FakeConfig
     ):
         """Check that root user gets unattached message."""
 
         m_getuid.return_value = uid
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "esm-infra"
@@ -48,12 +47,12 @@ class TestActionEnable:
         ],
     )
     def test_invalid_service_error_message(
-        self, m_getuid, uid, expected_error_template, tmpdir
+        self, m_getuid, uid, expected_error_template, FakeConfig
     ):
         """Check invalid service name results in custom error message."""
 
         m_getuid.return_value = uid
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.UserFacingError) as err:
             args = mock.MagicMock()
             args.name = "bogus"

--- a/uaclient/tests/test_cli_refresh.py
+++ b/uaclient/tests/test_cli_refresh.py
@@ -3,7 +3,6 @@ import mock
 import pytest
 
 from uaclient import exceptions
-from uaclient.testing.fakes import FakeConfig
 
 try:
     from typing import Any, Dict, Optional  # noqa: F401
@@ -19,17 +18,17 @@ M_PATH = "uaclient.cli."
 
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionRefresh:
-    def test_non_root_users_are_rejected(self, getuid, tmpdir):
+    def test_non_root_users_are_rejected(self, getuid, FakeConfig):
         """Check that a UID != 0 will receive a message and exit non-zero"""
         getuid.return_value = 1
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         with pytest.raises(exceptions.NonRootUserError):
             action_refresh(mock.MagicMock(), cfg)
 
-    def test_not_attached_errors(self, getuid, tmpdir):
+    def test_not_attached_errors(self, getuid, FakeConfig):
         """Check that an unattached machine emits message and exits 1"""
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         with pytest.raises(exceptions.UnattachedError):
             action_refresh(mock.MagicMock(), cfg)
@@ -37,14 +36,14 @@ class TestActionRefresh:
     @mock.patch(M_PATH + "logging.error")
     @mock.patch(M_PATH + "contract.request_updated_contract")
     def test_refresh_contract_error_on_failure_to_update_contract(
-        self, request_updated_contract, logging_error, getuid, tmpdir
+        self, request_updated_contract, logging_error, getuid, FakeConfig
     ):
         """On failure in request_updates_contract emit an error."""
         request_updated_contract.side_effect = exceptions.UserFacingError(
             "Failure to refresh"
         )
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
 
         with pytest.raises(exceptions.UserFacingError) as excinfo:
             action_refresh(mock.MagicMock(), cfg)
@@ -53,12 +52,12 @@ class TestActionRefresh:
 
     @mock.patch(M_PATH + "contract.request_updated_contract")
     def test_refresh_contract_happy_path(
-        self, request_updated_contract, getuid, capsys, tmpdir
+        self, request_updated_contract, getuid, capsys, FakeConfig
     ):
         """On success from request_updates_contract root user can refresh."""
         request_updated_contract.return_value = True
 
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         ret = action_refresh(mock.MagicMock(), cfg)
 
         assert 0 == ret

--- a/uaclient/tests/test_cli_status.py
+++ b/uaclient/tests/test_cli_status.py
@@ -6,7 +6,6 @@ import sys
 
 import pytest
 
-from uaclient.testing.fakes import FakeConfig
 from uaclient import util
 
 from uaclient.cli import action_status
@@ -50,9 +49,11 @@ Technical support level: n/a
 )
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionStatus:
-    def test_attached(self, m_getuid, m_get_avail_resources, capsys, tmpdir):
+    def test_attached(
+        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
+    ):
         """Check that root and non-root will emit attached status"""
-        cfg = FakeConfig.for_attached_machine(tmpdir.strpath)
+        cfg = FakeConfig.for_attached_machine()
         assert 0 == action_status(mock.MagicMock(), cfg)
         # capsys already converts colorized non-printable chars to space
         # Strip non-printables from output
@@ -68,18 +69,20 @@ class TestActionStatus:
             expected_dash = "\u2014"
         assert ATTACHED_STATUS.format(dash=expected_dash) == printable_stdout
 
-    def test_unattached(self, m_getuid, m_get_avail_resources, capsys, tmpdir):
+    def test_unattached(
+        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
+    ):
         """Check that unattached status is emitted to console"""
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         assert 0 == action_status(mock.MagicMock(), cfg)
         assert UNATTACHED_STATUS == capsys.readouterr()[0]
 
     def test_unattached_json(
-        self, m_getuid, m_get_avail_resources, capsys, tmpdir
+        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
     ):
         """Check that unattached status json output is emitted to console"""
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         args = mock.MagicMock(format="json")
         assert 0 == action_status(args, cfg)
@@ -103,14 +106,14 @@ class TestActionStatus:
         assert expected == json.loads(capsys.readouterr()[0])
 
     def test_error_on_connectivity_errors(
-        self, m_getuid, m_get_avail_resources, capsys, tmpdir
+        self, m_getuid, m_get_avail_resources, capsys, FakeConfig
     ):
         """Raise UrlError on connectivity issues"""
         m_get_avail_resources.side_effect = util.UrlError(
             socket.gaierror(-2, "Name or service not known")
         )
 
-        cfg = FakeConfig(tmpdir.strpath)
+        cfg = FakeConfig()
 
         with pytest.raises(util.UrlError):
             action_status(mock.MagicMock(), cfg)
@@ -125,7 +128,7 @@ class TestActionStatus:
         _m_get_avail_resources,
         encoding,
         expected_dash,
-        tmpdir,
+        FakeConfig,
     ):
         # This test can't use capsys because it doesn't emulate sys.stdout
         # encoding accurately in older versions of pytest
@@ -133,10 +136,7 @@ class TestActionStatus:
         fake_stdout = io.TextIOWrapper(underlying_stdout, encoding=encoding)
 
         with mock.patch("sys.stdout", fake_stdout):
-            action_status(
-                mock.MagicMock(),
-                FakeConfig.for_attached_machine(tmpdir.strpath),
-            )
+            action_status(mock.MagicMock(), FakeConfig.for_attached_machine())
 
         fake_stdout.flush()  # Make sure all output is in underlying_stdout
         out = underlying_stdout.getvalue().decode(encoding)


### PR DESCRIPTION
This simplifies test code currently, and also gives us a cleaner
interface for any future modifications that might be required for
FakeConfig.