### PR TITLE
testing: add integration test for behavior of attaching a valid_token

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -1,6 +1,7 @@
 Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
         subscription using a valid token
 
+    @uses.config.contract_token
     Scenario: Attach command in a trusty lxd container
        Given a trusty lxd container with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -1,0 +1,31 @@
+Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
+        subscription using a valid token
+
+    Scenario: Attach command in a trusty lxd container
+       Given a trusty lxd container with ubuntu-advantage-tools installed
+        When I attach "<contract_token>" with sudo
+        Then stdout will include:
+        """
+        ESM Infra enabled
+        """
+        And stdout will include:
+        """
+        This machine is now attached to
+        """
+        And stdout will include:
+        """
+        SERVICE       ENTITLED  STATUS    DESCRIPTION
+        cc-eal        yes       n/a       Common Criteria EAL2 Provisioning Packages
+        cis-audit     no        —         Center for Internet Security Audit Tools
+        esm-apps      no        —         UA Apps: Extended Security Maintenance
+        esm-infra     yes       enabled   UA Infra: Extended Security Maintenance
+        fips          yes       n/a       NIST-certified FIPS modules
+        fips-updates  yes       n/a       Uncertified security updates to FIPS modules
+        livepatch     yes       n/a       Canonical Livepatch service
+
+        Enable services with: ua enable <service>
+        """
+        And I will see the following on stderr:
+        """
+        Enabling default service esm-infra
+        """

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -4,26 +4,24 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     Scenario: Attach command in a trusty lxd container
        Given a trusty lxd container with ubuntu-advantage-tools installed
         When I attach "<contract_token>" with sudo
-        Then stdout will include:
+        Then stdout matches regexp:
         """
         ESM Infra enabled
         """
-        And stdout will include:
+        And stdout matches regexp:
         """
         This machine is now attached to
         """
-        And stdout will include:
+        And stdout matches regexp:
         """
         SERVICE       ENTITLED  STATUS    DESCRIPTION
-        cc-eal        yes       n/a       Common Criteria EAL2 Provisioning Packages
-        cis-audit     no        —         Center for Internet Security Audit Tools
-        esm-apps      no        —         UA Apps: Extended Security Maintenance
-        esm-infra     yes       enabled   UA Infra: Extended Security Maintenance
-        fips          yes       n/a       NIST-certified FIPS modules
-        fips-updates  yes       n/a       Uncertified security updates to FIPS modules
-        livepatch     yes       n/a       Canonical Livepatch service
-
-        Enable services with: ua enable <service>
+        cc-eal       +yes      +n/a      +Common Criteria EAL2 Provisioning Packages
+        cis-audit    +no       +—        +Center for Internet Security Audit Tools
+        esm-apps     +no       +—        +UA Apps: Extended Security Maintenance
+        esm-infra    +yes      +enabled  +UA Infra: Extended Security Maintenance
+        fips         +yes      +n/a      +NIST-certified FIPS modules
+        fips-updates +yes      +n/a      +Uncertified security updates to FIPS modules
+        livepatch    +yes      +n/a      +Canonical Livepatch service
         """
         And I will see the following on stderr:
         """

--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -3,7 +3,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
 
     Scenario: Attach command in a trusty lxd container
        Given a trusty lxd container with ubuntu-advantage-tools installed
-        When I attach "contract_token" with sudo
+        When I attach `contract_token` with sudo
         Then stdout matches regexp:
         """
         ESM Infra enabled

--- a/features/environment.py
+++ b/features/environment.py
@@ -35,18 +35,18 @@ class UAClientBehaveConfig:
     # environment variable input to the appropriate Python types for use within
     # the test framework
     boolean_options = ["image_clean", "destroy_instances"]
-    str_options = ["contract_token", "reuse_image"]
+    str_options = ["reuse_image"]
+    redact_options = ["contract_token"]
 
     # This variable is used in .from_environ() but also to emit the "Config
     # options" stanza in __init__
-    all_options = boolean_options + str_options
+    all_options = boolean_options + str_options + redact_options
 
     def __init__(
         self,
         *,
         image_clean: bool = True,
-        reuse_image: str = None,
-        destroy_instances: bool = True
+        destroy_instances: bool = True,
         contract_token: str = None,
         reuse_image: str = None
     ) -> None:
