### PR TITLE
tool: add make-release script for releasing ubuntu-advantage-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@ make demo
 ./demo/run-uaclient --series disco
 ./demo/run-uaclient --series xenial -b multipass
 ```
+
+## Releasing ubuntu-adantage-tools
+see [RELEASES.md](RELEASES.md)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,18 +6,28 @@ Below are the versioning schemes used for publishing debs:
 
 | Build target | Version Format |
 | -------- | -------- |
-| Devel series upstream release | XX.YY-<commit-revno>-g<commitish>~ubuntu1|
-| Devel series bugfix release | XX.YY.Z-<commit-revno>-g<commitish>~ubuntu1|
-| Stable series release | XX.YY-<commit-revno>-g<commitish>~ubuntu1~18.04.1|
-| [Daily Build Recipe](https://code.launchpad.net/~canonical-server/+recipe/ua-client-daily) | XX.YY-<revtime>-g<commitish>-~ubuntu1~18.04.1 |
+| Devel series upstream release | XX.YY |
+| Devel series bugfix release | XX.YY.Z~ubuntu1|
+| Stable series release | XX.YY~ubuntu1~18.04.1|
+| [Daily Build Recipe](https://code.launchpad.net/~canonical-server/+recipe/ua-client-daily) | XX.YY+<revtime>-g<commitish>~ubuntu1~18.04.1 |
+| Ubuntu PRO series release | binary copies of Daily PPA |
+
+## Supported upgrade use-cases based on version formats
+
+| Upgrade path | Version diffs |
+| LTS to LTS | 20.3~ubuntu1~14.04.1 -> 20.3~ubuntu1~16.04.1 |
+| LTS to Daily PPA | 20.3~ubuntu1~14.04.1 -> 20.3+202004011202~ubuntu1~14.04.1 |
+| Ubuntu PRO to latest <series>-updates | 20.3+202004011202~ubuntu1~14.04.1 -> 20.4~ubuntu1~14.04.1 |
+| Ubuntu PRO to Daily PPA | 20.3+202004011202~ubuntu1~14.04.1 -> 20.4+202004021202~ubuntu1~14.04.1 |
+
 
 ## Devel Release Process
 
-Below is the procedure used to release ubuntu-advantage-client:
+Below is the procedure used to release ubuntu-advantage-client to an Ubuntu series:
 
  1. create a release tarfile/changes file using uss-tableflip's build-package script
 ```
