### PR TITLE
contract: drop remaining support for request_resource_machine_access

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -78,6 +78,8 @@ case "$1" in
 
       # CACHE_DIR is no longer present or used since 19.1
       rm -rf /var/cache/ubuntu-advantage-tools
+      # machine-access cache files no longer present or used since 20.1
+      rm -rf /var/lib/ubuntu-advantage/private/machine-access*json
 
       if [ "14.04" = "$VERSION_ID" ]; then
         if echo "$ESM_SUPPORTED_ARCHS" | grep -qw "$MYARCH"; then

--- a/debian/postinst
+++ b/debian/postinst
@@ -79,7 +79,7 @@ case "$1" in
       # CACHE_DIR is no longer present or used since 19.1
       rm -rf /var/cache/ubuntu-advantage-tools
       # machine-access cache files no longer present or used since 20.1
-      rm -rf /var/lib/ubuntu-advantage/private/machine-access*json
+      rm -f /var/lib/ubuntu-advantage/private/machine-access-*.json
 
       if [ "14.04" = "$VERSION_ID" ]; then
         if echo "$ESM_SUPPORTED_ARCHS" | grep -qw "$MYARCH"; then

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -41,23 +41,6 @@ DataPath = namedtuple("DataPath", ("filename", "private"))
 class UAConfig:
 
     data_paths = {
-        "machine-access-cc-eal": DataPath("machine-access-cc-eal.json", True),
-        "machine-access-cis-audit": DataPath(
-            "machine-access-cis-audit.json", True
-        ),
-        "machine-access-esm-infra": DataPath(
-            "machine-access-esm-infra.json", True
-        ),
-        "machine-access-fips": DataPath("machine-access-fips.json", True),
-        "machine-access-fips-updates": DataPath(
-            "machine-access-fips-updates.json", True
-        ),
-        "machine-access-livepatch": DataPath(
-            "machine-access-livepatch.json", True
-        ),
-        "machine-access-support": DataPath(
-            "machine-access-support.json", True
-        ),
         "machine-id": DataPath("machine-id", True),
         "machine-token": DataPath("machine-token.json", True),
         "status-cache": DataPath("status.json", False),
@@ -173,7 +156,7 @@ class UAConfig:
             raise RuntimeError(
                 "Invalid or empty key provided to delete_cache_key"
             )
-        if key.startswith("machine-access") or key == "machine-token":
+        if key == "machine-token":
             self._entitlements = None
             self._machine_token = None
         cache_path = self.data_path(key)
@@ -204,7 +187,7 @@ class UAConfig:
             os.makedirs(data_dir)
             if os.path.basename(data_dir) == PRIVATE_SUBDIR:
                 os.chmod(data_dir, 0o700)
-        if key.startswith("machine-access") or key == "machine-token":
+        if key == "machine-token":
             self._machine_token = None
             self._entitlements = None
         if not isinstance(content, str):

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -121,37 +121,6 @@ class UAContractClient(serviceclient.UAServiceClient):
         self.cfg.write_cache("contract-token", response)
         return response
 
-    def request_resource_machine_access(
-        self,
-        machine_token: str,
-        resource: str,
-        machine_id: "Optional[str]" = None,
-    ) -> "Dict[str, Any]":
-        """Requests machine access context for a given resource
-
-        @param machine_token: The authentication token needed to talk to
-            this contract service endpoint.
-        @param resource: Entitlement name.
-        @param machine_id: Optional unique system machine id. When absent,
-            contents of /etc/machine-id will be used.
-
-        @return: Dict of the JSON response containing entitlement accessInfo.
-        """
-        if not machine_id:
-            machine_id = util.get_machine_id(self.cfg.data_dir)
-        headers = self.headers()
-        headers.update({"Authorization": "Bearer {}".format(machine_token)})
-        url = API_V1_TMPL_RESOURCE_MACHINE_ACCESS.format(
-            resource=resource, machine=machine_id
-        )
-        resource_access, headers = self.request_url(url, headers=headers)
-        if headers.get("expires"):
-            resource_access["expires"] = headers["expires"]
-        self.cfg.write_cache(
-            "machine-access-{}".format(resource), resource_access
-        )
-        return resource_access
-
     def request_machine_token_update(
         self, machine_token, contract_id, machine_id=None
     ):

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -289,10 +289,6 @@ class UAEntitlement(metaclass=abc.ABCMeta):
                         " `ua status`",
                         self.name,
                     )
-            # Clean up former entitled machine-access-<name> response cache
-            # file because uaclient doesn't access machine-access-* routes or
-            # responses on unentitled services.
-            self.cfg.delete_cache_key("machine-access-{}".format(self.name))
             return True
 
         resourceToken = orig_access.get("resourceToken")

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -100,9 +100,10 @@ class UAEntitlement(metaclass=abc.ABCMeta):
         :param silent: if True, suppress output
         """
         if self.is_access_expired():
-            token = self.cfg.machine_token["machineToken"]
-            contract_client = contract.UAContractClient(self.cfg)
-            contract_client.request_resource_machine_access(token, self.name)
+            logging.debug(
+                "Updating contract on service '%s' expiry", self.name
+            )
+            contract.request_updated_contract(self.cfg)
         if not self.contract_status() == ContractStatus.ENTITLED:
             if not silent:
                 print(status.MESSAGE_UNENTITLED_TMPL.format(title=self.title))

--- a/uaclient/entitlements/tests/conftest.py
+++ b/uaclient/entitlements/tests/conftest.py
@@ -80,8 +80,8 @@ def entitlement_factory(tmpdir):
 
     The function requires an entitlement class as its first argument, and takes
     keyword arguments for affordances, directives and suites which, if given,
-    replace the default values in the machine-access-*.json file for the
-    entitlement.
+    replace the default values in the resourceEntitlements of the
+    machine-token.json file for the entitlement.
     """
 
     def factory_func(

--- a/uaclient/entitlements/tests/test_repo.py
+++ b/uaclient/entitlements/tests/test_repo.py
@@ -87,7 +87,6 @@ class TestUserFacingStatus:
             "resourceEntitlements"
         ].pop()
         entitlement.cfg.write_cache("machine-token", no_entitlements)
-        entitlement.cfg.delete_cache_key("machine-access-repotest")
         m_platform_info.return_value = dict(PLATFORM_INFO_SUPPORTED)
         applicability, _details = entitlement.applicability_status()
         assert status.ApplicabilityStatus.APPLICABLE == applicability


### PR DESCRIPTION
Drop remaining call site of request_resource_machine_access and any UAConfig support
for machine-access data paths.

Entitlements will now call contract.request_updated_contract instead of request_resource_machine_access when entitlement is found expired.

Additionally we want to clean the unused /var/lib/ubuntu-advantage/private/machine-access*json files upon upgrade, since they will not be read again by ubuntu-advantage-tools

