### PR TITLE
Bug/reattach across instance id delta

### DIFF
--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -299,11 +299,20 @@ def action_enable(args, cfg):
 @assert_root
 @assert_attached()
 def action_detach(args, cfg) -> int:
+    """Perform the detach action for this machine.
+
+    @return: 0 on success, 1 otherwise
+    """
     return _detach(cfg, assume_yes=args.assume_yes)
 
 
 def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
-    """Perform the detach action for this machine.
+    """Detach the machine from the active Ubuntu Advantage subscription,
+
+    :param cfg: a ``config.UAConfig`` instance
+    :param assume_yes: Assume a yes answer to any prompts requested.
+         In this case, it means automatically disable any service during
+         detach.
 
     @return: 0 on success, 1 otherwise
     """

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -298,7 +298,11 @@ def action_enable(args, cfg):
 
 @assert_root
 @assert_attached()
-def action_detach(args, cfg):
+def action_detach(args, cfg) -> int:
+    return _detach(cfg, assume_yes=args.assume_yes)
+
+
+def _detach(cfg: config.UAConfig, assume_yes: bool) -> int:
     """Perform the detach action for this machine.
 
     @return: 0 on success, 1 otherwise
@@ -313,7 +317,7 @@ def action_detach(args, cfg):
         print("Detach will disable the following service{}:".format(suffix))
         for ent in to_disable:
             print("    {}".format(ent.name))
-    if not args.assume_yes and not util.prompt_for_confirmation():
+    if not assume_yes and not util.prompt_for_confirmation():
         return 1
     for ent in to_disable:
         ent.disable(silent=True)
