### PR TITLE
build: always use schroot mode

### DIFF
--- a/features/util.py
+++ b/features/util.py
@@ -284,6 +284,8 @@ def build_debs(
 
     sbuild_cmd = [
         "sbuild",
+        "--chroot-mode",
+        "schroot",
         "--no-run-lintian",
         "--resolve-alternatives",
         "--no-clean-source",


### PR DESCRIPTION
Builds fail when using unshare+mmdebstrap in EOSS releases (x, b, f)