### PR TITLE
tests: fix behave syntax on failing CI tests

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -4,12 +4,12 @@ Feature: Pro is expected version
   Scenario Outline: Check pro version
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `dpkg-query --showformat='${Version}' --show ubuntu-pro-client` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       $behave_var{version}
       """
     When I run `pro version` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       $behave_var{version}
       """
@@ -90,12 +90,12 @@ Feature: Pro is expected version
   Scenario Outline: Check pro version
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `dpkg-query --showformat='${Version}' --show ubuntu-pro-client` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       $behave_var{version}
       """
     When I run `pro version` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       $behave_var{version}
       """
@@ -187,12 +187,12 @@ Feature: Pro is expected version
       to get the latest bug fixes and new features.
       """
     When I run `pro api u.pro.version.v1` as non-root
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       \"code\": \"new-version-available\"
       """
     When I verify that running `pro api u.pro.version.inexistent` `as non-root` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       \"code\": \"new-version-available\"
       """

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -227,7 +227,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -239,13 +239,13 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one"
       """
     # Test that it is not shown in apt-get output
     When I apt-get upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -271,7 +271,7 @@ Feature: APT Messages
     # apt update stamp will prevent a apt_news refresh
     When I apt update
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -283,14 +283,14 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one"
       """
     # manual refresh gets new message
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -304,7 +304,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one\ntwo\nthree"
       """
@@ -317,7 +317,7 @@ Feature: APT Messages
     # the apt-news.service unit runs in the background, give it some time to fetch the json file
     When I wait `5` seconds
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -331,7 +331,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one\ntwo\nthree"
       """
@@ -354,7 +354,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -363,7 +363,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       null
       """
@@ -383,7 +383,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -392,7 +392,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       null
       """
@@ -413,7 +413,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -422,7 +422,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       null
       """
@@ -442,7 +442,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -454,7 +454,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one"
       """
@@ -475,7 +475,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -484,7 +484,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       null
       """
@@ -504,7 +504,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -513,7 +513,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       null
       """
@@ -545,7 +545,7 @@ Feature: APT Messages
     # the apt-news.service unit runs in the background, give it some time to fetch the json file
     When I wait `5` seconds
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -559,7 +559,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "CAUTION: Your Ubuntu Pro subscription will expire in 2 days.\nRenew your subscription at https://ubuntu.com/pro/dashboard to ensure\ncontinued security coverage for your applications."
       """
@@ -598,7 +598,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -611,7 +611,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your subscription at https://ubuntu.com/pro/dashboard"
       """
@@ -627,7 +627,7 @@ Feature: APT Messages
       """
     When I run `pro refresh messages` with sudo
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -640,7 +640,7 @@ Feature: APT Messages
       0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "*Your Ubuntu Pro subscription has EXPIRED*\nRenew your subscription at https://ubuntu.com/pro/dashboard"
       """
@@ -696,7 +696,7 @@ Feature: APT Messages
     When I apt upgrade
     # Plucky shows the Calculating upgrade line more than once.
     # TODO: change those tests to have different output per release.
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -708,13 +708,13 @@ Feature: APT Messages
         Upgrading: 0, Installing: 0, Removing: 0, Not Upgrading: 0
       """
     When I run shell command `pro api u.apt_news.current_news.v1 | jq .data.attributes.current_news` as non-root
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "one"
       """
     # Test that it is not shown in apt-get output
     When I apt-get upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -791,7 +791,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -820,7 +820,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Reading package lists...
       Building dependency tree...
@@ -1195,7 +1195,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1224,7 +1224,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1258,7 +1258,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1291,7 +1291,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1320,7 +1320,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     When I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1356,7 +1356,7 @@ Feature: APT Messages
     When I run `systemctl start apt-news.service` with sudo
     When I wait `5` seconds
     And I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1509,7 +1509,7 @@ Feature: APT Messages
     And I run `systemctl start apt-news.service` with sudo
     And I wait `5` seconds
     And I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1543,7 +1543,7 @@ Feature: APT Messages
     And I run `systemctl start apt-news.service` with sudo
     And I wait `5` seconds
     And I apt upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...
@@ -1563,7 +1563,7 @@ Feature: APT Messages
   Scenario Outline: APT Hook does not error when run as non-root
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run `apt upgrade --simulate` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
       """
