### PR TITLE
Add possible reboot text after enabling/disabling

### DIFF
--- a/features/attached_enable.feature
+++ b/features/attached_enable.feature
@@ -293,7 +293,8 @@ Feature: Enable command behaviour when attached to an UA subscription
     Scenario: Attached enable of vm-based services in a bionic lxd vm
         Given a `xenial` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        When I run `ua enable fips --assume-yes --beta` with sudo
+        When I run `ua disable livepatch` with sudo
+        And I run `ua enable fips --assume-yes --beta` with sudo
         Then stdout matches regexp:
             """
             Updating package lists

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -114,11 +114,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                     },
                 )
             ],
-            "post_enable": [
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="install"
-                )
-            ],
             "pre_disable": [
                 (
                     util.prompt_for_confirmation,
@@ -126,11 +121,6 @@ class FIPSEntitlement(FIPSCommonEntitlement):
                         "assume_yes": self.assume_yes,
                         "msg": status.PROMPT_FIPS_PRE_DISABLE,
                     },
-                )
-            ],
-            "post_disable": [
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="disable operation"
                 )
             ],
         }
@@ -157,11 +147,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                     },
                 )
             ],
-            "post_enable": [
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="install"
-                )
-            ],
             "pre_disable": [
                 (
                     util.prompt_for_confirmation,
@@ -169,11 +154,6 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
                         "assume_yes": self.assume_yes,
                         "msg": status.PROMPT_FIPS_PRE_DISABLE,
                     },
-                )
-            ],
-            "post_disable": [
-                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation="disable operation"
                 )
             ],
         }

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -80,6 +80,18 @@ class RepoEntitlement(base.UAEntitlement):
     def repo_key_file(self) -> str:
         pass
 
+    def check_for_reboot_msg(self, operation: str) -> None:
+        """Check if user should be alerted that a reboot must be performed.
+
+        @param operation: The operation being executed.
+        """
+        if util.should_reboot():
+            print(
+                status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
+                    operation=operation
+                )
+            )
+
     def enable(self, *, silent_if_inapplicable: bool = False) -> bool:
         """Enable specific entitlement.
 
@@ -128,6 +140,8 @@ class RepoEntitlement(base.UAEntitlement):
         msg_ops = self.messaging.get("post_enable", [])
         if not handle_message_operations(msg_ops):
             return False
+
+        self.check_for_reboot_msg(operation="install")
         return True
 
     def disable(self, silent=False):
@@ -140,6 +154,7 @@ class RepoEntitlement(base.UAEntitlement):
         msg_ops = self.messaging.get("post_disable", [])
         if not handle_message_operations(msg_ops):
             return False
+        self.check_for_reboot_msg(operation="disable operation")
         return True
 
     def _cleanup(self) -> None:

--- a/uaclient/entitlements/tests/test_cc.py
+++ b/uaclient/entitlements/tests/test_cc.py
@@ -108,12 +108,14 @@ class TestCommonCriteriaEntitlementEnable:
         "apt_transport_https,ca_certificates",
         itertools.product([False, True], repeat=2),
     )
+    @mock.patch("uaclient.util.should_reboot")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.get_platform_info")
     def test_enable_configures_apt_sources_and_auth_files(
         self,
         m_platform_info,
         m_subp,
+        m_should_reboot,
         capsys,
         tmpdir,
         apt_transport_https,
@@ -121,6 +123,7 @@ class TestCommonCriteriaEntitlementEnable:
     ):
         """When entitled, configure apt repo auth token, pinning and url."""
         m_subp.return_value = ("fakeout", "")
+        m_should_reboot.return_value = False
         original_exists = os.path.exists
 
         def fake_platform(key=None):
@@ -212,6 +215,7 @@ class TestCommonCriteriaEntitlementEnable:
         assert add_apt_calls == m_add_apt.call_args_list
         # No apt pinning for cc
         assert [] == m_add_pin.call_args_list