@@ -66,7 +66,10 @@ class UAClientBehaveConfig:
         # config options, and means they'll be included in test logs in CI.
         print("Config options:")
         for option in self.all_options:
-            print("  {}".format(option), "=", getattr(self, option, "ERROR"))
+            value = getattr(self, option, "ERROR")
+            if option in self.redact_options and value not in (None, "ERROR"):
+                value = "<REDACTED>"
+            print("  {}".format(option), "=", value)
 
     @classmethod
     def from_environ(cls) -> "UAClientBehaveConfig":

--- a/features/environment.py
+++ b/features/environment.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 from typing import Dict, Union
 
+from behave.model import Scenario
+
 from behave.runner import Context
 
 from features.util import launch_lxd_container, lxc_exec
@@ -107,6 +109,18 @@ def before_all(context: Context) -> None:
         create_trusty_uat_lxd_image(context)
     else:
         context.image_name = context.config.reuse_image
+
+
+def before_scenario(context: Context, scenario: Scenario):
+    for tag in scenario.effective_tags:
+        parts = tag.split(".")
+        if parts[0] == "uses":
+            val = context
+            for attr in parts[1:]:
+                val = getattr(val, attr, None)
+                if val is None:
+                    scenario.skip(
+                       reason="Skipped because tag value was None: {}".format(tag))
 
 
 def _capture_container_as_image(container_name: str, image_name: str) -> None:

--- a/features/environment.py
+++ b/features/environment.py
@@ -15,6 +15,8 @@ class UAClientBehaveConfig:
     source of truth for test configuration (rather than having environment
     variable handling throughout the test code).
 
+    :param contract_token:
+        A valid contract token to use during attach scenarios
     :param image_clean:
         This indicates whether the image created for this test run should be
         cleaned up when all tests are complete.
@@ -33,7 +35,7 @@ class UAClientBehaveConfig:
     # environment variable input to the appropriate Python types for use within
     # the test framework
     boolean_options = ["image_clean", "destroy_instances"]
-    str_options = ["reuse_image"]
+    str_options = ["contract_token", "reuse_image"]
 
     # This variable is used in .from_environ() but also to emit the "Config
     # options" stanza in __init__
@@ -45,8 +47,11 @@ class UAClientBehaveConfig:
         image_clean: bool = True,
         reuse_image: str = None,
         destroy_instances: bool = True
+        contract_token: str = None,
+        reuse_image: str = None
     ) -> None:
         # First, store the values we've detected
+        self.contract_token = contract_token
         self.image_clean = image_clean
         self.destroy_instances = destroy_instances
         self.reuse_image = reuse_image

--- a/features/environment.py
+++ b/features/environment.py
@@ -120,7 +120,10 @@ def before_scenario(context: Context, scenario: Scenario):
                 val = getattr(val, attr, None)
                 if val is None:
                     scenario.skip(
-                       reason="Skipped because tag value was None: {}".format(tag))
+                        reason="Skipped because tag value was None: {}".format(
+                            tag
+                        )
+                    )
 
 
 def _capture_container_as_image(container_name: str, image_name: str) -> None:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -29,7 +29,7 @@ def when_i_run_command(context, command, user_spec):
     context.process = process
 
 
-@when("I attach `{contrac_token}` {user_spec}")
+@when("I attach `{contract_token}` {user_spec}")
 def when_i_attach_token(context, contract_token, user_spec):
     token = context.config.contract_token
     if not token:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -54,7 +54,9 @@ def then_i_will_see_on_stdout(context):
 @then("stdout will include")
 def then_and_stdout_will_include(context):
     assert_that(context.process.stdout.strip(), contains_string(context.text))
-
++@then("stdout matches regexp")
++def then_stdout_matches_regexp(context):
++    assert_that(context.process.stdout.strip(), matches_regexp(context.text))
 
 @then("I will see the following on stderr")
 def then_i_will_see_on_stderr(context):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -2,7 +2,7 @@ import datetime
 import shlex
 
 from behave import given, then, when