@@ -1593,7 +1593,7 @@ Feature: APT Messages
       Get more security updates through Ubuntu Pro with 'esm-apps' enabled:
       """
     When I apt-get upgrade
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Reading package lists...
       Building dependency tree...

--- a/features/cis.feature
+++ b/features/cis.feature
@@ -45,14 +45,14 @@ Feature: Enable cis on Ubuntu
       \s* 500 https://esm.ubuntu.com/cis/ubuntu <release>/main amd64 Packages
       """
     When I verify that running `pro enable cis` `with sudo` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       One moment, checking your subscription first
       CIS Audit is already enabled - nothing to do.
       See: sudo pro status
       """
     When I run `cis-audit level1_server` with sudo
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Title.*Ensure no duplicate UIDs exist
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
@@ -64,7 +64,7 @@ Feature: Enable cis on Ubuntu
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
       Result.*fail
       """
-    And stdout matches regexp
+    And stdout matches regexp:
       """
       CIS audit scan completed
       """
@@ -76,7 +76,7 @@ Feature: Enable cis on Ubuntu
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
       Result.*pass
       """
-    And stdout matches regexp
+    And stdout matches regexp:
       """
       CIS audit scan completed
       """
@@ -122,7 +122,7 @@ Feature: Enable cis on Ubuntu
       \s* 500 https://esm.ubuntu.com/cis/ubuntu <release>/main amd64 Packages
       """
     When I verify that running `pro enable cis` `with sudo` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       One moment, checking your subscription first
       From Ubuntu 20.04 onward 'pro enable cis' has been
@@ -132,7 +132,7 @@ Feature: Enable cis on Ubuntu
       See: sudo pro status
       """
     When I run `cis-audit level1_server` with sudo
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Title.*Ensure no duplicate UIDs exist
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
@@ -144,7 +144,7 @@ Feature: Enable cis on Ubuntu
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
       Result.*fail
       """
-    And stdout matches regexp
+    And stdout matches regexp:
       """
       CIS audit scan completed
       """
@@ -156,7 +156,7 @@ Feature: Enable cis on Ubuntu
       Rule.*xccdf_com.ubuntu.<release>.cis_rule_CIS-.*
       Result.*pass
       """
-    And stdout matches regexp
+    And stdout matches regexp:
       """
       CIS audit scan completed
       """

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -377,7 +377,7 @@ Feature: CLI security-status command
       (.|\n)+
       """
     When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       usage: pro security-status [-h] [--format {json,yaml,text}]
                                  [--thirdparty | --unavailable | --esm-infra | --esm-apps]
@@ -718,7 +718,7 @@ Feature: CLI security-status command
       (.|\n)+
       """
     When I verify that running `pro security-status --thirdparty --unavailable` `as non-root` exits `2`
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       usage: pro security-status [-h] [--format {json,yaml,text}]
                                  [--thirdparty | --unavailable | --esm-infra | --esm-apps]

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -1572,85 +1572,85 @@ Feature: CLI status command
   Scenario Outline: Warn users not to redirect/pipe human readable output
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     When I run shell command `pro version | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     When I run shell command `pro version > version_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     When I run shell command `pro status | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status | cat` with sudo
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status > status_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status > status_out` with sudo
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status --format tabular | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status --format tabular > status_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro status --format json`.
       """
     When I run shell command `pro status --format json | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     When I run shell command `pro status --format json > status_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     # populate esm-cache
     When I apt update
     And I run shell command `pro security-status | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro security-status --format json`.
       """
     When I run shell command `pro security-status > status_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       WARNING: this output is intended to be human readable, and subject to change.
       In scripts, prefer using machine readable data from the `pro api` command,
       or use `pro security-status --format json`.
       """
     When I run shell command `pro security-status --format json | cat` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     When I run shell command `pro security-status --format json > status_out` as non-root
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
 

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -23,12 +23,12 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
     # verify installing pro created the cloud-id file
     When I run `cat /run/cloud-init/cloud-id` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       lxd
       """
     When I run `cat /run/cloud-init/cloud-id-lxd` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       lxd
       """
