### PR TITLE
fips: Disable FIPS when enabling FIPS Updates (SC-830)

### DIFF
--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -465,14 +465,11 @@ Feature: FIPS enablement in lxd VMs
            | focal   | FIPS Updates | fips-updates |https://esm.ubuntu.com/fips-updates/ubuntu focal-updates/main |
 
     @slow
-    @series.xenial
-    @series.bionic
+    @series.lts
     @uses.config.machine_type.lxd.vm
     Scenario Outline: Attached enable fips-updates on fips enabled vm
         Given a `<release>` machine with ubuntu-advantage-tools installed
         When I attach `contract_token` with sudo
-        And I run `ua disable livepatch` with sudo
-        And I run `DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y openssh-client openssh-server strongswan` with sudo, retrying exit [100]
         And I run `ua enable fips --assume-yes` with sudo
         Then stdout matches regexp:
             """
@@ -487,47 +484,61 @@ Feature: FIPS enablement in lxd VMs
             fips +yes                enabled
             """
         When I reboot the `<release>` machine
-        And  I run `ua enable fips-updates --assume-yes` with sudo
-        Then stdout matches regexp:
-            """
-            Updating package lists
-            Installing FIPS Updates packages
-            FIPS Updates enabled
-            A reboot is required to complete install
-            """
-        When I run `ua status --all` with sudo
-        Then stdout matches regexp:
-            """
-            fips +yes                n/a
-            """
-        And stdout matches regexp:
-            """
-            fips-updates +yes                enabled
-            """
-        When I reboot the `<release>` machine
-        Then I verify that running `apt update` `with sudo` exits `0`
-        And I verify that `ubuntu-fips` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-server` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-server-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `openssh-client-hmac` is installed from apt source `<fips-apt-source>`
-        And I verify that `strongswan-hmac` is installed from apt source `<fips-apt-source>`
-        When  I run `uname -r` as non-root
+        And  I run `uname -r` as non-root
         Then stdout matches regexp:
             """
             fips
             """
-        When I run `cat /proc/sys/crypto/fips_enabled` with sudo
-        Then I will see the following on stdout:
-        """
-        1
-        """
+        When I verify that running `ua enable fips-updates --assume-yes` `with sudo` exits `0`
+        Then stdout matches regexp:
+            """
+            One moment, checking your subscription first
+            Disabling incompatible service: FIPS
+            Updating package lists
+            Installing FIPS Updates packages
+            FIPS Updates enabled
+            A reboot is required to complete install.
+            """
+            When I run `ua status --all` with sudo
+            Then stdout matches regexp:
+                """
+                fips-updates +yes                enabled
+                """
+            And stdout matches regexp:
+                """
+                fips +yes                n/a
+                """
+            When I reboot the `<release>` machine
+            And  I run `ua enable livepatch` with sudo
+            And I run `ua status --all` with sudo
+            Then stdout matches regexp:
+                """
+                fips-updates +yes                enabled
+                """
+            And stdout matches regexp:
+                """
+                fips +yes                n/a
+                """
+            And stdout matches regexp:
+                """
+                livepatch +yes                enabled
+                """
+            When  I run `uname -r` as non-root
+            Then stdout matches regexp:
+                """
+                fips
+                """
+            When I run `cat /proc/sys/crypto/fips_enabled` with sudo
+            Then I will see the following on stdout:
+            """
+            1
+            """
 
         Examples: ubuntu release
-           | release | fips-apt-source                                                        |
-           | xenial  | https://esm.ubuntu.com/fips-updates/ubuntu xenial-updates/main |
-           | bionic  | https://esm.ubuntu.com/fips-updates/ubuntu bionic-updates/main |
+           | release |
+           | xenial  |
+           | bionic  |
+           | focal   |
 
     @slow
     @series.xenial

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -155,19 +155,23 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
                     )
                 )
 
-    def _check_for_reboot_msg(self, operation: str) -> None:
+    def _check_for_reboot_msg(
+        self, operation: str, silent: bool = False
+    ) -> None:
         """Check if user should be alerted that a reboot must be performed.
 
         @param operation: The operation being executed.
+        @param silent: Boolean set True to silence print/log of messages
         """
         reboot_required = util.should_reboot()
         event.needs_reboot(reboot_required)
         if reboot_required:
-            event.info(
-                messages.ENABLE_REBOOT_REQUIRED_TMPL.format(
-                    operation=operation
+            if not silent:
+                event.info(
+                    messages.ENABLE_REBOOT_REQUIRED_TMPL.format(
+                        operation=operation
+                    )
                 )
-            )
             if operation == "install":
                 self.cfg.add_notice(
                     "", messages.FIPS_SYSTEM_REBOOT_REQUIRED.msg
@@ -492,6 +496,14 @@ class FIPSUpdatesEntitlement(FIPSCommonEntitlement):
     title = "FIPS Updates"
     origin = "UbuntuFIPSUpdates"
     description = "NIST-certified core packages with priority security updates"
+
+    @property
+    def incompatible_services(self) -> Tuple[IncompatibleService, ...]:
+        return (
+            IncompatibleService(
+                FIPSEntitlement, messages.FIPS_INVALIDATES_FIPS_UPDATES
+            ),
+        )
 
     @property
     def messaging(self,) -> MessagingOperationsDict:

--- a/uaclient/messages.py
+++ b/uaclient/messages.py
@@ -668,6 +668,12 @@ FIPS_UPDATES_INVALIDATES_FIPS = NamedMessage(
     " FIPS Updates installs security patches that aren't officially"
     " certified.",
 )
+FIPS_INVALIDATES_FIPS_UPDATES = NamedMessage(
+    "fips-invalidates-fips-updates",
+    "FIPS Updates cannot be enabled if FIPS is enabled."
+    " FIPS Updates installs security patches that aren't officially"
+    " certified.",
+)
 LIVEPATCH_INVALIDATES_FIPS = NamedMessage(
     "livepatch-invalidates-fips",
     "Livepatch cannot be enabled while running the official FIPS"


### PR DESCRIPTION
## Proposed Commit Message
fips: Disable FIPS when enabling FIPS Updates

We cannot allow both FIPS and FIPS Updates in the system. FIPS Updates will not be able to hold the certification guarantees that we have for FIPS. Additionally, keeping both of these services alive will not allow us to enable Livepatch, since Livepatch cannot be enabled with FIPS. Because of that we are asking for users enabling FIPS Updates to disable FIPS to make enable process successful

## Test Steps
Run the new integration test

## Desired commit type
<!-- put an `x` in one merge type to allow the reviewer to merge for you -->
 - [ ] Squash and merge: Using the "Proposed Commit Message"
 - [ ] Create a merge commit and use "Proposed Commit Message"
 - [ ] Rebase and merge, no merge commit, rely only on existing commit messages

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly
