### PR TITLE
Fix apt-hook text output format on recent releases (resolute + )

### DIFF
--- a/apt-hook/json-hook.hh
+++ b/apt-hook/json-hook.hh
@@ -13,12 +13,18 @@ struct security_package_counts {
     long unsigned int esm_infra;
     long unsigned int esm_apps;
 };
+struct release_info {
+    std::string release; // e.g. "24.04"
+    std::string series;  // e.g. "noble"
+    bool is_lts;         // true for LTS releases
+};
 
 enum ESMType {APPS, INFRA};
 
 bool read_jsonrpc_request(std::istream &in, jsonrpc_request &req);
+release_info get_release_info();
 bool string_ends_with(std::string str, std::string ends_with);
 bool version_from_origin_and_archive_ends_with(json_object *version, std::string from_origin, std::string archive_ends_with);
 bool count_security_packages_from_apt_stats_json(json_object *stats, security_package_counts &result);
-std::string create_count_message(security_package_counts &counts);
+std::string create_count_message(security_package_counts &counts, release_info info);
 int run();

--- a/apt-hook/json-hook.test.cc
+++ b/apt-hook/json-hook.test.cc
@@ -8,42 +8,61 @@ BOOST_AUTO_TEST_SUITE(JSON_Hook)
 
 BOOST_AUTO_TEST_SUITE(Count_Message)
 
