### PR TITLE
fix: suppress upgrade hint for phased packages

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -342,6 +342,9 @@ def get_pkg_candidate_version(
         if not candidate:
             return None
 
+        if not dep_cache.phasing_applied(package):
+            return None
+
         candidate_version = candidate.ver_str
 
     if not check_esm_cache:

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -1346,6 +1346,42 @@ class TestGetPkgCandidateversion:
         actual_value = get_pkg_candidate_version("pkg1", check_esm_cache=True)
         assert "1.2" == actual_value
 
+    @mock.patch("uaclient.apt.apt_pkg.DepCache")
+    @mock.patch("uaclient.apt.get_apt_pkg_cache")
+    def test_get_pkg_candidate_version_when_phased(
+        self,
+        m_apt_cache,
+        m_dep_cache,
+    ):
+        """Return None when candidate exists but phasing is not yet applied."""
+        m_pkg = mock.MagicMock()
+        m_apt_cache.return_value = {"pkg1": m_pkg}
+        m_dep_cache.return_value.get_candidate_ver.return_value = (
+            mock.MagicMock(ver_str="1.2")
+        )
+        m_dep_cache.return_value.phasing_applied.return_value = False
+
+        actual_value = get_pkg_candidate_version("pkg1")
+        assert actual_value is None
+
+    @mock.patch("uaclient.apt.apt_pkg.DepCache")
+    @mock.patch("uaclient.apt.get_apt_pkg_cache")
+    def test_get_pkg_candidate_version_when_phasing_complete(
+        self,
+        m_apt_cache,
+        m_dep_cache,
+    ):
+        """Return candidate version when phasing is fully applied."""
+        m_pkg = mock.MagicMock()
+        m_apt_cache.return_value = {"pkg1": m_pkg}
+        m_dep_cache.return_value.get_candidate_ver.return_value = (
+            mock.MagicMock(ver_str="1.2")
+        )
+        m_dep_cache.return_value.phasing_applied.return_value = True
+
+        actual_value = get_pkg_candidate_version("pkg1")
+        assert actual_value == "1.2"
+
     @mock.patch("uaclient.apt.get_apt_pkg_cache")
     def test_get_pkg_candidate_version_when_package_doesnt_exist(
         self,


### PR DESCRIPTION
## Problem

When a newer `ubuntu-pro-client` version exists but is held back by Debian's phased rollout, `pro status` still displays:

```
[info] A new version is available: 32.3.1~24.04
Please run: sudo apt install ubuntu-pro-client
```

This is misleading — the user cannot actually install the update yet, as `apt-cache policy` shows it as `(phased 60%)`.

Fixes #3192

## Root Cause

`get_pkg_candidate_version()` in `uaclient/apt.py` calls `dep_cache.get_candidate_ver(package)` which returns the candidate version regardless of phasing status.

## Fix

After retrieving the candidate, check `dep_cache.phasing_applied(package)` — the official `apt_pkg` API that returns `False` when the phased update is not yet applicable to this machine. If not applicable, return `None` to suppress the hint.

## Tests

Added two new test cases to `TestGetPkgCandidateversion`:
- `test_get_pkg_candidate_version_when_phased` — verifies `None` is returned when phasing is not applied
- `test_get_pkg_candidate_version_when_phasing_complete` — verifies the version is returned normally when phasing is complete