### PR TITLE
chore: cache get_platform_info calls

### DIFF
--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -268,8 +268,13 @@ class UAContractClient(serviceclient.UAServiceClient):
         if not machine_id:
             machine_id = util.get_machine_id(self.cfg)
         platform = util.get_platform_info()
-        arch = platform.pop("arch")
-        return {"machineId": machine_id, "architecture": arch, "os": platform}
+        platform_os = platform.copy()
+        arch = platform_os.pop("arch")
+        return {
+            "machineId": machine_id,
+            "architecture": arch,
+            "os": platform_os,
+        }
 
 
 def process_entitlements_delta(

--- a/uaclient/tests/test_util.py
+++ b/uaclient/tests/test_util.py
@@ -391,7 +391,9 @@ class TestGetPlatformInfo:
         """get_platform_info errors when it cannot parse os-release."""
         m_parse.return_value = {"VERSION": "junk"}
         with pytest.raises(RuntimeError) as excinfo:
-            util.get_platform_info()
+            # Use __wrapped__ to avoid hitting the
+            # lru_cached value across tests
+            util.get_platform_info.__wrapped__()
         expected_msg = (
             "Could not parse /etc/os-release VERSION: junk (modified to junk)"
         )
@@ -437,7 +439,9 @@ class TestGetPlatformInfo:
                         ("", "", "kernel-ver", "", "aarch64")
                     )
                     m_subp.return_value = ("arm64\n", "")
-                    assert expected == util.get_platform_info()
+                    # Use __wrapped__ to avoid hitting the
+                    # lru_cached value across tests
+                    assert expected == util.get_platform_info.__wrapped__()
 
 
 class TestApplySeriesOverrides:

--- a/uaclient/util.py
+++ b/uaclient/util.py
@@ -311,6 +311,7 @@ def get_machine_id(cfg) -> str:
     return machine_id
 
 
+@lru_cache(maxsize=None)
 def get_platform_info() -> Dict[str, str]:
     """
     Returns a dict of platform information.


### PR DESCRIPTION
Per comment in #1839, cache the calls to get_platform_info.
We don't expect it to change often, and we call it here and there.

## Desired commit type
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [x] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