-void count_message_test(int standard_count, int infra_count, int apps_count, std::string expected_message) {
+void count_message_test(int standard_count, int infra_count, int apps_count, bool is_lts, std::string expected_message) {
     security_package_counts counts;
     counts.standard = standard_count;
     counts.esm_infra = infra_count;
     counts.esm_apps = apps_count;
-    std::string message = create_count_message(counts);
+    release_info info = {"", "", is_lts};
+    std::string message = create_count_message(counts, info);
     BOOST_CHECK(message == expected_message);
 }
 
-BOOST_AUTO_TEST_CASE(Test1) { count_message_test(0, 0, 0, ""); }
-BOOST_AUTO_TEST_CASE(Test2) { count_message_test(0, 0, 1, "1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test3) { count_message_test(0, 0, 2, "2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test4) { count_message_test(0, 1, 0, "1 esm-infra security update"); }
-BOOST_AUTO_TEST_CASE(Test5) { count_message_test(0, 1, 1, "1 esm-infra security update and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test6) { count_message_test(0, 1, 2, "1 esm-infra security update and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test7) { count_message_test(0, 2, 0, "2 esm-infra security updates"); }
-BOOST_AUTO_TEST_CASE(Test8) { count_message_test(0, 2, 1, "2 esm-infra security updates and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test9) { count_message_test(0, 2, 2, "2 esm-infra security updates and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test10) { count_message_test(1, 0, 0, "1 standard LTS security update"); }
-BOOST_AUTO_TEST_CASE(Test11) { count_message_test(1, 0, 1, "1 standard LTS security update and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test12) { count_message_test(1, 0, 2, "1 standard LTS security update and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test13) { count_message_test(1, 1, 0, "1 standard LTS security update and 1 esm-infra security update"); }
-BOOST_AUTO_TEST_CASE(Test14) { count_message_test(1, 1, 1, "1 standard LTS security update, 1 esm-infra security update and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test15) { count_message_test(1, 1, 2, "1 standard LTS security update, 1 esm-infra security update and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test16) { count_message_test(1, 2, 0, "1 standard LTS security update and 2 esm-infra security updates"); }
-BOOST_AUTO_TEST_CASE(Test17) { count_message_test(1, 2, 1, "1 standard LTS security update, 2 esm-infra security updates and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test18) { count_message_test(1, 2, 2, "1 standard LTS security update, 2 esm-infra security updates and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test19) { count_message_test(2, 0, 0, "2 standard LTS security updates"); }
-BOOST_AUTO_TEST_CASE(Test20) { count_message_test(2, 0, 1, "2 standard LTS security updates and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test21) { count_message_test(2, 0, 2, "2 standard LTS security updates and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test22) { count_message_test(2, 1, 0, "2 standard LTS security updates and 1 esm-infra security update"); }
-BOOST_AUTO_TEST_CASE(Test23) { count_message_test(2, 1, 1, "2 standard LTS security updates, 1 esm-infra security update and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test24) { count_message_test(2, 1, 2, "2 standard LTS security updates, 1 esm-infra security update and 2 esm-apps security updates"); }
-BOOST_AUTO_TEST_CASE(Test25) { count_message_test(2, 2, 0, "2 standard LTS security updates and 2 esm-infra security updates"); }
-BOOST_AUTO_TEST_CASE(Test26) { count_message_test(2, 2, 1, "2 standard LTS security updates, 2 esm-infra security updates and 1 esm-apps security update"); }
-BOOST_AUTO_TEST_CASE(Test27) { count_message_test(2, 2, 2, "2 standard LTS security updates, 2 esm-infra security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test1) { count_message_test(0, 0, 0, true, ""); }
+BOOST_AUTO_TEST_CASE(Test2) { count_message_test(0, 0, 1, true, "1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test3) { count_message_test(0, 0, 2, true, "2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test4) { count_message_test(0, 1, 0, true, "1 esm-infra security update"); }
+BOOST_AUTO_TEST_CASE(Test5) { count_message_test(0, 1, 1, true, "1 esm-infra security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test6) { count_message_test(0, 1, 2, true, "1 esm-infra security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test7) { count_message_test(0, 2, 0, true, "2 esm-infra security updates"); }
+BOOST_AUTO_TEST_CASE(Test8) { count_message_test(0, 2, 1, true, "2 esm-infra security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test9) { count_message_test(0, 2, 2, true, "2 esm-infra security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test10) { count_message_test(1, 0, 0, true, "1 standard LTS security update"); }
+BOOST_AUTO_TEST_CASE(Test11) { count_message_test(1, 0, 1, true, "1 standard LTS security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test12) { count_message_test(1, 0, 2, true, "1 standard LTS security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test13) { count_message_test(1, 1, 0, true, "1 standard LTS security update and 1 esm-infra security update"); }
+BOOST_AUTO_TEST_CASE(Test14) { count_message_test(1, 1, 1, true, "1 standard LTS security update, 1 esm-infra security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test15) { count_message_test(1, 1, 2, true, "1 standard LTS security update, 1 esm-infra security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test16) { count_message_test(1, 2, 0, true, "1 standard LTS security update and 2 esm-infra security updates"); }
+BOOST_AUTO_TEST_CASE(Test17) { count_message_test(1, 2, 1, true, "1 standard LTS security update, 2 esm-infra security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test18) { count_message_test(1, 2, 2, true, "1 standard LTS security update, 2 esm-infra security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test19) { count_message_test(2, 0, 0, true, "2 standard LTS security updates"); }
+BOOST_AUTO_TEST_CASE(Test20) { count_message_test(2, 0, 1, true, "2 standard LTS security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test21) { count_message_test(2, 0, 2, true, "2 standard LTS security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test22) { count_message_test(2, 1, 0, true, "2 standard LTS security updates and 1 esm-infra security update"); }
+BOOST_AUTO_TEST_CASE(Test23) { count_message_test(2, 1, 1, true, "2 standard LTS security updates, 1 esm-infra security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test24) { count_message_test(2, 1, 2, true, "2 standard LTS security updates, 1 esm-infra security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test25) { count_message_test(2, 2, 0, true, "2 standard LTS security updates and 2 esm-infra security updates"); }
+BOOST_AUTO_TEST_CASE(Test26) { count_message_test(2, 2, 1, true, "2 standard LTS security updates, 2 esm-infra security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test27) { count_message_test(2, 2, 2, true, "2 standard LTS security updates, 2 esm-infra security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test28) { count_message_test(1, 0, 0, false, "1 standard security update"); }
+BOOST_AUTO_TEST_CASE(Test29) { count_message_test(1, 0, 1, false, "1 standard security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test30) { count_message_test(1, 0, 2, false, "1 standard security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test31) { count_message_test(1, 1, 0, false, "1 standard security update and 1 esm-infra security update"); }
+BOOST_AUTO_TEST_CASE(Test32) { count_message_test(1, 1, 1, false, "1 standard security update, 1 esm-infra security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test33) { count_message_test(1, 1, 2, false, "1 standard security update, 1 esm-infra security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test34) { count_message_test(1, 2, 0, false, "1 standard security update and 2 esm-infra security updates"); }
+BOOST_AUTO_TEST_CASE(Test35) { count_message_test(1, 2, 1, false, "1 standard security update, 2 esm-infra security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test36) { count_message_test(1, 2, 2, false, "1 standard security update, 2 esm-infra security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test37) { count_message_test(2, 0, 0, false, "2 standard security updates"); }
+BOOST_AUTO_TEST_CASE(Test38) { count_message_test(2, 0, 1, false, "2 standard security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test39) { count_message_test(2, 0, 2, false, "2 standard security updates and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test40) { count_message_test(2, 1, 0, false, "2 standard security updates and 1 esm-infra security update"); }
+BOOST_AUTO_TEST_CASE(Test41) { count_message_test(2, 1, 1, false, "2 standard security updates, 1 esm-infra security update and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test42) { count_message_test(2, 1, 2, false, "2 standard security updates, 1 esm-infra security update and 2 esm-apps security updates"); }
+BOOST_AUTO_TEST_CASE(Test43) { count_message_test(2, 2, 0, false, "2 standard security updates and 2 esm-infra security updates"); }
+BOOST_AUTO_TEST_CASE(Test44) { count_message_test(2, 2, 1, false, "2 standard security updates, 2 esm-infra security updates and 1 esm-apps security update"); }
+BOOST_AUTO_TEST_CASE(Test45) { count_message_test(2, 2, 2, false, "2 standard security updates, 2 esm-infra security updates and 2 esm-apps security updates"); }
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -77,6 +77,32 @@ Feature: APT Messages
       | xenial  | lxd-container | apparmor=2.10.95-0ubuntu2 | curl=7.47.0-1ubuntu2 libcurl3-gnutls=7.47.0-1ubuntu2 | hello=2.10-1 |
 
   @uses.config.contract_token
+  Scenario Outline: APT JSON Hook prints package counts correctly on oracular
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
+    When I attach `contract_token` with sudo
+    When I apt upgrade
+    When I apt install `<standard-pkg-1>`
+    When I apt upgrade
+    Then stdout matches regexp:
+      """
+      Summary:
+        Upgrading: 1, Installing: 0, Removing: 0, Not Upgrading: 0
+        1 standard security update
+      """
+    When I apt install `<standard-pkg-1> <standard-pkg-2>`
+    When I apt upgrade
+    Then stdout matches regexp:
+      """
+      Summary:
+        Upgrading: 2, Installing: 0, Removing: 0, Not Upgrading: 0
+        2 standard security updates
+      """
+
+    Examples: ubuntu release
+      | release  | machine_type  | standard-pkg-1        | standard-pkg-2            |
+      | oracular | lxd-container | git=1:2.45.2-1ubuntu1 | git-man=1:2.45.2-1ubuntu1 |
+
+  @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-infra on upgrade
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I remove support for `backports` in APT
@@ -701,9 +727,10 @@ Feature: APT Messages
       Building dependency tree...
       Reading state information...
       Calculating upgrade...
-      #
-      # one
-      #
+
+      APT news:
+        one
+
       Summary:
         Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 0
       """

--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -263,8 +263,17 @@ def local_apt_news(cfg: UAConfig) -> Optional[str]:
 
 
 def format_news_for_apt_update(news: str) -> str:
+    lines = news.split("\n")
+
+    if system.get_release_info().release >= "24.10":
+        result = "\nAPT news:\n"
+        for line in lines:
+            result += "  {}\n".format(line)
+        result += "\n"
+        return result
+
     result = "#\n"
-    for line in news.split("\n"):
+    for line in lines:
         result += "# {}\n".format(line)
     result += "#\n"
     return result


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR solves all of our problems because it correctly formats apt news and apt messages for oracular.

Fixes: LP #2086753
<!--
By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing.
If your PR is small enough and you prefer, uncomment the following section and fill it out to request a squashed PR.
-->
<!--
## Please Squash this PR with this commit message

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate Launchpad bug reference if applicable)
Fixes: #NNNNNNN (replace with the appropriate github issue if applicable)
```
-->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->


---

- [x] *(un)check this to re-run the checklist action*