### PR TITLE
fix: add DMI path to esm-cache AppArmor profile

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -78,6 +78,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
   # LP: #2131292
   /sys/firmware/devicetree/base/model r,
+  /sys/firmware/dmi/entries/0-0/raw r,
 
 {% if ubuntu_codename in ["bionic", "xenial"] %}
   # see https://bugs.python.org/issue40501


### PR DESCRIPTION
## Why is this needed?
This is an extension of the work in [PR #3515](https://github.com/canonical/ubuntu-pro-client/pull/3515) to address [LP: #2131292](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2131292).

Similar to the Device Tree issue, the esm_cache.py script attempts to read hardware identification files when /var/lib/ubuntu-advantage/status.json is not present. While #3515 addressed the ARM case (`/sys/firmware/devicetree/base/model`), the script performs an equivalent read on x86 platforms via `/sys/firmware/dmi/entries/0-0/raw`.

Currently, this DMI path is only permitted within the systemd_detect_virt sub-profile. This results in an AppArmor denial when the main esm-cache.service (running under the ubuntu_pro_esm_cache profile) attempts to read the file directly.

## Test Steps
Build the package
```
./tools/build.sh noble
```
Run the AppArmor verification script
```
git checkout sru-test
./sru/release-37/test-apparmor-firmware-access.sh noble /path/to/built/ubuntu-pro-client.deb
```