### PR TITLE
upgrade: fix the apt lock logic

### DIFF
--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -59,7 +59,6 @@ Feature: Upgrade between releases when uaclient is attached
   Scenario Outline: Attached FIPS upgrade across LTS releases
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I attach `contract_token` with sudo
-    And I apt install `lsof`
     And I run `pro disable livepatch` with sudo
     And I run `pro enable <fips-service> --assume-yes` with sudo
     Then stdout contains substring:

--- a/uaclient/messages/__init__.py
+++ b/uaclient/messages/__init__.py
@@ -69,8 +69,8 @@ REBOOT_SCRIPT_FAILED = t.gettext(
     "Failed running reboot_cmds script. See: /var/log/ubuntu-advantage.log"
 )
 
-RELEASE_UPGRADE_APT_LOCK_HELD_WILL_WAIT = t.gettext(
-    "APT lock is held. Ubuntu Pro configuration will wait until it is released"
+RELEASE_UPGRADE_APT_LOCK_WAIT = t.gettext(
+    "Waiting for APT lock to start the Ubuntu Pro configuration"
 )
 RELEASE_UPGRADE_NO_PAST_RELEASE = t.gettext(
     "Could not find past release for {release}"


### PR DESCRIPTION
## Why is this needed?
We were using `lsof` to check if the apt lockfile was open before trying to perform apt operations after do-release-upgrade. This was wrong because:
- we don't Depend on lsof, and it's not seeded, which caused problems when upgrading server-minimal systems (see the LP bug)
- Just checking if the file is open generally doesn't guarantee it's locked, which could cause unecessary delays
- We check for the lock but never acquire it explicitly

The fix is actually trying to get the lock and unlocking it when the operations are finished.

LP: #2107604


## Test Steps
We have upgrade tests on behave where this issue was masked by installing `lsof` :|
That call was removed from the test - verify it passes without errors.
