### PR TITLE
fix: map aws-gov to aws for correct FIPS flavor

### DIFF
--- a/uaclient/apt_news.py
+++ b/uaclient/apt_news.py
@@ -113,9 +113,12 @@ def do_selectors_apply(
             return False
 
     if selectors.clouds is not None:
+        from uaclient.clouds.identity import cloud_type_to_contract_cloud_type
+
         cloud_id, fail = get_cloud_type()
         if fail is not None:
             return False
+        cloud_id = cloud_type_to_contract_cloud_type(cloud_id)
         if cloud_id not in selectors.clouds:
             return False
 

--- a/uaclient/cli/fix.py
+++ b/uaclient/cli/fix.py
@@ -344,7 +344,10 @@ def _run_ua_attach(cfg: UAConfig, token: str) -> bool:
 
 def _inform_ubuntu_pro_existence_if_applicable() -> None:
     """Alert the user when running Pro on cloud with PRO support."""
+    from uaclient.clouds.identity import cloud_type_to_contract_cloud_type
+
     cloud_type, _ = get_cloud_type()
+    cloud_type = cloud_type_to_contract_cloud_type(cloud_type)
     if cloud_type in PRO_CLOUD_URLS.keys():
         print(
             messages.SECURITY_USE_PRO_TMPL.format(

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -23,6 +23,7 @@ PRO_CLOUD_URLS = {
 }
 
 CONTRACT_CLOUD_TYPE_ALIASES = {
+    "aws-china": "aws",
     "aws-gov": "aws",
 }
 

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -23,7 +23,6 @@ PRO_CLOUD_URLS = {
 }
 
 CONTRACT_CLOUD_TYPE_ALIASES = {
-    "aws-china": "aws",
     "aws-gov": "aws",
 }
 

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -22,10 +22,21 @@ PRO_CLOUD_URLS = {
     "gce": messages.urls.PRO_ON_GCP_HOME_PAGE,
 }
 
+CONTRACT_CLOUD_TYPE_ALIASES = {
+    "aws-china": "aws",
+    "aws-gov": "aws",
+}
+
 
 class NoCloudTypeReason(Enum):
     NO_CLOUD_DETECTED = 0
     CLOUD_ID_ERROR = 1
+
+
+def cloud_type_to_contract_cloud_type(
+    cloud_type: Optional[str],
+) -> Optional[str]:
+    return CONTRACT_CLOUD_TYPE_ALIASES.get(cloud_type, cloud_type)
 
 
 def get_instance_id() -> Optional[str]:

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -94,7 +94,6 @@ class TestCloudTypeToContractCloudType:
         (
             ("aws", "aws"),
             ("aws-gov", "aws"),
-            ("aws-china", "aws"),
             ("azure", "azure"),
             (None, None),
         ),

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -5,6 +5,7 @@ from uaclient import exceptions
 from uaclient.clouds.identity import (
     NoCloudTypeReason,
     cloud_instance_factory,
+    cloud_type_to_contract_cloud_type,
     get_cloud_type,
     get_instance_id,
 )
@@ -85,6 +86,21 @@ class TestGetCloudType:
 
         m_load_file.return_value = settings_overrides
         assert get_cloud_type.__wrapped__() == (expected_value, None)
+
+
+class TestCloudTypeToContractCloudType:
+    @pytest.mark.parametrize(
+        "cloud_type,expected",
+        (
+            ("aws", "aws"),
+            ("aws-gov", "aws"),
+            ("aws-china", "aws"),
+            ("azure", "azure"),
+            (None, None),
+        ),
+    )
+    def test_cloud_aliases(self, cloud_type, expected):
+        assert cloud_type_to_contract_cloud_type(cloud_type) == expected
 
 
 @mock.patch(M_PATH + "get_cloud_type")

--- a/uaclient/clouds/tests/test_identity.py
+++ b/uaclient/clouds/tests/test_identity.py
@@ -94,6 +94,7 @@ class TestCloudTypeToContractCloudType:
         (
             ("aws", "aws"),
             ("aws-gov", "aws"),
+            ("aws-china", "aws"),
             ("azure", "azure"),
             (None, None),
         ),

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -251,9 +251,11 @@ class UAContractClient(serviceclient.UAServiceClient):
 
         @return: Dict of the JSON response containing the contract-token.
         """
+        from uaclient.clouds.identity import cloud_type_to_contract_cloud_type
+
         response = self.request_url(
             API_V1_GET_CONTRACT_TOKEN_FOR_CLOUD_INSTANCE.format(
-                cloud_type=cloud_type
+                cloud_type=cloud_type_to_contract_cloud_type(cloud_type)
             ),
             data=data,
         )
@@ -925,7 +927,10 @@ def apply_contract_overrides(
 
     :param orig_access: Dict with original entitlement access details
     """
-    from uaclient.clouds.identity import get_cloud_type
+    from uaclient.clouds.identity import (
+        cloud_type_to_contract_cloud_type,
+        get_cloud_type,
+    )
 
     if not all([isinstance(orig_access, dict), "entitlement" in orig_access]):
         raise RuntimeError(
@@ -937,6 +942,7 @@ def apply_contract_overrides(
         system.get_release_info().series if series is None else series
     )
     cloud_type, _ = get_cloud_type()
+    cloud_type = cloud_type_to_contract_cloud_type(cloud_type)
     orig_entitlement = orig_access.get("entitlement", {})
 
     overrides = _select_overrides(

--- a/uaclient/entitlements/fips.py
+++ b/uaclient/entitlements/fips.py
@@ -5,7 +5,11 @@ from itertools import groupby
 from typing import List, Optional, Tuple
 
 from uaclient import api, apt, event_logger, exceptions, messages, system, util
-from uaclient.clouds.identity import NoCloudTypeReason, get_cloud_type
+from uaclient.clouds.identity import (
+    NoCloudTypeReason,
+    cloud_type_to_contract_cloud_type,
+    get_cloud_type,
+)
 from uaclient.entitlements import repo
 from uaclient.entitlements.base import EntitlementWithMessage
 from uaclient.entitlements.entitlement_status import ApplicationStatus
@@ -469,6 +473,7 @@ class FIPSCommonEntitlement(repo.RepoEntitlement):
     def static_affordances(self) -> Tuple[StaticAffordance, ...]:
         cloud_titles = {"aws": "an AWS", "azure": "an Azure", "gce": "a GCP"}
         cloud_id, _ = get_cloud_type()
+        cloud_id = cloud_type_to_contract_cloud_type(cloud_id)
         if cloud_id is None:
             cloud_id = ""
 

--- a/uaclient/tests/test_apt_news.py
+++ b/uaclient/tests/test_apt_news.py
@@ -103,6 +103,28 @@ class TestAptNews:
             ),
             (
                 apt_news.AptNewsMessageSelectors(
+                    clouds=["aws"],
+                ),
+                "xenial",
+                ("aws-gov", None),
+                False,
+                None,
+                None,
+                True,
+            ),
+            (
+                apt_news.AptNewsMessageSelectors(
+                    clouds=["aws"],
+                ),
+                "xenial",
+                ("aws-china", None),
+                False,
+                None,
+                None,
+                True,
+            ),
+            (
+                apt_news.AptNewsMessageSelectors(
                     pro=False, architectures=["amd64"]
                 ),
                 "xenial",

--- a/uaclient/tests/test_apt_news.py
+++ b/uaclient/tests/test_apt_news.py
@@ -114,6 +114,17 @@ class TestAptNews:
             ),
             (
                 apt_news.AptNewsMessageSelectors(
+                    clouds=["aws"],
+                ),
+                "xenial",
+                ("aws-china", None),
+                False,
+                None,
+                None,
+                True,
+            ),
+            (
+                apt_news.AptNewsMessageSelectors(
                     pro=False, architectures=["amd64"]
                 ),
                 "xenial",

--- a/uaclient/tests/test_apt_news.py
+++ b/uaclient/tests/test_apt_news.py
@@ -114,17 +114,6 @@ class TestAptNews:
             ),
             (
                 apt_news.AptNewsMessageSelectors(
-                    clouds=["aws"],
-                ),
-                "xenial",
-                ("aws-china", None),
-                False,
-                None,
-                None,
-                True,
-            ),
-            (
-                apt_news.AptNewsMessageSelectors(
                     pro=False, architectures=["amd64"]
                 ),
                 "xenial",

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1706,28 +1706,6 @@ class TestRequestAutoAttach:
             mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
         ] == m_request_url.call_args_list
 
-    def test_request_normalizes_aws_china_cloud_type(
-        self, m_request_url, FakeConfig
-    ):
-        cfg = FakeConfig()
-        contract = UAContractClient(cfg)
-
-        m_request_url.return_value = http.HTTPResponse(
-            code=200,
-            headers={},
-            body="",
-            json_dict={"contractToken": "token"},
-            json_list=[],
-        )
-
-        contract.get_contract_token_for_cloud_instance(
-            cloud_type="aws-china", data={"pkcs7": "doc"}
-        )
-
-        assert [
-            mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
-        ] == m_request_url.call_args_list
-
     @mock.patch("uaclient.contract.LOG.debug")
     def test_request_for_invalid_pro_image(
         self, m_logging_debug, m_request_url, FakeConfig
@@ -1775,35 +1753,6 @@ class TestApplyContractOverridesCloudAliases:
         return_value=("aws-gov", None),
     )
     def test_aws_gov_matches_aws_cloud_selector(
-        self, _m_cloud_type, _m_release_info
-    ):
-        orig_access = {
-            "entitlement": {
-                "affordances": {"packages": ["ubuntu-fips"]},
-                "overrides": [
-                    {
-                        "selector": {"cloud": "aws"},
-                        "affordances": {"packages": ["ubuntu-aws-fips"]},
-                    }
-                ],
-            }
-        }
-
-        apply_contract_overrides(orig_access)
-
-        assert orig_access["entitlement"]["affordances"] == {
-            "packages": ["ubuntu-aws-fips"]
-        }
-
-    @mock.patch(
-        "uaclient.system.get_release_info",
-        return_value=mock.MagicMock(series="ubuntuX"),
-    )
-    @mock.patch(
-        "uaclient.clouds.identity.get_cloud_type",
-        return_value=("aws-china", None),
-    )
-    def test_aws_china_matches_aws_cloud_selector(
         self, _m_cloud_type, _m_release_info
     ):
         orig_access = {

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1706,6 +1706,28 @@ class TestRequestAutoAttach:
             mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
         ] == m_request_url.call_args_list
 
+    def test_request_normalizes_aws_china_cloud_type(
+        self, m_request_url, FakeConfig
+    ):
+        cfg = FakeConfig()
+        contract = UAContractClient(cfg)
+
+        m_request_url.return_value = http.HTTPResponse(
+            code=200,
+            headers={},
+            body="",
+            json_dict={"contractToken": "token"},
+            json_list=[],
+        )
+
+        contract.get_contract_token_for_cloud_instance(
+            cloud_type="aws-china", data={"pkcs7": "doc"}
+        )
+
+        assert [
+            mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
+        ] == m_request_url.call_args_list
+
     @mock.patch("uaclient.contract.LOG.debug")
     def test_request_for_invalid_pro_image(
         self, m_logging_debug, m_request_url, FakeConfig
@@ -1753,6 +1775,35 @@ class TestApplyContractOverridesCloudAliases:
         return_value=("aws-gov", None),
     )
     def test_aws_gov_matches_aws_cloud_selector(
+        self, _m_cloud_type, _m_release_info
+    ):
+        orig_access = {
+            "entitlement": {
+                "affordances": {"packages": ["ubuntu-fips"]},
+                "overrides": [
+                    {
+                        "selector": {"cloud": "aws"},
+                        "affordances": {"packages": ["ubuntu-aws-fips"]},
+                    }
+                ],
+            }
+        }
+
+        apply_contract_overrides(orig_access)
+
+        assert orig_access["entitlement"]["affordances"] == {
+            "packages": ["ubuntu-aws-fips"]
+        }
+
+    @mock.patch(
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="ubuntuX"),
+    )
+    @mock.patch(
+        "uaclient.clouds.identity.get_cloud_type",
+        return_value=("aws-china", None),
+    )
+    def test_aws_china_matches_aws_cloud_selector(
         self, _m_cloud_type, _m_release_info
     ):
         orig_access = {

--- a/uaclient/tests/test_contract.py
+++ b/uaclient/tests/test_contract.py
@@ -1684,6 +1684,50 @@ class TestApplyContractOverrides:
 
 @mock.patch("uaclient.http.serviceclient.UAServiceClient.request_url")
 class TestRequestAutoAttach:
+    def test_request_normalizes_aws_gov_cloud_type(
+        self, m_request_url, FakeConfig
+    ):
+        cfg = FakeConfig()
+        contract = UAContractClient(cfg)
+
+        m_request_url.return_value = http.HTTPResponse(
+            code=200,
+            headers={},
+            body="",
+            json_dict={"contractToken": "token"},
+            json_list=[],
+        )
+
+        contract.get_contract_token_for_cloud_instance(
+            cloud_type="aws-gov", data={"pkcs7": "doc"}
+        )
+
+        assert [
+            mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
+        ] == m_request_url.call_args_list
+
+    def test_request_normalizes_aws_china_cloud_type(
+        self, m_request_url, FakeConfig
+    ):
+        cfg = FakeConfig()
+        contract = UAContractClient(cfg)
+
+        m_request_url.return_value = http.HTTPResponse(
+            code=200,
+            headers={},
+            body="",
+            json_dict={"contractToken": "token"},
+            json_list=[],
+        )
+
+        contract.get_contract_token_for_cloud_instance(
+            cloud_type="aws-china", data={"pkcs7": "doc"}
+        )
+
+        assert [
+            mock.call("/v1/clouds/aws/token", data={"pkcs7": "doc"})
+        ] == m_request_url.call_args_list
+
     @mock.patch("uaclient.contract.LOG.debug")
     def test_request_for_invalid_pro_image(
         self, m_logging_debug, m_request_url, FakeConfig
@@ -1719,3 +1763,63 @@ class TestRequestAutoAttach:
         assert expected_message.msg == exc_error.value.msg
         assert expected_args == m_logging_debug.call_args_list
         assert exc_error.value.msg_code == "invalid-pro-image"
+
+
+class TestApplyContractOverridesCloudAliases:
+    @mock.patch(
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="ubuntuX"),
+    )
+    @mock.patch(
+        "uaclient.clouds.identity.get_cloud_type",
+        return_value=("aws-gov", None),
+    )
+    def test_aws_gov_matches_aws_cloud_selector(
+        self, _m_cloud_type, _m_release_info
+    ):
+        orig_access = {
+            "entitlement": {
+                "affordances": {"packages": ["ubuntu-fips"]},
+                "overrides": [
+                    {
+                        "selector": {"cloud": "aws"},
+                        "affordances": {"packages": ["ubuntu-aws-fips"]},
+                    }
+                ],
+            }
+        }
+
+        apply_contract_overrides(orig_access)
+
+        assert orig_access["entitlement"]["affordances"] == {
+            "packages": ["ubuntu-aws-fips"]
+        }
+
+    @mock.patch(
+        "uaclient.system.get_release_info",
+        return_value=mock.MagicMock(series="ubuntuX"),
+    )
+    @mock.patch(
+        "uaclient.clouds.identity.get_cloud_type",
+        return_value=("aws-china", None),
+    )
+    def test_aws_china_matches_aws_cloud_selector(
+        self, _m_cloud_type, _m_release_info
+    ):
+        orig_access = {
+            "entitlement": {
+                "affordances": {"packages": ["ubuntu-fips"]},
+                "overrides": [
+                    {
+                        "selector": {"cloud": "aws"},
+                        "affordances": {"packages": ["ubuntu-aws-fips"]},
+                    }
+                ],
+            }
+        }
+
+        apply_contract_overrides(orig_access)
+
+        assert orig_access["entitlement"]["affordances"] == {
+            "packages": ["ubuntu-aws-fips"]
+        }


### PR DESCRIPTION
## Why is this needed?
Fixes [LP: 2144693](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2144693) by aliasing `aws-gov` to `aws` within the pro client.

## Reproduce bug:
From host machine:
```
multipass launch --name fips-repro noble
multipass shell fips-repro
```
From fips-repo:
Install AWS kernel
```
sudo apt update && sudo apt install -y linux-aws
sudo reboot
```
Mock aws-gov
```
# 1. Overwrite the result files
echo "aws-gov" | sudo tee /run/cloud-init/cloud-id-result
echo "aws-gov" | sudo tee /run/cloud-init/cloud-id

# 2. Update the instance metadata JSON
# Note: If this is a fresh Multipass instance, we change 'multipass' to 'aws-gov'
sudo sed -i 's/multipass/aws-gov/g' /run/cloud-init/instance-data.json

# 3. Clear cache
sudo rm -rf /var/lib/ubuntu-advantage/private/machine-access-cache
```
Verify the mock
```
# Check that it says aws-gov
cloud-id
```

Try fips enablement:
```
sudo pro enable fips-updates
``` 

## Test Code
From host machine:
Build the deb based on this PR
```
./tools/build.sh noble
```
Delploy client
```
multipass launch --name fips-test noble
multipass transfer /path/to/the/built/debs/*.deb fips-test:/tmp/
multipass shell fips-test
```
From fips-test:
Install client
```
sudo apt install ./*.deb
```
Install AWS kernel
```
sudo apt update && sudo apt install -y linux-aws
sudo reboot
```
Mock aws-gov
```
# 1. Overwrite the result files
echo "aws-gov" | sudo tee /run/cloud-init/cloud-id-result
echo "aws-gov" | sudo tee /run/cloud-init/cloud-id

# 2. Update the instance metadata JSON
# Note: If this is a fresh Multipass instance, we change 'multipass' to 'aws-gov'
sudo sed -i 's/multipass/aws-gov/g' /run/cloud-init/instance-data.json

# 3. Clear cache
sudo rm -rf /var/lib/ubuntu-advantage/private/machine-access-cache
```
Verify the mock
```
# Check that it says aws-gov
cloud-id
```
Try fips enablement:
```
sudo pro enable fips-updates
``` 