### PR TITLE
Update enable_in_dockerfile.rst

### DIFF
--- a/docs/howtoguides/enable_in_dockerfile.rst
+++ b/docs/howtoguides/enable_in_dockerfile.rst
@@ -58,7 +58,7 @@ you want to invoke when running ``pro attach``. The file has two fields,
     
        sudo pro api u.pro.attach.guest.get_guest_token.v1
     
-    That command will output JSON that includes a guest token that is valid for a
+    That command will output JSON that includes a guest token that is usable only once and valid for a
     short time, during which you can use it in your Docker build.
     
     .. tip::


### PR DESCRIPTION
Specify that guest token is usable only once.

According to the spec and the code, guest tokens are usable only once.
The fact that we didn't specify this detail in the doc is confusing customers.