@@ -40,12 +40,12 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       (code=exited, status=0/SUCCESS)
       """
     When I run `cat /run/cloud-init/cloud-id` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       lxd
       """
     When I run `cat /run/cloud-init/cloud-id-lxd` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       lxd
       """
@@ -377,7 +377,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
   @skip_local_environment @skip_prebuilt_environment @uses.config.contract_token
   Scenario Outline: daemon should wait for cloud-config.service to finish
     # TODO: <caveat> when adding a 'noble' entry here, make sure the key is ubuntu_pro instead.
-    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
       """
       ubuntu_advantage: {}
       """

--- a/features/enable_fips_vm.feature
+++ b/features/enable_fips_vm.feature
@@ -7,7 +7,7 @@ Feature: FIPS enablement in lxd VMs
     When I attach `contract_token` with sudo
     And I run shell command `pro status --format json` with sudo
     And I apply this jq filter `.services[] | select(.name == "fips") | .blocked_by[0].reason_code` to the output
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "livepatch-invalidates-fips"
       """
@@ -55,13 +55,13 @@ Feature: FIPS enablement in lxd VMs
     And I verify that `<fips-packages>` are installed from apt source `<fips-apt-source>`
     When I run shell command `pro status --format json --all` with sudo
     And I apply this jq filter `.services[] | select(.name == "livepatch") | .available` to the output
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "no"
       """
     When I run shell command `pro status --format json --all` with sudo
     And I apply this jq filter `.services[] | select(.name == "livepatch") | .blocked_by[0].reason_code` to the output
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       "livepatch-invalidates-fips"
       """
@@ -324,7 +324,7 @@ Feature: FIPS enablement in lxd VMs
       Livepatch enabled
       """
     When I run `pro enable fips --assume-yes` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       One moment, checking your subscription first
       Disabling incompatible service: Livepatch

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -394,7 +394,7 @@ Feature: Ua fix command behaviour
       .*✘.* CVE-2017-9233 is not resolved.
       """
     When I fix `USN-5079-2` by attaching to a subscription with `contract_token_staging_expired`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       USN-5079-2: curl vulnerabilities
       Associated CVEs:

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -65,7 +65,7 @@ Feature: Pro Install and Uninstall related tests
     When I run `make -C Python-3.10.0` with sudo
     When I run `make -C Python-3.10.0 install` with sudo
     When I run `python3 --version` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       Python 3.10.0
       """
@@ -112,7 +112,7 @@ Feature: Pro Install and Uninstall related tests
 
   @skip_local_environment @skip_prebuilt_environment
   Scenario Outline: Does not cause deadlock when cloud-init installs ubuntu-advantage-tools
-    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data
+    Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:
       """
       <user_data_field>: {}
       """

--- a/features/landscape.feature
+++ b/features/landscape.feature
@@ -17,7 +17,7 @@ Feature: Enable landscape on Ubuntu
       Installing landscape-client
       Executing `landscape-config --computer-title $behave_var{machine-name sut} --account-name pro-client-qa --registration-key <REDACTED> --silent`
       """
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       Registration request sent successfully
       """
@@ -46,7 +46,7 @@ Feature: Enable landscape on Ubuntu
       """
     # Fail to enable with assume-yes
     When I verify that running `pro enable landscape --assume-yes -- --computer-title $behave_var{machine-name sut} --account-name pro-client-qa --registration-key wrong` `with sudo` exits `1`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       landscape-config command failed
       Could not enable Landscape.