- ./tools/make-release <SERIES> <PPA_URL_FOR_TEST_UPLOADS>
+ ./tools/make-release --series <SERIES> --ppa <PPA_URL_FOR_TEST_UPLOADS>
  # follow printed procedure for dput to test PPA, and tag the released commitish
 ```
 
@@ -26,3 +36,16 @@ Below is the procedure used to release ubuntu-advantage-client:
  3. Describe the need, provide testing PPA and describe test instuctions
  4. Ping appropriate maintainer about upload and verification
  5. Validate tests, accept upload and ship it
+
+
+## Ubuntu PRO Release Process
+
+Manually perform a binary package copy from Daily PPA to Premium PPA and notify image creators
+
+ 1. [Open Daily PPA copy-package operation](https://code.launchpad.net/~canonical-server/+archive/ubuntu/ua-client-daily/+copy-packages)
+ 2. Check Trusty, Xenial, Bionic package
+ 3. Select Destination PPA: UA Client Premium [~canonical-server/ubuntu/ua-client-premium]
+ 4. Select Destination series: The same series
+ 5. Copy options: "Copy existing binaries
+ 6. Click Copy packages
+ 7. Notify Pro Image creatros about expected Premium PPA version (patviafore/rcj)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,28 @@
+# Ubuntu Advantage Client Releases
+
+## Release versioning schemes:
+
+Below are the versioning schemes used for publishing debs:
+
+| Build target | Version Format |
+| -------- | -------- |
+| Devel series upstream release | XX.YY-<commit-revno>-g<commitish>~ubuntu1|
+| Devel series bugfix release | XX.YY.Z-<commit-revno>-g<commitish>~ubuntu1|
+| Stable series release | XX.YY-<commit-revno>-g<commitish>~ubuntu1~18.04.1|
+| [Daily Build Recipe](https://code.launchpad.net/~canonical-server/+recipe/ua-client-daily) | XX.YY-<revtime>-g<commitish>-~ubuntu1~18.04.1 |
+
+## Devel Release Process
+
+Below is the procedure used to release ubuntu-advantage-client:
+
+ 1. create a release tarfile/changes file using uss-tableflip's build-package script
+```
+ ./tools/make-release <SERIES> <PPA_URL_FOR_TEST_UPLOADS>
+ # follow printed procedure for dput to test PPA, and tag the released commitish
+```
+
+ 2. Create an "upload a new version bug" in https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bugs
+
+ 3. Describe the need, provide testing PPA and describe test instuctions
+ 4. Ping appropriate maintainer about upload and verification
+ 5. Validate tests, accept upload and ship it

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-advantage-tools (20.3) focal; urgency=medium
+ubuntu-advantage-tools (20.3) UNRELEASED; urgency=medium
 
   * New upstream release 20.3:
     - ubuntu-pro: automatically reattach across instance id delta

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ubuntu-advantage-tools (20.3) UNRELEASED; urgency=medium
+ubuntu-advantage-tools (20.3) focal; urgency=medium
 
   * New upstream release 20.3:
     - ubuntu-pro: automatically reattach across instance id delta

--- a/tools/make-release
+++ b/tools/make-release
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Create a native package release of ubuntu-advantage-tools for a given series
+#
+# Because we are using native packages, we will only apply the target series to
+# the most recent debian/changelog, call build-package and attempt to dput that to
+# a PPA for test because the upstream ua-tools team members do not have the ability 
+# to upload themselves. 
+#
+# This process will change if we change from native package to non-native packaging for
+# each series.
+
+# Release version schemes are based on git describe --long and have the following format:
+# XX.YY-<commit-offset>-g<commitish>: 20.3-0-gb20e0cf
+#
+#   devel-release-versioning:
+#     - upstream release: XX.YY-<commit-offset-count>-g<commitish>~ubuntu1
+#     - bugfix only: XX.YY.Z-<commit-offset-count>-g<commitish>~ubuntu1
+#   stable-release-versioning:
+#     - upstream release: XX.YY-<commit-offset-count>-g<commitish>~ubuntu1~20.04.1
+#   daily PPA recipe: XX.YY-<revtime>-g<commitish>~ubuntu1~20.04.1
+
+CWD=$PWD
+if [ $# -ne 2 ]; then
+  echo "usage $0 <SERIES_NAME> <PPA_URL>"
+  exit 1
+fi
+which build-package
+if [ $? -ne 0 ]; then
+    echo "Missing build-package script."
+    echo "Install with 'git clone git@github.com:CanonicalLtd/uss-tableflip.git'"
+    echo "Modify PATH to include uss-tableflip/scripts"
+    exit 1
+fi
+SERIES=$1
+PPA_URL=$2
+
+
+cd /tmp
+[ -e ubuntu-advantage-client ] && rm -rf ubuntu-advantage-client
+git clone git@github.com:CanonicalLtd/ubuntu-advantage-client.git
+cd ubuntu-advantage-client
+CHANGELOG_VERSION=$(dpkg-parsechangelog -S Version)
+GIT_DESCR_LONG=$(git describe --long)
+RELEASE_NUMBER=$(distro-info --series ${SERIES} -r)
+RELEASE_VERSION_STRING="${GIT_DESCR_LONG}~ubuntu1"
+
+DEVEL_SERIES=$(distro-info --devel)
+if [ "${SERIES}" -ne "${DEVEL_SERIES}" ]; then
+  # Only append ~XX.YY.1 to stable releases
+  RELEASE_VERSION_STRING=${RELEASE_VERSION_STRING}~${RELEASE_NUMBER/ LTS/}.1
+fi
+
+sed -i "s/ubuntu-advantage-tools (${CHANGELOG_VERSION}) [[:alpha:]]\+;/ubuntu-advantage-tools (${RELEASE_VERSION_STRING}) ${SERIES};/" debian/changelog
+cp $CWD/tools/make-tarball tools/
+git add tools
+git commit -am "wip update changelog for release to ${SERIES}"
+build-package
+git reset HEAD~1
+cd $CWD
+
+cat << EOF
+---- To release ${RELEASE_VERSION_STRING} to ${SERIES} ----
+dput $PPA_URL /tmp/out/ubuntu-advantage-tools_${RELEASE_VERSION_STRING}_source.changes
+# To mark that we've released to  ${SERIES}
+git tag ${RELEASE_VERSION_STRING//\~/_}
+git push upstream ${RELEASE_VERSION_STRING//\~/_}
+EOF

--- a/tools/make-release
+++ b/tools/make-release
@@ -1,39 +1,70 @@
 #!/bin/bash
+set -ex
 #
 # Create a native package release of ubuntu-advantage-tools for a given series
+# This assumes latest debian/changelog entry version is (MM.NN) UNRELEASED.
 #
-# Because we are using native packages, we will only apply the target series to
-# the most recent debian/changelog, call build-package and attempt to dput that to
-# a PPA for test because the upstream ua-tools team members do not have the ability 
-# to upload themselves. 
+# Release this package version to devel release with the format: YY.N where
+# YY is the 2-digit year and N is a counter of public releases in that year.
 #
-# This process will change if we change from native package to non-native packaging for
-# each series.
+# When releasing to stable series, an ~ubuntu1~XX.YY.1 suffix will be added
+# where XX.YY is the release version 18.04, 16.04 etc.
 
-# Release version schemes are based on git describe --long and have the following format:
-# XX.YY-<commit-offset>-g<commitish>: 20.3-0-gb20e0cf
-#
-#   devel-release-versioning:
-#     - upstream release: XX.YY-<commit-offset-count>-g<commitish>~ubuntu1
-#     - bugfix only: XX.YY.Z-<commit-offset-count>-g<commitish>~ubuntu1
-#   stable-release-versioning:
-#     - upstream release: XX.YY-<commit-offset-count>-g<commitish>~ubuntu1~20.04.1
-#   daily PPA recipe: XX.YY-<revtime>-g<commitish>~ubuntu1~20.04.1
+# This scipt temporarily sets the appropriate version and series in the most
+# recent debian/changelog entry, runs build-package, and prints the steps
+# necessary to queue an upload for review.
 
-CWD=$PWD
-if [ $# -ne 2 ]; then
-  echo "usage $0 <SERIES_NAME> <PPA_URL>"
-  exit 1
-fi
-which build-package
+# Release version schemes are described in RELEASES.md
+
+DEVEL_SERIES=$(distro-info --devel)
+
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} --ppa PPA_URL [options]
+    Create an ubuntu-advantage-tools package release for a given series.
+
+    options:
+      -h | --help               print usage
+      -p | --ppa PPA_URL        URL of the PPA to upload to
+      -s | --series SERIES      named Ubuntu series to release. Default: $DEVEL_SERIES.
+EOF
+}
+
+
+which build-package 2>&1 > /dev/null
 if [ $? -ne 0 ]; then
     echo "Missing build-package script."
     echo "Install with 'git clone git@github.com:CanonicalLtd/uss-tableflip.git'"
     echo "Modify PATH to include uss-tableflip/scripts"
     exit 1
 fi
-SERIES=$1
-PPA_URL=$2
+
+CWD=$PWD
+
+short_opts="hp:s:"
+long_opts="help,ppa:,series:"
+getopt_out=$(getopt --name "${0##*/}" \
+    --options "${short_opts}" --long "${long_opts}" -- "$@") &&
+    eval set -- "${getopt_out}" || { Usage 1>&2; exit 1; }
+
+PPA_URL=""
+SERIES=$DEVEL_SERIES
+while [ $# -ne 0 ]; do
+    cur=$1; next=$2
+    case "$cur" in
+        -h|--help) Usage; exit 0;;
+        -p|--ppa) PPA_URL=$next; shift;;
+        -s|--series) SERIES=$next; shift;;
+        --) shift; break;;
+    esac
+    shift;
+done
+
+if [ -z "$PPA_URL" ]; then
+  echo -e "\nMissing --ppa\n"
+  Usage
+  exit 1
+fi
 
 
 cd /tmp
@@ -41,28 +72,49 @@ cd /tmp
 git clone git@github.com:CanonicalLtd/ubuntu-advantage-client.git
 cd ubuntu-advantage-client
 CHANGELOG_VERSION=$(dpkg-parsechangelog -S Version)
-GIT_DESCR_LONG=$(git describe --long)
+CHANGELOG_MAJOR=${CHANGELOG_VERSION%.*}
+CHANGELOG_MINOR=${CHANGELOG_VERSION#*.}
 RELEASE_NUMBER=$(distro-info --series ${SERIES} -r)
-RELEASE_VERSION_STRING="${GIT_DESCR_LONG}~ubuntu1"
 
-DEVEL_SERIES=$(distro-info --devel)
-if [ "${SERIES}" -ne "${DEVEL_SERIES}" ]; then
-  # Only append ~XX.YY.1 to stable releases
-  RELEASE_VERSION_STRING=${RELEASE_VERSION_STRING}~${RELEASE_NUMBER/ LTS/}.1
+YEAR=$(date +%y)
+if [ $YEAR == $CHANGELOG_MAJOR ]; then
+  # increment CHANGELOG_MINOR for this year
+  NEW_VERSION=$YEAR.$(($CHANGELOG_MINOR + 1))
+else
+  # First release of the new year
+  NEW_VERSION=$YEAR.1
 fi
 
-sed -i "s/ubuntu-advantage-tools (${CHANGELOG_VERSION}) [[:alpha:]]\+;/ubuntu-advantage-tools (${RELEASE_VERSION_STRING}) ${SERIES};/" debian/changelog
+if [ "${SERIES}" != "${DEVEL_SERIES}" ]; then
+  # Only append ~XX.YY.1 to stable releases
+  CHANGELOG_VERSION=${CHANGELOG_VERSION}~${RELEASE_NUMBER/ LTS/}.1
+fi
+
+sed -i "s/ubuntu-advantage-tools (${CHANGELOG_VERSION}) [[:alpha:]]\+;/ubuntu-advantage-tools (${CHANGELOG_VERSION}) ${SERIES};/" debian/changelog
 cp $CWD/tools/make-tarball tools/
 git add tools
-git commit -am "wip update changelog for release to ${SERIES}"
-build-package
+git commit -am "update changelog for release to ${SERIES}"
+build-package --verbose
 git reset HEAD~1
 cd $CWD
 
+TAG_EXISTS=$(git tag --list ${CHANGELOG_VERSION})
+if [ -z "${TAG_EXISTS}" ]; then
+  sed -i "s/ubuntu-advantage-tools (${CHANGELOG_VERSION}) [[:alpha:]]\+;/ubuntu-advantage-tools (${CHANGELOG_VERSION}) ${DEVEL_SERIES};/" debian/changelog
+  git commit -am "update changelog for release to ${DEVEL_SERIES}"
+  git tag -a ${CHANGELOG_VERSION}
+fi
+git checkout -b release/dev-${NEW_VERSION}
+sed -i "s/${CHANGELOG_VERSION}/${NEW_VERSION}/" uaclient/version.py
+git commit -am "open $NEW_VERSION for development"
+dch -v ${NEW_VERSION} -m "open $NEW_VERSION for development"
+git commit -am "update changelog"
+
 cat << EOF
----- To release ${RELEASE_VERSION_STRING} to ${SERIES} ----
-dput $PPA_URL /tmp/out/ubuntu-advantage-tools_${RELEASE_VERSION_STRING}_source.changes
-# To mark that we've released to  ${SERIES}
-git tag ${RELEASE_VERSION_STRING//\~/_}
-git push upstream ${RELEASE_VERSION_STRING//\~/_}
+---- To release ${CHANGELOG_VERSION} to ${SERIES} ----
+dput $PPA_URL /tmp/out/ubuntu-advantage-tools_${CHANGELOG_VERSION}_source.changes
+# Push annotated tag upstream to change daily build versions
+git push upstream ${CHANGELOG_VERSION}
+# Open ${NEW_VERSION} version for development by pushing a PR up for review
+git push <YOUR_REMOTE>  release/dev-${NEW_VERSION}
 EOF

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -1,0 +1,81 @@
+#!/bin/sh
+set -e
+
+TEMP_D=""
+cleanup() {
+    [ -z "$TEMP_D" ] || rm -Rf "${TEMP_D}"
+}
+trap cleanup EXIT
+
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} [revision]
+    create a tarball of revision (default HEAD)
+
+    options:
+      -h | --help		print usage
+      -o | --output FILE	write to file
+           --version VERSION	Set the version used in the tarball. Default value is determined with 'git describe'.
+           --orig-tarball	Write file ubuntu-advantage-tools_<version>.orig.tar.gz
+           --long		Use git describe --long for versioning
+EOF
+}
+
+short_opts="ho:v"
+long_opts="help,output:,version:,orig-tarball,long"
+getopt_out=$(getopt --name "${0##*/}" \
+    --options "${short_opts}" --long "${long_opts}" -- "$@") &&
+    eval set -- "${getopt_out}" || { Usage 1>&2; exit 1; }
+
+long_opt=""
+orig_opt=""
+output=""
+version=""
+while [ $# -ne 0 ]; do
+    cur=$1; next=$2
+    case "$cur" in
+        -h|--help) Usage; exit 0;;
+        -o|--output) output=$next; shift;;
+           --version) version=$next; shift;;
+           --long) long_opt="--long";;
+           --orig-tarball) orig_opt=".orig";;
+        --) shift; break;;
+    esac
+    shift;
+done
+
+rev=${1:-HEAD}
+if [ -z "$version" ]; then
+    version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
+elif [ ! -z "$long_opt" ]; then
+    echo "WARNING: --long has no effect when --version is passed" >&2
+    exit 1
+fi
+
+archive_base="ubuntu-advantage-tools-$version"
+if [ -z "$output" ]; then
+    if [ ! -z "$orig_opt" ]; then
+        archive_base="ubuntu-advantage-tools_$version"
+    fi
+    output="${archive_base}${orig_opt}.tar.gz"
+fi
+
+# when building an archive from HEAD, ensure that there aren't any
+# uncomitted changes in the working directory (because these would not
+# end up in the archive).
+if [ "$rev" = HEAD ] && ! git diff-index --quiet HEAD --; then
+    if [ -z "$SKIP_UNCOMITTED_CHANGES_CHECK" ]; then
+        echo "ERROR: There are uncommitted changes in your working directory." >&2
+        exit 1
+    else
+        echo "WARNING: There are uncommitted changes in your working directory." >&2
+        echo "         These changes will not be included in the archive." >&2
+    fi
+fi
+
+TEMP_D=$(mktemp -d)
+tar=${output##*/}
+tar="$TEMP_D/${tar%.gz}"
+git archive --format=tar --prefix="$archive_base/" "$rev" > "$tar"
+gzip -9 -c "$tar" > "$output"
+echo "$output"


### PR DESCRIPTION
Add scripts and doc guidance for releasing ubuntu-advantage-tools.

Generally we'll be using ./tools/make-release -p <your_PPA_URL_FOR_TESTING>

Used this branch to push to a test PPA for build and test:
sudo add-apt-repository ppa:chad.smith/test-release-ua-tools

Fixes: #1009
LP: #1869980