@@ -372,7 +376,22 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
 
     :return: contract token obtained from identity doc
     """
-    instance = identity.cloud_instance_factory()
+    try:
+        instance = identity.cloud_instance_factory()
+    except exceptions.UserFacingError as e:
+        if cfg.is_attached:
+            # We are attached on non-Pro Image, just report already attached
+            raise exceptions.AlreadyAttachedError(cfg)
+        # Unattached on non-Pro return UserFacing error msg details
+        raise e
+    current_iid = identity.get_instance_id()
+    if cfg.is_attached:
+        prev_iid = cfg.read_cache("instance-id")
+        if current_iid == prev_iid:
+            raise exceptions.AlreadyAttachedError(cfg)
+        print("Re-attaching Ubuntu Advantage subscription on new instance")
+        _detach(cfg, assume_yes=True)
+
     contract_client = contract.UAContractClient(cfg)
     try:
         tokenResponse = contract_client.request_auto_attach_contract_token(
@@ -384,10 +403,12 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
                 ua_status.MESSAGE_UNSUPPORTED_AUTO_ATTACH
             )
         raise e
+    if current_iid:
+        cfg.write_cache("instance-id", current_iid)
+
     return tokenResponse["contractToken"]
 
 
-@assert_not_attached
 @assert_root
 def action_auto_attach(args, cfg):
     token = _get_contract_token_from_cloud_identity(cfg)

--- a/uaclient/cli.py
+++ b/uaclient/cli.py
@@ -399,8 +399,10 @@ def _get_contract_token_from_cloud_identity(cfg: config.UAConfig) -> str:
         if current_iid == prev_iid:
             raise exceptions.AlreadyAttachedError(cfg)
         print("Re-attaching Ubuntu Advantage subscription on new instance")
-        _detach(cfg, assume_yes=True)
-
+        if _detach(cfg, assume_yes=True) != 0:
+            raise exceptions.UserFacingError(
+                ua_status.MESSAGE_DETACH_AUTOMATION_FAILURE
+            )
     contract_client = contract.UAContractClient(cfg)
     try:
         tokenResponse = contract_client.request_auto_attach_contract_token(

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 
 from uaclient import exceptions
 from uaclient import clouds
@@ -11,11 +13,29 @@ except ImportError:
     # typing isn't available on trusty, so ignore its absence
     pass
 
+# Needed for Trusty-only
 CLOUDINIT_RESULT_FILE = "/var/lib/cloud/data/result.json"
+CLOUDINIT_INSTANCE_ID_FILE = "/var/lib/cloud/data/instance-id"
 
 
 # Mapping of datasource names to cloud-id responses. Trusty compat with Xenial+
 DATASOURCE_TO_CLOUD_ID = {"azurenet": "azure", "ec2": "aws"}
+
+
+def get_instance_id(
+    _iid_file: str = CLOUDINIT_INSTANCE_ID_FILE
+) -> "Optional[str]":
+    """Query cloud instance-id from cmdline or CLOUDINIT_INSTANCE_ID_FILE"""
+    if "trusty" != util.get_platform_info()["series"]:
+        # Present in cloud-init on >= Xenial
+        out, _err = util.subp(["cloud-init", "query", "instance_id"])
+        return out.strip()
+    if os.path.exists(_iid_file):
+        return util.load_file(_iid_file)
+    logging.warning(
+        "Unable to determine current instance-id from %s", _iid_file
+    )
+    return None
 
 
 def get_cloud_type_from_result_file(

--- a/uaclient/config.py
+++ b/uaclient/config.py
@@ -41,6 +41,7 @@ DataPath = namedtuple("DataPath", ("filename", "private"))
 class UAConfig:
 
     data_paths = {
+        "instance-id": DataPath("instance-id", True),
         "machine-id": DataPath("machine-id", True),
         "machine-token": DataPath("machine-token.json", True),
         "status-cache": DataPath("status.json", False),

--- a/uaclient/status.py
+++ b/uaclient/status.py
@@ -203,6 +203,7 @@ MESSAGE_ENABLE_BY_DEFAULT_TMPL = "Enabling default service {name}"
 MESSAGE_ENABLE_BY_DEFAULT_MANUAL_TMPL = """\
 Service {name} is recommended by default. Run: sudo ua enable {name}"""
 MESSAGE_DETACH_SUCCESS = "This machine is now detached"
+MESSAGE_DETACH_AUTOMATION_FAILURE = "Unable to automatically detach machine"
 
 MESSAGE_REFRESH_ENABLE = "One moment, checking your subscription first"
 MESSAGE_REFRESH_SUCCESS = "Successfully refreshed your subscription"

--- a/uaclient/tests/test_cli_auto_attach.py
+++ b/uaclient/tests/test_cli_auto_attach.py
@@ -1,5 +1,4 @@
 import mock
-import os
 
 import pytest
 
@@ -14,12 +13,14 @@ from uaclient.exceptions import (
     AlreadyAttachedError,
     NonRootUserError,
     NonAutoAttachImageError,
+    UserFacingError,
 )
 from uaclient import status
 from uaclient.tests.test_cli_attach import BASIC_MACHINE_TOKEN
 from uaclient import util
 
 M_PATH = "uaclient.cli."
+M_ID_PATH = "uaclient.clouds.identity."
 
 
 @mock.patch(M_PATH + "os.getuid")
@@ -41,7 +42,7 @@ class TestGetContractTokenFromCloudIdentity:
     @pytest.mark.parametrize(
         "cloud_type", ("awslookalike", "unsupported-cloud", "azure2", "!aws")
     )
-    @mock.patch("uaclient.clouds.identity.get_cloud_type")
+    @mock.patch(M_ID_PATH + "get_cloud_type")
     def test_non_aws_cloud_type_raises_error(
         self, m_get_cloud_type, cloud_type, FakeConfig
     ):
@@ -67,12 +68,12 @@ class TestGetContractTokenFromCloudIdentity:
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
-    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
-    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    @mock.patch(M_ID_PATH + "get_instance_id", return_value="old-iid")
+    @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_aws_cloud_type_non_auto_attach_returns_no_token(
         self,
-        _get_cloud_type,
         cloud_instance_factory,
+        get_instance_id,
         request_auto_attach_contract_token,
         http_msg,
         http_code,
@@ -80,7 +81,6 @@ class TestGetContractTokenFromCloudIdentity:
         FakeConfig,
     ):
         """VMs running on non-auto-attach images do not return a token."""
-
         cloud_instance_factory.side_effect = self.fake_instance_factory
         request_auto_attach_contract_token.side_effect = ContractAPIError(
             util.UrlError(
@@ -95,12 +95,12 @@ class TestGetContractTokenFromCloudIdentity:
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
-    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
-    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    @mock.patch(M_ID_PATH + "get_instance_id", return_value="my-iid")
+    @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_raise_unexpected_errors(
         self,
-        _get_cloud_type,
         cloud_instance_factory,
+        _get_instance_id,
         request_auto_attach_contract_token,
         FakeConfig,
     ):
@@ -119,17 +119,13 @@ class TestGetContractTokenFromCloudIdentity:
             _get_contract_token_from_cloud_identity(FakeConfig())
         assert unexpected_error == excinfo.value
 
-    @mock.patch(
-        "uaclient.clouds.identity.get_instance_id", return_value="my-iid"
-    )
+    @mock.patch(M_ID_PATH + "get_instance_id", return_value="my-iid")
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
-    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
-    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_return_token_from_contract_server_using_identity_doc(
         self,
-        _get_cloud_type,
         cloud_instance_factory,
         request_auto_attach_contract_token,
         get_instance_id,
@@ -147,22 +143,19 @@ class TestGetContractTokenFromCloudIdentity:
         cfg = FakeConfig()
         assert "myPKCS7-token" == _get_contract_token_from_cloud_identity(cfg)
         # instance-id is persisted for next auto-attach call
-        iid_file = os.path.join(cfg.data_dir, "instance-id")
         assert 1 == get_instance_id.call_count
-        assert "my-iid" == util.load_file(iid_file)
+        assert "my-iid" == cfg.read_cache("instance-id")
 
     @pytest.mark.parametrize(
         "iid_response,calls_detach", (("old-iid", False), ("new-iid", True))
     )
-    @mock.patch("uaclient.clouds.identity.get_instance_id")
+    @mock.patch(M_ID_PATH + "get_instance_id")
     @mock.patch(
         M_PATH + "contract.UAContractClient.request_auto_attach_contract_token"
     )
-    @mock.patch("uaclient.clouds.identity.cloud_instance_factory")
-    @mock.patch("uaclient.clouds.identity.get_cloud_type", return_value="aws")
+    @mock.patch(M_ID_PATH + "cloud_instance_factory")
     def test_delta_in_instance_id_forces_detach(
         self,
-        _get_cloud_type,
         cloud_instance_factory,
         request_auto_attach_contract_token,
         get_instance_id,
@@ -183,8 +176,7 @@ class TestGetContractTokenFromCloudIdentity:
         account_name = "test_account"
         cfg = FakeConfig.for_attached_machine(account_name=account_name)
         # persist old instance-id value
-        iid_file = os.path.join(cfg.data_dir, "instance-id")
-        util.write_file(iid_file, "old-iid")
+        cfg.write_cache("instance-id", "old-iid")
 
         if calls_detach:
             with mock.patch(M_PATH + "_detach") as m_detach:
@@ -197,17 +189,21 @@ class TestGetContractTokenFromCloudIdentity:
             with pytest.raises(AlreadyAttachedError):
                 _get_contract_token_from_cloud_identity(cfg)
         # current instance-id is persisted for next auto-attach call
-        assert iid_response == util.load_file(iid_file)
+        assert iid_response == cfg.read_cache("instance-id")
 
 
 # For all of these tests we want to appear as root, so mock on the class
 @mock.patch(M_PATH + "os.getuid", return_value=0)
 class TestActionAutoAttach:
-    def test_already_attached(self, _m_getuid, FakeConfig):
-        """Check that an attached machine raises AlreadyAttachedError."""
+    @mock.patch(M_ID_PATH + "cloud_instance_factory")
+    def test_already_attached_on_non_ubuntu_pro(
+        self, m_cloud_instance_factory, _m_getuid, FakeConfig
+    ):
+        """An attached machine raises AlreadyAttachedError on non-PRO."""
+        # Non-PRO raises UserFacingError on non-PRO image
+        m_cloud_instance_factory.side_effect = UserFacingError("Not-a-PRO")
         account_name = "test_account"
         cfg = FakeConfig.for_attached_machine(account_name=account_name)
-
         with pytest.raises(AlreadyAttachedError):
             action_auto_attach(mock.MagicMock(), cfg)
 


### PR DESCRIPTION
When VMs are cloned and relaunched in Azure and AWS, instance-ids change for the new vms.
cloud-init picks up on those instance-id changes and re-runs. UA auto-attach should be cognizant of a delta in instance-id and re-attach on Pro instances.

LP: #1867573