### PR TITLE
fix: apparmor denied audit messages when devicetree exists

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -329,5 +329,5 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     @{PROC}/sys/kernel/osrelease r,
 
     # LP: #2131292
-    /sys/firmware/dmi/entries/** r,
+    /sys/firmware/dmi/entries/0-0/raw r,
   }


### PR DESCRIPTION

Fixes: http://bugs.launchpad.net/bugs/2131292

## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
The esm_cache.py script will try to read from
/sys/firmware/devicetree/base/model when /var/lib/ubuntu-advantage/status.json is not present. On devices without a device tree, the script will simply print an info message that the file can't be found but on devices with a device tree, it will generate an apparmor denied audit message as the apparmor rules don't allow access to this file.

Furthermore, the first run of esm-cache.servce after removal of status.json, will generate an additional apparmor denied audit message when systemd-detect-virt is run.

Therefore, add the appropriate rules to the ubuntu_pro_esm_cache and the ubuntu_pro_esm_cache_systemd_detect_virt apparmor profiles.

<!-- By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing. If your PR is small enough and you prefer, you can write a suggested commit message here and request a squashed PR. -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if this is a bug fix) this change on a live deployed system, including any necessary configuration files, user-data, setup, and teardown. Scripts used may be attached directly to this PR. -->

```
# remove status.json
sudo rm -f /usr/lib/ubuntu-advantage/status.json
# restart esm-cache.service
sudo systemctl start --no-block esm-cache.service
# check that no new apparmor denied audit message is printed for devicetree or dmi entries
sudo dmesg | grep apparmor | grep ubuntu_pro
```
