### PR TITLE
fips: show correct kernel version in the downgrade message on clouds

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -248,7 +248,17 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
         our_m = re.search(
             r"(?P<kernel_version>\d+\.\d+\.\d+)", our_full_kernel_str
         )
-        fips_kernel_version_str = apt.get_pkg_candidate_version("linux-fips")
+        # This relies on the fact that fips has a single metapackage in
+        # additionalPackages. If more packages are added to additionalPackages
+        # for some reason, we fall back to "ubuntu-fips".
+        fips_package = "ubuntu-fips"
+        if len(self.packages) == 1:
+            fips_package = self.packages[0]
+
+        # We are interested in the actual kernel version
+        fips_kernel_version_str = apt.get_pkg_candidate_version(
+            fips_package.replace("ubuntu", "linux")
+        )
         if our_m is not None and fips_kernel_version_str is not None:
             our_kernel_version_str = our_m.group("kernel_version")
             LOG.debug(


### PR DESCRIPTION
## Why is this needed?
It 
Fixes: #3488

'linux-fips' was hardcoded as the package to look at. Instead, we look into whatever the backend tells us is the correct package which will be installed.

This relies on three facts that must remain true:
- There is only one metapackage for each fips flavor on VMs
- This metapackage is called ubuntu-fips or ubuntu-<something>
- The linux kernel to be installed is called linux-<something>

If something derails, the worse that can happen is, again, a wrong version in the CLI. So not much to worry about.


## Test Steps
Behave tests for this would be hell, because kernel versions tend to change and keeping track of it without mocking would be horrible.

Unit tests would be possible but unfortunately too convoluted with the current codebase. Lots of refactors before we could make a unit test really useful here.

So the best way is manually testing with the steps outlined in the linked bug, with and without this change, and confirm the fix.