-from hamcrest import assert_that, contains_string, equal_to
+from hamcrest import assert_that, equal_to, matches_regexp
 
 from features.util import launch_lxd_container, lxc_exec
 
@@ -20,13 +20,6 @@ def given_a_trusty_lxd_container(context):
 @when("I run `{command}` {user_spec}")
 def when_i_run_command(context, command, user_spec):
     prefix = get_command_prefix_for_user_spec(user_spec)
-    if user_spec == "with sudo":
-        prefix = ["sudo"]
-    elif user_spec != "as non-root":
-        raise Exception(
-            "The two acceptable values for user_spec are: 'with sudo',"
-            " 'as non-root'"
-        )
     process = lxc_exec(
         context.container_name,
         prefix + shlex.split(command),
@@ -51,12 +44,10 @@ def then_i_will_see_on_stdout(context):
     assert_that(context.process.stdout.strip(), equal_to(context.text))
 
 
-@then("stdout will include")
-def then_and_stdout_will_include(context):
-    assert_that(context.process.stdout.strip(), contains_string(context.text))
-+@then("stdout matches regexp")
-+def then_stdout_matches_regexp(context):
-+    assert_that(context.process.stdout.strip(), matches_regexp(context.text))
+@then("stdout matches regexp")
+def then_stdout_matches_regexp(context):
+    assert_that(context.process.stdout.strip(), matches_regexp(context.text))
+
 
 @then("I will see the following on stderr")
 def then_i_will_see_on_stderr(context):

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -32,10 +32,6 @@ def when_i_run_command(context, command, user_spec):
 @when("I attach `{contract_token}` {user_spec}")
 def when_i_attach_token(context, contract_token, user_spec):
     token = context.config.contract_token
-    if not token:
-        context.feature.skip(
-            "Skipping test because you didn't provide a token"
-        )
     when_i_run_command(context, "ua attach %s" % token, user_spec)
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -2,7 +2,7 @@ import datetime
 import shlex
 
 from behave import given, then, when
-from hamcrest import assert_that, equal_to
+from hamcrest import assert_that, contains_string, equal_to
 
 from features.util import launch_lxd_container, lxc_exec
 
@@ -19,7 +19,7 @@ def given_a_trusty_lxd_container(context):
 
 @when("I run `{command}` {user_spec}")
 def when_i_run_command(context, command, user_spec):
-    prefix = []
+    prefix = get_command_prefix_for_user_spec(user_spec)
     if user_spec == "with sudo":
         prefix = ["sudo"]
     elif user_spec != "as non-root":
@@ -36,11 +36,38 @@ def when_i_run_command(context, command, user_spec):
     context.process = process
 
 
+@when('I attach "{token}" {user_spec}')
+def when_i_attach_token(context, token, user_spec):
+    token = context.config.contract_token
+    if not token:
+        context.scenario.skip(
+            "Skipping test because you didn't provide a token"
+        )
+    when_i_run_command(context, "ua attach %s" % token, user_spec)
+
+
 @then("I will see the following on stdout")
 def then_i_will_see_on_stdout(context):
     assert_that(context.process.stdout.strip(), equal_to(context.text))
 
 
+@then("stdout will include")
+def then_and_stdout_will_include(context):
+    assert_that(context.process.stdout.strip(), contains_string(context.text))
+
+
 @then("I will see the following on stderr")
 def then_i_will_see_on_stderr(context):
     assert_that(context.process.stderr.strip(), equal_to(context.text))
+
+
+def get_command_prefix_for_user_spec(user_spec):
+    prefix = []
+    if user_spec == "with sudo":
+        prefix = ["sudo"]
+    elif user_spec != "as non-root":
+        raise Exception(
+            "The two acceptable values for user_spec are: 'with sudo',"
+            " 'as non-root'"
+        )
+    return prefix


### PR DESCRIPTION
TODO list:
- figure out a way of checking the colored status
  - currently it is not working because if you are entitled to a service and if
    it is enabled - they are green.
- improve skip option: the test do not run, but didn't show the message
- maybe check if contract_token is None inside `UAClientBehaveConfig` class