### PR TITLE
fix: check reboot-required.pkgs to reboot

### DIFF
--- a/features/attached_commands.feature
+++ b/features/attached_commands.feature
@@ -267,6 +267,18 @@ Feature: Command behaviour when attached to an UA subscription
             """
             esm-infra    +yes      +disabled +UA Infra: Extended Security Maintenance \(ESM\)
             """
+        When I run `touch /var/run/reboot-required` with sudo
+        And I run `touch /var/run/reboot-required.pkgs` with sudo
+        And I run `ua enable esm-infra` with sudo
+        Then stdout matches regexp:
+            """
+            Updating package lists
+            UA Infra: ESM enabled
+            """
+        And stdout does not match regexp:
+            """
+            A reboot is required to complete install.
+            """
 
         Examples: ubuntu release
            | release |

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -589,12 +589,16 @@ class UAEntitlement(metaclass=abc.ABCMeta):
 
         return True
 
+    def _check_for_reboot(self) -> bool:
+        """Check if system needs to be rebooted."""
+        return util.should_reboot()
+
     def _check_for_reboot_msg(self, operation: str) -> None:
         """Check if user should be alerted that a reboot must be performed.
 
         @param operation: The operation being executed.
         """
-        if util.should_reboot():
+        if self._check_for_reboot():
             print(
                 status.MESSAGE_ENABLE_REBOOT_REQUIRED_TMPL.format(
                     operation=operation

--- a/uaclient/entitlements/repo.py
+++ b/uaclient/entitlements/repo.py
@@ -52,6 +52,10 @@ class RepoEntitlement(base.UAEntitlement):
 
         return packages
 
+    def _check_for_reboot(self) -> bool:
+        """Check if system needs to be rebooted."""
+        return util.should_reboot(installed_pkgs=set(self.packages))
+
     @property
     @abc.abstractmethod
     def repo_key_file(self) -> str:


### PR DESCRIPTION
## Proposed Commit Message
fix: check reboot-required.pkgs to reboot


During a fix operation we may install some package on the system. Those packages may require a reboot to complete their setup. Currently, we only check the existence of the /var/run/reboot-required file to notify the user that the system needs a reboot. However, that marker file could have been generated by a different package install outside of the fix operation. To address that, we are now using the /var/run/reboot-required.pkgs file to check if the packages installed during fix are on that file. Only if we have the packages there and the reboot marker file that we will ask the user to reboot the system.<!-- Include a proposed commit message because all PRs can be merged in a variety of ways by the reviewer


## Test Steps
Run the xenial fix test and the enabling FIPS VM tests to assure that we are still asking for a reboot

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
