### PR TITLE
ci: fix null exception in checklist actions

### DIFF
--- a/.github/actions/pr-checklist/index.js
+++ b/.github/actions/pr-checklist/index.js
@@ -104,7 +104,7 @@ function createTestUpdatesSection({
 }) {
     const header = commentSectionHeader(TEST_UPDATES);
     const footer = commentSectionFooter(TEST_UPDATES);
-    const existingSection = existingBody ? getCommentSection(TEST_UPDATES, existingBody) : null;
+    const existingSection = existingBody ? getCommentSection(TEST_UPDATES, existingBody) : "";
     const unitTestCheck = existingSection.includes(`- [x] ${unitTestsUpdated}`) ? "x" : " "
     const unitTestNotCheck = existingSection.includes(`- [x] ${unitTestsNotUpdated}`) ? "x" : " "
     const integrationTestCheck = existingSection.includes(`- [x] ${integrationTestsUpdated}`) ? "x" : " "
@@ -141,7 +141,7 @@ function createDocsSection({
 }) {
     const header = commentSectionHeader(DOCS);
     const footer = commentSectionFooter(DOCS);
-    const existingSection = existingBody ? getCommentSection(DOCS, existingBody) : null;
+    const existingSection = existingBody ? getCommentSection(DOCS, existingBody) : "";
     const docsCheck = existingSection.includes(`- [x] ${docsUpdated}`) ? "x" : " "
     const docsNotCheck = existingSection.includes(`- [x] ${docsNotUpdated}`) ? "x" : " "
     
@@ -171,7 +171,7 @@ function createExtraReviewsSection({
 }) {
     const header = commentSectionHeader(EXTRA_REVIEWS);
     const footer = commentSectionFooter(EXTRA_REVIEWS);
-    const existingSection = existingBody ? getCommentSection(EXTRA_REVIEWS, existingBody) : null;
+    const existingSection = existingBody ? getCommentSection(EXTRA_REVIEWS, existingBody) : "";
     const extraReviewsCheck = existingSection.includes(`- [x] ${extraReviewsNeeded}`) ? "x" : " "
     const extraReviewsNotCheck = existingSection.includes(`- [x] ${extraReviewsNotNeeded}`) ? "x" : " "
     

--- a/.github/actions/release-checklist/index.js
+++ b/.github/actions/release-checklist/index.js
@@ -29,7 +29,7 @@ function createBugRefsSection({
 }) {
     const header = commentSectionHeader(BUG_REFS);
     const footer = commentSectionFooter(BUG_REFS);
-    const existingSection = existingBody ? getCommentSection(BUG_REFS, existingBody) : null;
+    const existingSection = existingBody ? getCommentSection(BUG_REFS, existingBody) : "";
     const verified = existingSection ? bugRefsVerified(existingSection) : false;
     
     


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This fixes a null exception as seen at https://github.com/canonical/ubuntu-pro-client/actions/runs/9550543222/job/26322739176?pr=3155#step:4:1

<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
PR checklist should be created successffully for this PR
<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*