### PR TITLE
test: add check for DMI path

### DIFF
--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -17,7 +17,6 @@ function on_err {
 }
 trap on_err ERR
 
-
 lxc launch ubuntu-daily:$series $name -c security.nesting=true -c security.privileged=true
 sleep 5
 
@@ -27,7 +26,7 @@ lxc exec $name -- apt-get install -y ubuntu-advantage-tools > /dev/null
 echo -e "\n* Current ubuntu-advantage-tools installed"
 echo "###########################################"
 lxc exec $name -- apt-cache policy ubuntu-advantage-tools
-echo -e "###########################################\n"
+echo "###########################################\n"
 
 APPARMOR_PROFILE=/etc/apparmor.d/ubuntu_pro_esm_cache
 
@@ -47,81 +46,32 @@ fi
 # ----------------------------------------------------------------
 
 echo "Setting up hardware mocks to trigger AppArmor..."
-
 lxc exec $name -- bash -c "
-  # 1. Force the code path
-  rm -f /var/lib/ubuntu-advantage/status.json
-  
-  # 2. Create the writeable canvas
-  # We mount a tmpfs over /sys/firmware so we can create directories
   mount -t tmpfs tmpfs /sys/firmware
-  
-  # 3. Re-create the hardware structure
   mkdir -p /sys/firmware/devicetree/base/
   mkdir -p /sys/firmware/dmi/entries/0-0/
-  
-  # 4. Create the dummy hardware ID files
   echo 'Mock Model' > /sys/firmware/devicetree/base/model
   echo 'Mock DMI' > /sys/firmware/dmi/entries/0-0/raw
 "
 
-# --- Run the esm-cache service and check for AppArmor denials ---
-echo ""
-echo "=== Running esm-cache service under the AppArmor profile ==="
+echo "=== Ensuring AppArmor profile is loaded ==="
+lxc exec $name -- apparmor_parser -r $APPARMOR_PROFILE
 
-# Ensure apparmor is enforcing the profile
-lxc exec $name -- apparmor_parser -r $APPARMOR_PROFILE || true
+echo "=== Verifying Devicetree path (main profile) ==="
+# If this fails, set -e triggers on_err
+lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()"
 
-# Clear the journal log so we only inspect fresh messages
-lxc exec $name -- journalctl --rotate > /dev/null 2>&1 || true
-lxc exec $name -- journalctl --vacuum-time=1s > /dev/null 2>&1 || true
-
-lxc exec $name -- systemctl start esm-cache.service || true
-sleep 3
-
-# --- Verification ---
-echo "=== Testing AppArmor Policy Enforcement ==="
-
-# 1. Check Devicetree path under the main profile
-# This works because 'ubuntu_pro_esm_cache' includes <abstractions/python>
-echo "Testing: ubuntu_pro_esm_cache -> /sys/firmware/devicetree/base/model"
-if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
-  echo "FAILED: AppArmor profile DENIED access to the devicetree path."
-  lxc exec $name -- dmesg | grep "apparmor=\"DENIED\"" | grep "ubuntu_pro_esm_cache" | tail -n 5
-  cleanup
-  exit 1
-fi
-echo "  - OK"
-
-# 2. Check DMI path under the systemd-detect-virt profile
-# PROBLEM: This profile doesn't allow python. 
-# SOLUTION: Temporarily replace systemd-detect-virt with cat to test the path.
-echo "Testing: ubuntu_pro_esm_cache_systemd_detect_virt -> /sys/firmware/dmi/entries/0-0/raw"
-
-# Backup the real binary and replace it with 'cat'
+echo "=== Verifying DMI path (systemd-detect-virt profile) ==="
+# We swap cat in to test the path within the restricted profile context
 lxc exec $name -- mv /usr/bin/systemd-detect-virt /usr/bin/systemd-detect-virt.bak
 lxc exec $name -- cp /usr/bin/cat /usr/bin/systemd-detect-virt
 
