### PR TITLE
docs: Add details about HWE real-time kernel

### DIFF
--- a/custom_wordlist.txt
+++ b/custom_wordlist.txt
@@ -45,6 +45,7 @@ howtoguides
 html
 http
 https
+HWE
 IaaS
 init
 internetless

--- a/docs/explanations/about_esm.rst
+++ b/docs/explanations/about_esm.rst
@@ -121,4 +121,4 @@ pinning and priorities.
 
 .. LINKS
 
-.. _APT configuration article: https://wiki.debian.org/AptConfiguration#apt_preferences_.28APT_pinning.29
+.. _APT configuration article: https://wiki.debian.org/AptConfiguration#Using_pinning

--- a/docs/explanations/deprecation_policy.rst
+++ b/docs/explanations/deprecation_policy.rst
@@ -57,4 +57,4 @@ directing the reader to the replacement.
 .. LINKS
 
 .. _Stable Release Update: https://wiki.ubuntu.com/StableReleaseUpdates
-.. _devel: https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/reference/glossary/#term-Devel
+.. _devel: https://documentation.ubuntu.com/project/how-ubuntu-is-made/concepts/glossary/#term-Devel

--- a/docs/explanations/using_pro_offline.rst
+++ b/docs/explanations/using_pro_offline.rst
@@ -74,7 +74,7 @@ greater control over when those patches roll out across your infrastructure.
 
 .. _Customer Support teams: https://ubuntu.com/support
 .. _install Landscape: https://ubuntu.com/landscape/docs/how-to-install-landscape-in-an-air-gapped-or-offline-environment
-.. _manage repositories: https://ubuntu.com/landscape/docs/how-to-manage-repositories-in-an-air-gapped-or-offline-environment
+.. _manage repositories: https://documentation.ubuntu.com/landscape/how-to-guides/repository-mirrors/manage-repositories-in-an-air-gapped-or-offline-environment/
 .. _Snap-store-proxy: https://snapcraft.io/snap-store-proxy
 .. _Livepatch on-prem: https://ubuntu.com/security/livepatch/docs/livepatch_on_prem
 .. _operate in offline mode: https://docs.ubuntu.com/snap-store-proxy/en/airgap

--- a/docs/howtoguides/enable_anbox.rst
+++ b/docs/howtoguides/enable_anbox.rst
@@ -100,4 +100,4 @@ To also purge the service, removing all the APT packages installed with it, see
 .. LINKS
 
 .. include:: ../links.txt
-.. _Anbox Cloud requirements page: https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/requirements
+.. _Anbox Cloud requirements page: https://documentation.ubuntu.com/anbox-cloud/reference/requirements/

--- a/docs/howtoguides/enable_realtime_kernel.rst
+++ b/docs/howtoguides/enable_realtime_kernel.rst
@@ -131,6 +131,41 @@ for Raspberry Pi):
 
 After rebooting, you'll be running Real-time Ubuntu.
 
+Install the hardware enablement (HWE) real-time kernel
+======================================================
+
+Once you have Real-time Ubuntu enabled, you can install the HWE real-time 
+kernel to get support for newer hardware.
+
+.. caution::
+
+   Note: The HWE real-time kernel only supports generic Real-time Ubuntu, 
+   not Real-time Ubuntu for Raspberry Pi or Intel IOTG.
+
+.. tab-set::
+
+   .. tab-item:: Ubuntu 22.04 LTS
+
+      .. code-block:: bash
+
+         sudo apt install linux-realtime-hwe-22.04
+
+      .. note::
+         The HWE real-time kernel for Ubuntu 22.04 LTS is based on the 6.8 
+         kernel.
+
+   .. tab-item:: Ubuntu 24.04 LTS
+
+      .. code-block:: bash
+
+         sudo apt install linux-realtime-hwe-24.04
+
+      .. note::
+         The HWE real-time kernel for Ubuntu 24.04 LTS is based on the 6.17 
+         kernel.
+
+After rebooting, you'll be running the HWE kernel for Real-time Ubuntu.
+
 Next steps
 ==========
 

--- a/docs/howtoguides/enable_realtime_kernel.rst
+++ b/docs/howtoguides/enable_realtime_kernel.rst
@@ -134,12 +134,14 @@ After rebooting, you'll be running Real-time Ubuntu.
 Install the hardware enablement (HWE) real-time kernel
 ======================================================
 
-Once you have Real-time Ubuntu enabled, you can install the HWE real-time 
-kernel to get support for newer hardware.
+Once you have Real-time Ubuntu enabled, you can install the HWE real-time
+kernel to get support for newer hardware. To learn more about what kernel
+versions and variants are supported by the HWE real-time kernel, refer to
+`the supported releases page <rt_releases_>`_.
 
 .. caution::
 
-   Note: The HWE real-time kernel only supports generic Real-time Ubuntu, 
+   The HWE real-time kernel only supports generic Real-time Ubuntu,
    not Real-time Ubuntu for Raspberry Pi or Intel IOTG.
 
 .. tab-set::
@@ -151,7 +153,7 @@ kernel to get support for newer hardware.
          sudo apt install linux-realtime-hwe-22.04
 
       .. note::
-         The HWE real-time kernel for Ubuntu 22.04 LTS is based on the 6.8 
+         The HWE real-time kernel for Ubuntu 22.04 LTS is based on the 6.8
          kernel.
 
    .. tab-item:: Ubuntu 24.04 LTS
@@ -161,7 +163,7 @@ kernel to get support for newer hardware.
          sudo apt install linux-realtime-hwe-24.04
 
       .. note::
-         The HWE real-time kernel for Ubuntu 24.04 LTS is based on the 6.17 
+         The HWE real-time kernel for Ubuntu 24.04 LTS is based on the 6.17
          kernel.
 
 After rebooting, you'll be running the HWE kernel for Real-time Ubuntu.


### PR DESCRIPTION
## Why is this needed?
While we have references the Hardware Enablement (HWE) real-time kernel in our [Ubuntu Real-time Documentation](https://documentation.ubuntu.com/real-time), it should be mentioned here too, since this is where we point people for install instructions on Ubuntu 22.04/24.04.