@@ -79,7 +79,7 @@ Feature: Enable landscape on Ubuntu
     When I run `sudo pro disable landscape` with sudo
     # Fail to enable with assume-yes and format json
     When I verify that running `pro enable landscape --assume-yes --format=json -- --computer-title $behave_var{machine-name sut} --account-name pro-client-qa --registration-key wrong` `with sudo` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       {"_schema_version": "0.1", "errors": \[{"additional_info": {"stderr": .*, "stdout": .*}, "message": "landscape-config command failed", "message_code": "landscape-config-failed", "service": "landscape", "type": "service"}], "failed_services": \["landscape"], "needs_reboot": false, "processed_services": \[], "result": "failure", "warnings": \[]}
       """

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -278,7 +278,7 @@ Feature: Livepatch
         block_disable_on_enable: true
       """
     Then I verify that running `pro enable livepatch` `with sudo` exits `1`
-    And I will see the following on stdout
+    And I will see the following on stdout:
       """
       One moment, checking your subscription first
       Cannot enable Livepatch when FIPS is enabled.
@@ -355,7 +355,7 @@ Feature: Livepatch
     When I replace `<contract_token>` in `/lib/systemd/system/test.service` with token `contract_token`
     When I run `systemctl start test.service` with sudo
     Then I verify that running `canonical-livepatch` `with sudo` exits `1`
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       sudo: canonical-livepatch: command not found
       """

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -7,7 +7,7 @@ Feature: Logs in Json Array Formatter
     And I verify that running `pro status` `with sudo` exits `0`
     And I verify that running `pro enable test_entitlement` `with sudo` exits `1`
     And I run shell command `tail /var/log/ubuntu-advantage.log | jq -r .` <user_spec>
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
     When I attach `contract_token` with sudo
@@ -15,7 +15,7 @@ Feature: Logs in Json Array Formatter
     And I verify that running `pro status` `with sudo` exits `0`
     And I verify that running `pro enable test_entitlement` `with sudo` exits `1`
     And I run shell command `tail /var/log/ubuntu-advantage.log | jq -r .` <user_spec>
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       """
 
@@ -40,7 +40,7 @@ Feature: Logs in Json Array Formatter
     Then I verify that files exist matching `/home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log`
     When I verify `/var/log/ubuntu-advantage.log` is empty
     And I run `cat /home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log` as non-root
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Executed with sys.argv: ['/usr/bin/pro', 'status']
       """
