### PR TITLE
fix: keep fips package on disable/detach to prevent boot failure

### DIFF
--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -549,23 +549,6 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
             messages.FIPS_REBOOT_REQUIRED,
         )
 
-    def remove_packages(self) -> None:
-        """Remove fips meta package to disable the service.
-
-        FIPS meta-package will unset grub config options which will deactivate
-        FIPS on any related packages.
-        """
-        installed_packages = set(apt.get_installed_packages_names())
-        fips_metapackage = set(self.packages).difference(
-            set(self.conditional_packages)
-        )
-        remove_packages = fips_metapackage.intersection(installed_packages)
-        if remove_packages:
-            apt.remove_packages(
-                list(fips_metapackage),
-                messages.DISABLE_FAILED_TMPL.format(title=self.title),
-            )
-
     def _perform_enable(self, progress: api.ProgressWrapper) -> bool:
         if super()._perform_enable(progress):
             notices.remove(


### PR DESCRIPTION
## Why is this needed?

Removing the FIPS package (ubuntu-fips, ubuntu-aws-fips, ubuntu-azure-fips, ubuntu-gcp-fips) during disable/detach causes its removal scripts to unset fips=1 and blockdev kernel boot parameters from grub configuration, which leads to boot failure on Noble (24.04) where initramfs performs strict FIPS integrity checks.

LP: #2140749


## Test Steps
1. Attach a Noble (24.04) machine to an Ubuntu Pro subscription
2. pro enable fips
3. Reboot (required for FIPS activation)
4. pro detach
5. Reboot
6. stuck while boot because can't find bootdev