### PR TITLE
livepatch: check arch affordance again

### DIFF
--- a/uaclient/entitlements/livepatch.py
+++ b/uaclient/entitlements/livepatch.py
@@ -32,11 +32,13 @@ class LivepatchEntitlement(UAEntitlement):
     name = "livepatch"
     title = "Livepatch"
     description = "Canonical Livepatch service"
-    affordance_check_arch = False
     affordance_check_kernel_min_version = False
     affordance_check_kernel_flavor = False
     # we do want to check series because livepatch errors on non-lts releases
     affordance_check_series = True
+    # we still need to check arch because the livepatch-client is not built
+    # for all arches
+    affordance_check_arch = True
 
     @property
     def incompatible_services(self) -> Tuple[IncompatibleService, ...]:


### PR DESCRIPTION
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`pro attach` should not try to enable livepatch on non-amd64 systems

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any integration tests accordingly
 - [ ] I have updated or added any documentation accordingly

## Does this PR require extra reviews?
<!-- Should people outside of the team see and approve these changes before the
PR gets merged? If yes, make sure to tag them as reviewers. -->
 - [ ] Yes
 - [x] No