+        assert 1 == m_should_reboot.call_count
         assert subp_apt_cmds == m_subp.call_args_list
         expected_stdout += "\n".join(
             [

--- a/uaclient/entitlements/tests/test_cis.py
+++ b/uaclient/entitlements/tests/test_cis.py
@@ -33,10 +33,11 @@ class TestCISEntitlementCanEnable:
 
 
 class TestCISEntitlementEnable:
+    @mock.patch("uaclient.util.should_reboot")
     @mock.patch("uaclient.util.subp")
     @mock.patch("uaclient.util.get_platform_info")
     def test_enable_configures_apt_sources_and_auth_files(
-        self, m_platform_info, m_subp, capsys, entitlement
+        self, m_platform_info, m_subp, m_should_reboot, capsys, entitlement
     ):
         """When entitled, configure apt repo auth token, pinning and url."""
 
@@ -48,6 +49,7 @@ class TestCISEntitlementEnable:
 
         m_platform_info.side_effect = fake_platform
         m_subp.return_value = ("fakeout", "")
+        m_should_reboot.return_value = False
 
         with mock.patch(
             M_REPOPATH + "os.path.exists", mock.Mock(return_value=True)
@@ -91,6 +93,7 @@ class TestCISEntitlementEnable:
         # No apt pinning for cis-audit
         assert [] == m_add_pin.call_args_list
         assert subp_apt_cmds == m_subp.call_args_list
+        assert 1 == m_should_reboot.call_count
         expected_stdout = (
             "Updating package lists\n"
             "Installing CIS Audit packages\n"

--- a/uaclient/entitlements/tests/test_fips.py
+++ b/uaclient/entitlements/tests/test_fips.py
@@ -65,6 +65,7 @@ class TestFIPSEntitlementDefaults:
     ):
         """FIPS and FIPS Updates pass assume_yes into messaging args"""
         entitlement = fips_entitlement_factory(assume_yes=assume_yes)
+
         expected_msging = {
             "fips": {
                 "pre_enable": [
@@ -76,11 +77,6 @@ class TestFIPSEntitlementDefaults:
                         },
                     )
                 ],
-                "post_enable": [
-                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                        operation="install"
-                    )
-                ],
                 "pre_disable": [
                     (
                         util.prompt_for_confirmation,
@@ -88,11 +84,6 @@ class TestFIPSEntitlementDefaults:
                             "assume_yes": assume_yes,
                             "msg": status.PROMPT_FIPS_PRE_DISABLE,
                         },
-                    )
-                ],
-                "post_disable": [
-                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                        operation="disable operation"
                     )
                 ],
             },
@@ -106,11 +97,6 @@ class TestFIPSEntitlementDefaults:
                         },
                     )
                 ],
-                "post_enable": [
-                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                        operation="install"
-                    )
-                ],
                 "pre_disable": [
                     (
                         util.prompt_for_confirmation,
@@ -120,13 +106,9 @@ class TestFIPSEntitlementDefaults:
                         },
                     )
                 ],
-                "post_disable": [
-                    status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
-                        operation="disable operation"
-                    )
-                ],
             },
         }
+
         if entitlement.name in expected_msging:
             assert expected_msging[entitlement.name] == entitlement.messaging
         else:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -16,6 +16,10 @@ from http.client import HTTPMessage  # noqa: F401
 from uaclient import exceptions
 from uaclient import status
 
+
+REBOOT_FILE_CHECK_PATH = "/var/run/reboot-required"
+
+
 try:
     from typing import (  # noqa: F401
         Any,
@@ -615,3 +619,8 @@ def is_config_value_true(config: "Dict[str, Any]", path_to_value: str):
                 value=value_str,
             )
         )
+
+
+def should_reboot() -> bool:
+    """Check if the system needs to be rebooted."""
+    return os.path.exists(REBOOT_FILE_CHECK_PATH)


### PR DESCRIPTION
When enabling/disabling a repo based entitlement, we will check `/var/run/reboot-required` to verify if we should alert the user
that a reboot must take place in the system