### PR TITLE
Add note about cloud setup for Trusty legacy

### DIFF
--- a/docs/howtoguides/trusty_legacy_support.rst
+++ b/docs/howtoguides/trusty_legacy_support.rst
@@ -19,7 +19,7 @@ All Trusty systems come with ``ua`` pre-installed through the
     If you are running Trusty on a public cloud instance, you must install the updated
     package from this `PPA <https://launchpad.net/~ua-client/+archive/ubuntu/legacy-trusty>`_.
     Follow the instructions to add the PPA to your machine, then continue with
-    this guide
+    this guide.
 
 To make sure that you're running the latest version of ``ua``, run the following commands:
 


### PR DESCRIPTION
Add documentation that explains how to setup Trusty legacy on cloud machines