-# Now we run our 'fake' systemd-detect-virt under the sub-profile.
-# Since the profile allows this binary name and 'cat' is simple enough 
-# to run with abstractions/base, this should succeed.
-if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache_systemd_detect_virt systemd-detect-virt /sys/firmware/dmi/entries/0-0/raw > /dev/null 2>&1; then
-  echo "FAILED: AppArmor profile DENIED access to the DMI path."
-  echo "Showing recent AppArmor denials from dmesg:"
-  lxc exec $name -- dmesg | grep "apparmor=\"DENIED\"" | grep "systemd_detect_virt" | tail -n 5
-  # Restore and fail
-  lxc exec $name -- mv /usr/bin/systemd-detect-virt.bak /usr/bin/systemd-detect-virt
-  cleanup
-  exit 1
-fi
+# If aa-exec returns 1 (denied), the script stops here and calls on_err
+lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache_systemd_detect_virt systemd-detect-virt /sys/firmware/dmi/entries/0-0/raw > /dev/null
 
-# Restore the original binary
+# Clean up the swap (optional since cleanup deletes the LXC, but good practice)
 lxc exec $name -- mv /usr/bin/systemd-detect-virt.bak /usr/bin/systemd-detect-virt
 
-echo "  - OK"
-echo ""
-echo "------------------------------------------------------------"
-echo "PASSED: All firmware paths are accessible under correct profiles."
-echo "------------------------------------------------------------"
+echo -e "\n=== Test PASSED ==="
 
 cleanup

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -81,30 +81,21 @@ sleep 3
 
 # --- Verification ---
 echo "=== Testing AppArmor Policy Enforcement ==="
-echo "Attempting to read firmware paths under profile: $APPARMOR_PROFILE"
+echo "Attempting to read /sys/firmware/devicetree/base/model under profile: $APPARMOR_PROFILE"
 
-# Check both the Device Tree and DMI paths mocked earlier
-PATHS_TO_TEST="/sys/firmware/devicetree/base/model /sys/firmware/dmi/entries/0-0/raw"
-
-if lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "
-import sys
-paths = '$PATHS_TO_TEST'.split()
-for p in paths:
-    try:
-        open(p).read()
-        print(f'SUCCESS: Read {p}')
-    except Exception as e:
-        print(f'FAILURE: Could not read {p} - {e}')
-        sys.exit(1)
-" ; then
+# Capture the attempt. We use 'aa-exec' to force the security profile.
+if lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
   echo "------------------------------------------------------------"
-  echo "PASSED: AppArmor profile ALLOWED access to all firmware paths."
+  echo "PASSED: AppArmor profile ALLOWED access to the firmware path."
+  echo "The whitelist is correctly functioning for this package."
   echo "------------------------------------------------------------"
   cleanup
   exit 0
 else
   echo "------------------------------------------------------------"
-  echo "FAILED: AppArmor profile DENIED access to one or more paths."
+  echo "FAILED: AppArmor profile DENIED access to the firmware path."
+  echo "The kernel blocked the read request (Permission Denied)."
+  echo "Note: On an unfixed 'prefix' package, this failure confirms the bug is present."
   echo "------------------------------------------------------------"
   cleanup
   exit 1

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -47,6 +47,7 @@ fi
 
 echo "Setting up hardware mocks to trigger AppArmor..."
 lxc exec $name -- bash -c "
+  rm -f /var/lib/ubuntu-advantage/status.json
   mount -t tmpfs tmpfs /sys/firmware
   mkdir -p /sys/firmware/devicetree/base/
   mkdir -p /sys/firmware/dmi/entries/0-0/

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# NOTE: LXC is an unsuitable way to get comprehensive testing for AppArmor 
+# fixes for LP: #2131292. This is not a comprehensive test; we are 
+# specifically emulating the read behavior to verify the profile.
+# TODO: Revisit this test in the future if environment improvements allow.
+
 series=$1
 install_from=$2  # either path to a .deb, or 'staging', or 'proposed'
 

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -83,21 +83,43 @@ sleep 3
 echo "=== Testing AppArmor Policy Enforcement ==="
 
 # 1. Check Devicetree path under the main profile