@@ -48,7 +48,7 @@ Feature: Logs in Json Array Formatter
     And I attach `contract_token` with sudo
     And I verify `/home/ubuntu/.cache/ubuntu-pro/ubuntu-pro.log` is empty
     And I run `cat /var/log/ubuntu-advantage.log` with sudo
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Executed with sys.argv: ['/usr/bin/pro', 'attach'
       """
@@ -65,10 +65,10 @@ Feature: Logs in Json Array Formatter
 
   Scenario Outline: Non-root user log files included in collect logs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
-    When i verify that running `pro status` `with sudo` exits `0`
+    When I verify that running `pro status` `with sudo` exits `0`
     And I verify that running `pro collect-logs` `with sudo` exits `0`
     And I run `tar -tf pro_logs.tar.gz` as non-root
-    Then stdout does not contain substring
+    Then stdout does not contain substring:
       """
       user0.log
       """
@@ -76,7 +76,7 @@ Feature: Logs in Json Array Formatter
     And I verify that running `pro status` `as non-root` exits `0`
     And I verify that running `pro collect-logs` `with sudo` exits `0`
     And I run `tar -tf pro_logs.tar.gz` as non-root
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       user0.log
       """

--- a/features/proxy_config.feature
+++ b/features/proxy_config.feature
@@ -997,14 +997,14 @@ Feature: Proxy configuration
     And I run `systemctl restart snapd.service` with sudo
     # error message to install pycurl
     When I verify that running `pro config set https_proxy=https://someuser:somepassword@$behave_var{machine-name proxy}.lxd:3129` `with sudo` exits `1`
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       To use an HTTPS proxy for HTTPS connections, please install pycurl with `apt install python3-pycurl`
       """
     When I apt install `python3-pycurl`
     # error message on failed auth
     When I verify that running `pro config set https_proxy=https://someuser:wrongpassword@$behave_var{machine-name proxy}.lxd:3129` `with sudo` exits `1`
-    Then I will see the following on stderr
+    Then I will see the following on stderr:
       """
       Proxy authentication failed
       """
@@ -1024,22 +1024,22 @@ Feature: Proxy configuration
     When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
     And I attach `contract_token` with sudo and options `--no-auto-enable`
     And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       CONNECT contracts.canonical.com:443 someuser
       """
-    And stdout does not contain substring
+    And stdout does not contain substring:
       """
       error:transaction-end-before-headers
       """
     When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
     And I run `pro enable esm-infra` with sudo
     And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       CONNECT esm.ubuntu.com:443 someuser
       """
-    And stdout does not contain substring
+    And stdout does not contain substring:
       """
       error:transaction-end-before-headers
       """
@@ -1050,18 +1050,18 @@ Feature: Proxy configuration
     When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
     And I run `pro enable livepatch` with sudo
     And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       CONNECT api.snapcraft.io:443 someuser
       """
-    And stdout does not contain substring
+    And stdout does not contain substring:
       """
       error:transaction-end-before-headers
       """
     When I run `truncate -s 0 /var/log/squid/access.log` `with sudo` on the `proxy` machine
     And I apt install `hello`
     And I run `cat /var/log/squid/access.log` `with sudo` on the `proxy` machine
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       CONNECT esm.ubuntu.com:443 someuser
       """

--- a/features/realtime_kernel.feature
+++ b/features/realtime_kernel.feature
@@ -91,7 +91,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
       {"_schema_version": "v1", "data": {"attributes": {"enabled_services": \[{"name": "realtime-kernel", "variant_enabled": true, "variant_name": "generic"}\]}, "meta": {"environment_vars": \[\]}, "type": "EnabledServices"}, "errors": \[\], "result": "success", "version": ".*", "warnings": \[\]}
       """
     When I verify that running `pro enable realtime-kernel` `with sudo` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       One moment, checking your subscription first
       Real-time kernel is already enabled - nothing to do.
@@ -119,7 +119,7 @@ Feature: Enable command behaviour when attached to an Ubuntu Pro subscription
               but you must ensure this is correct before running it.
       """
     When I run `apt-cache policy ubuntu-realtime` as non-root
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Installed: (none)
       """

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -85,7 +85,7 @@ Feature: auto-attach retries periodically on failures
     When I run `systemctl restart ubuntu-advantage.service` with sudo
     And I wait `5` seconds
     Then I verify that running `systemctl status ubuntu-advantage.service` `with sudo` exits `3`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Active: inactive (dead)
       """
@@ -209,7 +209,7 @@ Feature: auto-attach retries periodically on failures
     When I run `systemctl restart ubuntu-advantage.service` with sudo
     And I wait `5` seconds
     Then I verify that running `systemctl status ubuntu-advantage.service` `with sudo` exits `3`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Active: inactive (dead)
       """
@@ -304,7 +304,7 @@ Feature: auto-attach retries periodically on failures
     # _should_ run and finish before the retry service has done anything
     When I run `pro auto-attach` with sudo
     When I verify that running `systemctl status ubuntu-advantage.service` `as non-root` exits `3`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Active: inactive (dead)
       """
@@ -368,7 +368,7 @@ Feature: auto-attach retries periodically on failures
     When I run `systemctl start ubuntu-advantage.service` with sudo
     When I wait `1` seconds
     When I verify that running `systemctl status ubuntu-advantage.service` `as non-root` exits `0`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Active: active (running)
       """
@@ -463,7 +463,7 @@ Feature: auto-attach retries periodically on failures
     And I run `pro status --wait` with sudo
     Then the machine is attached
     When I verify that running `systemctl status ubuntu-advantage.service` `as non-root` exits `3`
-    Then stdout contains substring
+    Then stdout contains substring:
       """
       Active: inactive (dead)
       """

--- a/features/ros.feature
+++ b/features/ros.feature
@@ -10,13 +10,13 @@ Feature: Enable ROS on ubuntu
     And I verify that `esm-apps` is enabled
     And I verify that `esm-infra` is enabled
     When I verify that running `pro disable esm-apps` `with sudo` and stdin `N` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       ROS ESM Security Updates depends on Ubuntu Pro: ESM Apps.
       Disable ROS ESM Security Updates and proceed to disable Ubuntu Pro: ESM Apps\? \(y\/N\) Cannot disable Ubuntu Pro: ESM Apps when ROS ESM Security Updates is enabled.
       """
     When I run `pro disable esm-apps` `with sudo` and stdin `y`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       ROS ESM Security Updates depends on Ubuntu Pro: ESM Apps.
       Disable ROS ESM Security Updates and proceed to disable Ubuntu Pro: ESM Apps\? \(y\/N\) Disabling dependent service: ROS ESM Security Updates
@@ -28,13 +28,13 @@ Feature: Enable ROS on ubuntu
     And I verify that `ros` is disabled
     And I verify that `esm-apps` is disabled
     When I verify that running `pro enable ros` `with sudo` and stdin `N` exits `1`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       ROS ESM Security Updates cannot be enabled with Ubuntu Pro: ESM Apps disabled.
       Enable Ubuntu Pro: ESM Apps and proceed to enable ROS ESM Security Updates\? \(y\/N\) Cannot enable ROS ESM Security Updates when Ubuntu Pro: ESM Apps is disabled.
       """
     When I run `pro enable ros` `with sudo` and stdin `y`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       One moment, checking your subscription first
       ROS ESM Security Updates cannot be enabled with Ubuntu Pro: ESM Apps disabled.
@@ -65,7 +65,7 @@ Feature: Enable ROS on ubuntu
     When I apt install `python3-catkin-pkg`
     Then I verify that `python3-catkin-pkg` is installed from apt source `<ros-updates-source>`
     When I run `pro disable ros` `with sudo` and stdin `y`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       ROS ESM All Updates depends on ROS ESM Security Updates.
       Disable ROS ESM All Updates and proceed to disable ROS ESM Security Updates\? \(y\/N\) Disabling dependent service: ROS ESM All Updates
@@ -76,7 +76,7 @@ Feature: Enable ROS on ubuntu
       """
     And I verify that `ros-updates` is disabled
     When I run `pro enable ros-updates` `with sudo` and stdin `y`
-    Then stdout matches regexp
+    Then stdout matches regexp:
       """
       One moment, checking your subscription first
       ROS ESM All Updates cannot be enabled with ROS ESM Security Updates disabled.

--- a/features/steps/files.py
+++ b/features/steps/files.py
@@ -31,7 +31,7 @@ def when_i_push_file(context, file_name, machine_name=SUT):
     )
 
 
