### PR TITLE
deb: only deliver apt esm allow-origins cfg on trusty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,15 @@ def _get_version():
 
 def _get_data_files():
     data_files = [
-        ("/etc/apt/apt.conf.d", ["apt.conf.d/51ubuntu-advantage-esm"]),
         ("/etc/ubuntu-advantage", ["uaclient.conf"]),
         ("/usr/share/keyrings", glob.glob("keyrings/*")),
         (defaults.CONFIG_DEFAULTS["data_dir"], []),
     ]
     rel_major, _rel_minor = util.get_platform_info()["release"].split(".", 1)
     if rel_major == "14":
+        data_files.append(
+            ("/etc/apt/apt.conf.d", ["apt.conf.d/51ubuntu-advantage-esm"])
+        )
         data_files.append(("/etc/init", glob.glob("upstart/*")))
     else:
         data_files.append(("/lib/systemd/system", glob.glob("systemd/*")))


### PR DESCRIPTION
Unattended-upgrades package now delivers the following apt config on
xenial, bionic, eoan and focal:

Unattended-Upgrade::Allowed-Origins {
...
	"${distro_id}ESMApps:${distro_codename}-apps-security";
	"${distro_id}ESM:${distro_codename}-infra-security";

Ubuntu-advantage-tools now only needs to deliver this apt config file
on trusty.

Fixes: #1005