### PR TITLE
docs: missing backslash

### DIFF
--- a/docs/howtoguides/enable_in_dockerfile.rst
+++ b/docs/howtoguides/enable_in_dockerfile.rst
@@ -124,7 +124,7 @@ inline comments explaining each line:
       # If your container needs ca-certificates, then do not purge it from the
       # system here.
       ###########################################################################
-      && pro detach --assume-yes
+      && pro detach --assume-yes \
       && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
       #
       # Finally, we clean up the apt lists which should not be needed anymore


### PR DESCRIPTION
Dear Team,

A backslash `\` was missing after the `pro detach ...` command.

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
This PR fixes a RUN in the example Dockerfile.

Please, fix my PR if necessary.

Regards,