+# This works because 'ubuntu_pro_esm_cache' includes <abstractions/python>
 echo "Testing: ubuntu_pro_esm_cache -> /sys/firmware/devicetree/base/model"
 if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
   echo "FAILED: AppArmor profile DENIED access to the devicetree path."
+  lxc exec $name -- dmesg | grep "apparmor=\"DENIED\"" | grep "ubuntu_pro_esm_cache" | tail -n 5
   cleanup
   exit 1
 fi
+echo "  - OK"
 
-# 2. Check DMI path under the systemd-detect-virt transition profile
+# 2. Check DMI path under the systemd-detect-virt profile
+# PROBLEM: This profile doesn't allow python. 
+# SOLUTION: Temporarily replace systemd-detect-virt with cat to test the path.
 echo "Testing: ubuntu_pro_esm_cache_systemd_detect_virt -> /sys/firmware/dmi/entries/0-0/raw"
-if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache_systemd_detect_virt python3 -c "open('/sys/firmware/dmi/entries/0-0/raw').read()" > /dev/null 2>&1; then
+
+# Backup the real binary and replace it with 'cat'
+lxc exec $name -- mv /usr/bin/systemd-detect-virt /usr/bin/systemd-detect-virt.bak
+lxc exec $name -- cp /usr/bin/cat /usr/bin/systemd-detect-virt
+
+# Now we run our 'fake' systemd-detect-virt under the sub-profile.
+# Since the profile allows this binary name and 'cat' is simple enough 
+# to run with abstractions/base, this should succeed.
+if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache_systemd_detect_virt systemd-detect-virt /sys/firmware/dmi/entries/0-0/raw > /dev/null 2>&1; then
   echo "FAILED: AppArmor profile DENIED access to the DMI path."
+  echo "Showing recent AppArmor denials from dmesg:"
+  lxc exec $name -- dmesg | grep "apparmor=\"DENIED\"" | grep "systemd_detect_virt" | tail -n 5
+  # Restore and fail
+  lxc exec $name -- mv /usr/bin/systemd-detect-virt.bak /usr/bin/systemd-detect-virt
   cleanup
   exit 1
 fi
 
+# Restore the original binary
+lxc exec $name -- mv /usr/bin/systemd-detect-virt.bak /usr/bin/systemd-detect-virt
+
+echo "  - OK"
+echo ""
 echo "------------------------------------------------------------"
 echo "PASSED: All firmware paths are accessible under correct profiles."
 echo "------------------------------------------------------------"

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -81,21 +81,30 @@ sleep 3
 
 # --- Verification ---
 echo "=== Testing AppArmor Policy Enforcement ==="
-echo "Attempting to read /sys/firmware/devicetree/base/model under profile: $APPARMOR_PROFILE"
+echo "Attempting to read firmware paths under profile: $APPARMOR_PROFILE"
 
-# Capture the attempt. We use 'aa-exec' to force the security profile.
-if lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
+# Check both the Device Tree and DMI paths mocked earlier
+PATHS_TO_TEST="/sys/firmware/devicetree/base/model /sys/firmware/dmi/entries/0-0/raw"
+
+if lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "
+import sys
+paths = '$PATHS_TO_TEST'.split()
+for p in paths:
+    try:
+        open(p).read()
+        print(f'SUCCESS: Read {p}')
+    except Exception as e:
+        print(f'FAILURE: Could not read {p} - {e}')
+        sys.exit(1)
+" ; then
   echo "------------------------------------------------------------"
-  echo "PASSED: AppArmor profile ALLOWED access to the firmware path."
-  echo "The whitelist is correctly functioning for this package."
+  echo "PASSED: AppArmor profile ALLOWED access to all firmware paths."
   echo "------------------------------------------------------------"
   cleanup
   exit 0
 else
   echo "------------------------------------------------------------"
