### PR TITLE
Release/20.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,17 @@
-ubuntu-advantage-tools (20.3) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (20.3) focal; urgency=medium
 
-  * Start development on next release
+  * New upstream release 20.3:
+    - ubuntu-pro: automatically reattach across instance id delta
+      (LP: #1867573)
+    - integration testing:
+      + add behave tests ua subcommands for attached vm
+      + add invalid token tests
+      + add reuse_container test docs
+      + refactor token parameter
 
- -- Joshua Powers <josh.powers@canonical.com>  Wed, 04 Mar 2020 13:18:15 -0800
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 30 Mar 2020 14:49:17 -0600
 
-ubuntu-advantage-tools (20.2) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (20.2) focal; urgency=medium
 
   * d/templates: add a debconf note on upgrade from pre-ubuntu pro package
   * d/control: create a separate ubuntu-advantage-pro package which


### PR DESCRIPTION
Update debian/changelog to create a public focal 20.3 release

Steps performed:
* cd /tmp; git clone git@github.com:CanonicalLtd/ubuntu-advantage-client.git; cd ubuntu-advantage-client
*Fixing debian/changelog entry 20.2 as released in focal (instead of UNRELEASED)
* Curating latest commits past 20.2 and adding them to the 20.3 debian/changelog entry
   git log 20.2..HEAD | log2dch