### PR TITLE
Reuse container

### DIFF
--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -12,9 +12,14 @@ CONTAINER_PREFIX = "behave-test-"
 
 @given("a trusty lxd container with ubuntu-advantage-tools installed")
 def given_a_trusty_lxd_container(context):
-    now = datetime.datetime.now()
-    context.container_name = CONTAINER_PREFIX + now.strftime("%s%f")
-    launch_lxd_container(context, context.image_name, context.container_name)
+    if context.reuse_container:
+        context.container_name = context.reuse_container
+    else:
+        now = datetime.datetime.now()
+        context.container_name = CONTAINER_PREFIX + now.strftime("%s%f")
+        launch_lxd_container(
+            context, context.image_name, context.container_name
+        )
 
 
 @when("I run `{command}` {user_spec}")


### PR DESCRIPTION
changes for reusing a container with userdata config

It allows to run behave choosing an existent container to run the tests in.
I've added it via `userdata` config, so just add `-D reuse_container=existent_cont`.
From that point, it will then proceed to install UAT.
If you don't add this config it stays the same.