### PR TITLE
apparmor: adjust apparmor profiles to cope with coreutils paths

### DIFF
--- a/debian/apparmor/ubuntu_pro_apt_news.jinja2
+++ b/debian/apparmor/ubuntu_pro_apt_news.jinja2
@@ -33,7 +33,10 @@ profile ubuntu_pro_apt_news flags=(attach_disconnected) {
   /{,usr/}bin/python3.{1,}[0-9] mrix,
   # "import uuid" in focal triggers an uname call
   # And also see LP: #2067319
-  /{,usr/}bin/uname mrix,
+  # We are not using the variable @{coreutil_dirs} because it's only
+  # available in questing and this package is usually backported to
+  # older releases. (LP: #2123870)
+  /{bin/,usr/bin/,usr/bin/gnu,usr/lib/cargo/bin/coreutils/}uname mrix,
 
   /{,usr/}lib/apt/methods/http mrix,
   /{,usr/}lib/apt/methods/https mrix,

--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -41,8 +41,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
   /{,usr/}bin/apt-cache mrix,
   /{,usr/}bin/ischroot mrix,
   /{,usr/}bin/python3.{1,}[0-9] mrix,
-  # LP: #2067319
-  /{,usr/}bin/uname mrix,
+  # LP: #2067319, #2123870
+  /{bin/,usr/bin/,usr/bin/gnu,usr/lib/cargo/bin/coreutils/}uname mrix,
 
   /{,usr/}bin/cloud-id Cx -> cloud_id,
   # LP: #2067319
@@ -138,8 +138,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /{,usr/}bin/ r,
     /{,usr/}bin/cloud-id r,
     /{,usr/}bin/python3.{1,}[0-9] mrix,
-    # LP: #2067319
-    /{,usr/}bin/uname mrix,
+    # LP: #2067319, #2123870
+    /{bin/,usr/bin/,usr/bin/gnu,usr/lib/cargo/bin/coreutils/}uname mrix,
 
     /usr/share/dpkg/** r,
 
@@ -242,7 +242,8 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     # there are just too many shell script tools that are called, like head,
     # tail, cut, sed, etc
-    /{,usr/}bin/* mrix,
+    # LP: #2123870
+    /{bin/,usr/bin/,usr/bin/gnu,usr/lib/cargo/bin/coreutils/}* mrix,
 
     /{,usr/}lib/apt/methods/gpgv mr,
 


### PR DESCRIPTION
Due to Rust coreutils in questing, some AppArmor policy is affected due to the change in path and symlinks.
Instead of using the @{coreutil_dirs} variable, which is available only on apparmor 5.0.0~alpha1-0ubuntu7, we are using the hardcoded path. This is because this project is usually backported to older releases and that will maintain compatibility.

Fixes: https://bugs.launchpad.net/bugs/2123870

Tested with version in PPA 
https://launchpad.net/~georgiag/+archive/ubuntu/apparmor-coreutils