-@when("I add this text on `{file_name}` on `{machine_name}` above `{line}`")
+@when("I add this text on `{file_name}` on `{machine_name}` above `{line}`:")
 def when_i_add_this_text_on_file_above_line(
     context, file_name, machine_name, line
 ):

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -273,7 +273,7 @@ def given_a_sut_machine(context, series, machine_type):
 
 
 @given(
-    "a `{series}` `{machine_type}` machine with ubuntu-advantage-tools installed adding this cloud-init user_data"  # noqa: E501
+    "a `{series}` `{machine_type}` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:"  # noqa: E501
 )
 def given_a_sut_machine_with_user_data(context, series, machine_type):
     # doesn't support snapshot strategy because the test depends on

--- a/features/yaml.feature
+++ b/features/yaml.feature
@@ -61,7 +61,7 @@ Feature: YAML related interactions with Pro client
     # Known crash that can happen but we don't care about for this test because it isn't pro related
     When I run shell command `rm -f /var/crash/_usr_bin_cloud-id.*.crash` with sudo
     When I run `ls /var/crash` with sudo
-    Then I will see the following on stdout
+    Then I will see the following on stdout:
       """
       """
 


### PR DESCRIPTION
## Why is this needed?
The behave lib was updated recently and now the step matching is more strict. This mean that if a step has a colon at the end, that colon should also be reflected on the step implementation as well.

Of course there may be other steps we are not fixing here and will only be caught in a full run but this at least will make CI happier

## Test Steps
See the CI and verify there are no 'not implemented' steps.