### PR TITLE
refactor contract_token parameter

### DIFF
--- a/features/attach_validtoken.feature
+++ b/features/attach_validtoken.feature
@@ -4,7 +4,7 @@ Feature: Command behaviour when attaching a machine to an Ubuntu Advantage
     @uses.config.contract_token
     Scenario: Attach command in a trusty lxd container
        Given a trusty lxd container with ubuntu-advantage-tools installed
-        When I attach `contract_token` with sudo
+        When I attach contract_token with sudo
         Then stdout matches regexp:
         """
         ESM Infra enabled

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -34,8 +34,8 @@ def when_i_run_command(context, command, user_spec):
     context.process = process
 
 
-@when("I attach `{contract_token}` {user_spec}")
-def when_i_attach_token(context, contract_token, user_spec):
+@when("I attach contract_token {user_spec}")
+def when_i_attach_token(context, user_spec):
     token = context.config.contract_token
     when_i_run_command(context, "ua attach %s" % token, user_spec)
 


### PR DESCRIPTION
It will avoid calling this step sending `contract_token` parameter that
is not taken into account, as it is provided via CLI environment variable `UACLIENT_BEHAVE_CONTRACT_TOKEN=...`.
The current way, doesn't matter what the function has received
because `contract_token = context.config.contract_token` overrides it.