-  echo "FAILED: AppArmor profile DENIED access to the firmware path."
-  echo "The kernel blocked the read request (Permission Denied)."
-  echo "Note: On an unfixed 'prefix' package, this failure confirms the bug is present."
+  echo "FAILED: AppArmor profile DENIED access to one or more paths."
   echo "------------------------------------------------------------"
   cleanup
   exit 1

--- a/sru/release-37/test-apparmor-firmware-access.sh
+++ b/sru/release-37/test-apparmor-firmware-access.sh
@@ -81,24 +81,25 @@ sleep 3
 
 # --- Verification ---
 echo "=== Testing AppArmor Policy Enforcement ==="
-echo "Attempting to read /sys/firmware/devicetree/base/model under profile: $APPARMOR_PROFILE"
 
-# Capture the attempt. We use 'aa-exec' to force the security profile.
-if lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
-  echo "------------------------------------------------------------"
-  echo "PASSED: AppArmor profile ALLOWED access to the firmware path."
-  echo "The whitelist is correctly functioning for this package."
-  echo "------------------------------------------------------------"
-  cleanup
-  exit 0
-else
-  echo "------------------------------------------------------------"
-  echo "FAILED: AppArmor profile DENIED access to the firmware path."
-  echo "The kernel blocked the read request (Permission Denied)."
-  echo "Note: On an unfixed 'prefix' package, this failure confirms the bug is present."
-  echo "------------------------------------------------------------"
+# 1. Check Devicetree path under the main profile
+echo "Testing: ubuntu_pro_esm_cache -> /sys/firmware/devicetree/base/model"
+if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache python3 -c "open('/sys/firmware/devicetree/base/model').read()" > /dev/null 2>&1; then
+  echo "FAILED: AppArmor profile DENIED access to the devicetree path."
   cleanup
   exit 1
 fi
+
+# 2. Check DMI path under the systemd-detect-virt transition profile
+echo "Testing: ubuntu_pro_esm_cache_systemd_detect_virt -> /sys/firmware/dmi/entries/0-0/raw"
+if ! lxc exec $name -- aa-exec -p ubuntu_pro_esm_cache_systemd_detect_virt python3 -c "open('/sys/firmware/dmi/entries/0-0/raw').read()" > /dev/null 2>&1; then
+  echo "FAILED: AppArmor profile DENIED access to the DMI path."
+  cleanup
+  exit 1
+fi
+
+echo "------------------------------------------------------------"
+echo "PASSED: All firmware paths are accessible under correct profiles."
+echo "------------------------------------------------------------"
 
 cleanup


### PR DESCRIPTION
## Why is this needed?
This PR updates the AppArmor firmware verification script to include  `/sys/firmware/dmi/entries/0-0/raw` verfication.

## Test Steps
Build debian files with:
- post-fix: main
- pre-fix device-tree: comment out line 80 (`/sys/firmware/devicetree/base/model r,`) from [debian/apparmor/ubuntu_pro_esm_cache.jinja2](https://github.com/canonical/ubuntu-pro-client/blob/main/debian/apparmor/ubuntu_pro_esm_cache.jinja2).
- pre-fix dmi: comment out line 331 (`/sys/firmware/dmi/entries/0-0/raw r,`) from [debian/apparmor/ubuntu_pro_esm_cache.jinja2](https://github.com/canonical/ubuntu-pro-client/blob/main/debian/apparmor/ubuntu_pro_esm_cache.jinja2).

How to build deb:
```
./tools/build.sh noble
```

Verify device-tree check failure
```
./sru/release-37/test-apparmor-firmware-access.sh noble /path/to/built/pre-fix/device-tree/ubuntu-pro-client.deb
```
Verify dmi check failure
```
./sru/release-37/test-apparmor-firmware-access.sh noble /path/to/built/pre-fix/dmi/ubuntu-pro-client.deb
```
Verify success detection
```
./sru/release-37/test-apparmor-firmware-access.sh noble /path/to/built/post-fix/ubuntu-pro-client.deb
```