### PR TITLE
test: use ditto-repo for airgap tests

### DIFF
--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -11,13 +11,16 @@ Feature: Performing attach using pro-airgapped
     And I download the service credentials on the `mirror` machine
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
+    And I extract the `cis` credentials from the `mirror` machine
     And I download the ditto binary from `https://github.com/canonical/ditto-repo/releases/download/v0.3.0/ditto` on the `mirror` machine
     And I run ditto for `esm-infra` on `jammy` on the `mirror` machine
     And I run ditto for `esm-apps` on `jammy` on the `mirror` machine
+    And I run ditto for `cis` on `jammy` on the `mirror` machine
     And I serve the `esm-infra` mirror using port `8000` on the `mirror` machine
     And I serve the `esm-apps` mirror using port `9000` on the `mirror` machine
+    And I serve the `cis` mirror using port `9010` on the `mirror` machine
     # set up the pro-airgapped configuration
-    And I create the contract config overrides file for `esm-infra,esm-apps` on the `mirror` machine
+    And I create the contract config overrides file for `esm-infra,esm-apps,cis` on the `mirror` machine
     And I generate the contracts-airgapped configuration on the `mirror` machine
     # set up the contracts-airgapped configuration
     Given a `jammy` `<machine_type>` machine named `contracts`
@@ -32,8 +35,10 @@ Feature: Performing attach using pro-airgapped
     And I disable any internet connection on the machine
     And I change config key `contract_url` to use value `http://$behave_var{machine-ip contracts}:8484`
     And I attach `contract_token` with sudo
+    And I run `pro enable cis` with sudo
     Then I verify that `esm-infra` is enabled
     And I verify that `esm-apps` is enabled
+    And I verify that `usg` is enabled
     When I run `apt-cache policy hello` with sudo
     Then stdout matches regexp:
       """

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -12,7 +12,7 @@ Feature: Performing attach using pro-airgapped
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
     And I set the ditto-repo config file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
-    And I download the ditto binary from `http://10.149.172.1:8000/ditto` on the `mirror` machine
+    And I download the ditto binary from `https://github.com/canonical/ditto-repo/releases/download/v0.2.0/ditto` on the `mirror` machine
     And I run ditto with the `infra_updates` config on the `mirror` machine
     And I run ditto with the `infra_security` config on the `mirror` machine
     And I run ditto with the `apps_updates` config on the `mirror` machine

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -7,12 +7,16 @@ Feature: Performing attach using pro-airgapped
     Given a `jammy` `<machine_type>` machine named `mirror`
     When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
     And I apt update on the `mirror` machine
-    And I apt install `apt-mirror get-resource-tokens pro-airgapped` on the `mirror` machine
+    And I apt install `get-resource-tokens pro-airgapped` on the `mirror` machine
     And I download the service credentials on the `mirror` machine
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
-    And I set the apt-mirror file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
-    And I run `apt-mirror` `with sudo` on the `mirror` machine
+    And I set the ditto-repo config file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
+    And I download the ditto binary from `http://10.149.172.1:8000/ditto` on the `mirror` machine
+    And I run ditto with the `infra_updates` config on the `mirror` machine
+    And I run ditto with the `infra_security` config on the `mirror` machine
+    And I run ditto with the `apps_updates` config on the `mirror` machine
+    And I run ditto with the `apps_security` config on the `mirror` machine
     And I serve the `esm-infra` mirror using port `8000` on the `mirror` machine
     And I serve the `esm-apps` mirror using port `9000` on the `mirror` machine
     # set up the pro-airgapped configuration
@@ -54,12 +58,16 @@ Feature: Performing attach using pro-airgapped
     Given a `jammy` `<machine_type>` machine named `mirror`
     When I run `add-apt-repository ppa:yellow/ua-airgapped -y` `with sudo` on the `mirror` machine
     And I run `apt-get update` `with sudo` on the `mirror` machine
-    And I run `apt-get install apt-mirror get-resource-tokens pro-airgapped -yq` `with sudo` on the `mirror` machine
+    And I run `apt-get install get-resource-tokens pro-airgapped -yq` `with sudo` on the `mirror` machine
     And I download the service credentials on the `mirror` machine
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
-    And I set the apt-mirror file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
-    And I run `apt-mirror` `with sudo` on the `mirror` machine
+    And I set the ditto-repo config file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
+    And I download the ditto binary from `http://10.149.172.1:8000/ditto` on the `mirror` machine
+    And I run ditto with the `infra_updates` config on the `mirror` machine
+    And I run ditto with the `infra_security` config on the `mirror` machine
+    And I run ditto with the `apps_updates` config on the `mirror` machine
+    And I run ditto with the `apps_security` config on the `mirror` machine
     And I consolidate `esm-infra,esm-apps` on a single mirror on the `mirror` machine
     And I serve the `all-mirrors` mirror using port `8000` on the `mirror` machine
     # set up the pro-airgapped configuration

--- a/features/airgapped.feature
+++ b/features/airgapped.feature
@@ -11,12 +11,9 @@ Feature: Performing attach using pro-airgapped
     And I download the service credentials on the `mirror` machine
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
-    And I set the ditto-repo config file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
-    And I download the ditto binary from `https://github.com/canonical/ditto-repo/releases/download/v0.2.0/ditto` on the `mirror` machine
-    And I run ditto with the `infra_updates` config on the `mirror` machine
-    And I run ditto with the `infra_security` config on the `mirror` machine
-    And I run ditto with the `apps_updates` config on the `mirror` machine
-    And I run ditto with the `apps_security` config on the `mirror` machine
+    And I download the ditto binary from `https://github.com/canonical/ditto-repo/releases/download/v0.3.0/ditto` on the `mirror` machine
+    And I run ditto for `esm-infra` on `jammy` on the `mirror` machine
+    And I run ditto for `esm-apps` on `jammy` on the `mirror` machine
     And I serve the `esm-infra` mirror using port `8000` on the `mirror` machine
     And I serve the `esm-apps` mirror using port `9000` on the `mirror` machine
     # set up the pro-airgapped configuration
@@ -62,12 +59,9 @@ Feature: Performing attach using pro-airgapped
     And I download the service credentials on the `mirror` machine
     And I extract the `esm-infra` credentials from the `mirror` machine
     And I extract the `esm-apps` credentials from the `mirror` machine
-    And I set the ditto-repo config file for `<release>` with the `esm-infra,esm-apps` credentials on the `mirror` machine
-    And I download the ditto binary from `http://10.149.172.1:8000/ditto` on the `mirror` machine
-    And I run ditto with the `infra_updates` config on the `mirror` machine
-    And I run ditto with the `infra_security` config on the `mirror` machine
-    And I run ditto with the `apps_updates` config on the `mirror` machine
-    And I run ditto with the `apps_security` config on the `mirror` machine
+    And I download the ditto binary from `https://github.com/canonical/ditto-repo/releases/download/v0.3.0/ditto` on the `mirror` machine
+    And I run ditto for `esm-infra` on `jammy` on the `mirror` machine
+    And I run ditto for `esm-apps` on `jammy` on the `mirror` machine
     And I consolidate `esm-infra,esm-apps` on a single mirror on the `mirror` machine
     And I serve the `all-mirrors` mirror using port `8000` on the `mirror` machine
     # set up the pro-airgapped configuration

--- a/features/steps/airgap.py
+++ b/features/steps/airgap.py
@@ -198,10 +198,10 @@ def then_i_consolidate_services_on_the_same_mirror(
     context, services_list, machine_name
 ):
     services = services_list.split(",")
-    all_mirrors_path = "/var/spool/apt-mirror/mirror/all-mirrors/"
+    all_mirrors_path = "/var/spool/ditto-repo/all-mirrors/"
 
     for service in services:
-        cmd = "rsync -a /var/spool/apt-mirror/mirror/esm.ubuntu.com/{}/ {}".format(  # noqa
+        cmd = "rsync -a /var/spool/ditto-repo/{}/ {}".format(  # noqa
             service.split("-")[1], all_mirrors_path
         )
         when_i_run_command(
@@ -246,8 +246,8 @@ def set_ditto_repo_config_with_credentials(
                 "components": ["main"],
                 "archs": ["amd64"],
                 "languages": ["en"],
-                "download-path": "/var/spool/ditto-repo/{}/{}/".format(
-                    service_type, dist_suffix
+                "download-path": "/var/spool/ditto-repo/{}/ubuntu/".format(
+                    service_type,
                 ),
                 "workers": 5,
             }

--- a/features/steps/airgap.py
+++ b/features/steps/airgap.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from typing import Any, Dict  # noqa: F401
@@ -208,3 +209,139 @@ def then_i_consolidate_services_on_the_same_mirror(
         )
 
     context.service_mirror_cfg["all_mirrors"] = {"path": all_mirrors_path}
+
+
+@when(
+    "I set the ditto-repo config file for `{release}` with the `{service_list}` credentials on the `{machine_name}` machine"  # noqa
+)
+def set_ditto_repo_config_with_credentials(
+    context, release, service_list, machine_name
+):
+    """
+    Generate ditto-repo configuration JSON files with credentials for ESM services.
+    Creates separate config files for both 'updates' and 'security' distributions.
+    Similar to set_apt_mirror_file_with_credentials but for ditto-repo tool.
+    """
+    service_list = service_list.split(",")
+
+    if not hasattr(context, "ditto_config_files"):
+        context.ditto_config_files = {}
+
+    for service in service_list:
+        token = context.service_mirror_cfg[service.replace("-", "_")][
+            "credentials"
+        ]
+        service_type = service.split("-")[1]
+
+        # Create authenticated URL for ditto-repo
+        repo_url = "https://bearer:{}@esm.ubuntu.com/{}/ubuntu/".format(
+            token, service_type
+        )
+
+        # Create two configs: one for updates, one for security
+        for dist_suffix in ["updates", "security"]:
+            ditto_config = {
+                "repo-url": repo_url,
+                "dist": "{}-{}-{}".format(release, service_type, dist_suffix),
+                "components": ["main"],
+                "archs": ["amd64"],
+                "languages": ["en"],
+                "download-path": "/var/spool/ditto-repo/{}/{}/".format(
+                    service_type, dist_suffix
+                ),
+                "workers": 5,
+            }
+
+            # Write config to file
+            text = json.dumps(ditto_config, indent=4)
+            config_file_path = "/etc/ditto-config-{}-{}.json".format(
+                service_type, dist_suffix
+            )
+            when_i_create_file_with_content(
+                context,
+                config_file_path,
+                machine_name=machine_name,
+                text=text,
+            )
+
+            # Store config file paths for later use
+            config_key = "{}_{}".format(service_type, dist_suffix)
+            context.ditto_config_files[config_key] = config_file_path
+
+        # Store the base download path for later use
+        context.service_mirror_cfg[service.replace("-", "_")]["path"] = (
+            "/var/spool/ditto-repo/{}/".format(service_type)
+        )
+
+
+@when(
+    "I download the ditto binary from `{url}` on the `{machine_name}` machine"
+)
+def download_ditto_binary(context, url, machine_name):
+    """
+    Download the ditto-repo binary from a configurable URL and make it executable.
+    """
+    ditto_binary_path = "/usr/local/bin/ditto"
+
+    # Download the binary using wget
+    download_cmd = "wget -O {} {}".format(ditto_binary_path, url)
+    when_i_run_command(
+        context,
+        download_cmd,
+        "with sudo",
+        machine_name=machine_name,
+    )
+
+    # Make the binary executable
+    chmod_cmd = "chmod +x {}".format(ditto_binary_path)
+    when_i_run_command(
+        context,
+        chmod_cmd,
+        "with sudo",
+        machine_name=machine_name,
+    )
+
+    # Store the binary path in context for later use
+    if not hasattr(context, "ditto_binary_path"):
+        context.ditto_binary_path = ditto_binary_path
+
+
+@when(
+    "I run ditto with the `{config_key}` config on the `{machine_name}` machine"  # noqa
+)
+def run_ditto_with_config(context, config_key, machine_name):
+    """
+    Run the ditto command with a specified config file.
+    Copies the config file to ditto-config.json in a working directory.
+    """
+    # Get the config file path from context
+    if not hasattr(context, "ditto_config_files"):
+        raise ValueError("No ditto config files found in context")
+
+    if config_key not in context.ditto_config_files:
+        raise ValueError(
+            "Config key '{}' not found. Available keys: {}".format(
+                config_key, list(context.ditto_config_files.keys())
+            )
+        )
+
+    source_config_path = context.ditto_config_files[config_key]
+
+    # Copy the config file to ditto-config.json in the working directory
+    target_config_path = "ditto-config.json"
+    cp_cmd = "cp {} {}".format(source_config_path, target_config_path)
+    when_i_run_command(
+        context,
+        cp_cmd,
+        "with sudo",
+        machine_name=machine_name,
+    )
+
+    # Run ditto from the working directory
+    ditto_cmd = "ditto"
+    when_i_run_command(
+        context,
+        ditto_cmd,
+        "with sudo",
+        machine_name=machine_name,
+    )

--- a/features/steps/airgap.py
+++ b/features/steps/airgap.py
@@ -261,16 +261,24 @@ def run_ditto_for_service(context, service, release, machine_name):
         )
 
     token = context.service_mirror_cfg[service_key]["credentials"]
-    service_type = service.split("-")[1]
+
+    if "esm" in service:
+        service_type = service.split("-")[1]
+    else:
+        service_type = service
 
     repo_url = "https://bearer:{}@esm.ubuntu.com/{}/ubuntu/".format(
         token, service_type
     )
 
-    dists = [
-        "{}-{}-{}".format(release, service_type, dist_suffix)
-        for dist_suffix in ["updates", "security"]
-    ]
+    if "esm" in service:
+        dists = [
+            "{}-{}-{}".format(release, service_type, dist_suffix)
+            for dist_suffix in ["updates", "security"]
+        ]
+    else:
+        dists = [release]
+
     download_path = "/var/spool/ditto-repo/{}/ubuntu/".format(service_type)
 
     if "path" not in context.service_mirror_cfg[service_key]:

--- a/features/steps/airgap.py
+++ b/features/steps/airgap.py
@@ -212,69 +212,6 @@ def then_i_consolidate_services_on_the_same_mirror(
 
 
 @when(
-    "I set the ditto-repo config file for `{release}` with the `{service_list}` credentials on the `{machine_name}` machine"  # noqa
-)
-def set_ditto_repo_config_with_credentials(
-    context, release, service_list, machine_name
-):
-    """
-    Generate ditto-repo configuration JSON files with credentials for ESM services.
-    Creates separate config files for both 'updates' and 'security' distributions.
-    Similar to set_apt_mirror_file_with_credentials but for ditto-repo tool.
-    """
-    service_list = service_list.split(",")
-
-    if not hasattr(context, "ditto_config_files"):
-        context.ditto_config_files = {}
-
-    for service in service_list:
-        token = context.service_mirror_cfg[service.replace("-", "_")][
-            "credentials"
-        ]
-        service_type = service.split("-")[1]
-
-        # Create authenticated URL for ditto-repo
-        repo_url = "https://bearer:{}@esm.ubuntu.com/{}/ubuntu/".format(
-            token, service_type
-        )
-
-        # Create two configs: one for updates, one for security
-        for dist_suffix in ["updates", "security"]:
-            ditto_config = {
-                "repo-url": repo_url,
-                "dist": "{}-{}-{}".format(release, service_type, dist_suffix),
-                "components": ["main"],
-                "archs": ["amd64"],
-                "languages": ["en"],
-                "download-path": "/var/spool/ditto-repo/{}/ubuntu/".format(
-                    service_type,
-                ),
-                "workers": 5,
-            }
-
-            # Write config to file
-            text = json.dumps(ditto_config, indent=4)
-            config_file_path = "/etc/ditto-config-{}-{}.json".format(
-                service_type, dist_suffix
-            )
-            when_i_create_file_with_content(
-                context,
-                config_file_path,
-                machine_name=machine_name,
-                text=text,
-            )
-
-            # Store config file paths for later use
-            config_key = "{}_{}".format(service_type, dist_suffix)
-            context.ditto_config_files[config_key] = config_file_path
-
-        # Store the base download path for later use
-        context.service_mirror_cfg[service.replace("-", "_")]["path"] = (
-            "/var/spool/ditto-repo/{}/".format(service_type)
-        )
-
-
-@when(
     "I download the ditto binary from `{url}` on the `{machine_name}` machine"
 )
 def download_ditto_binary(context, url, machine_name):
@@ -307,38 +244,51 @@ def download_ditto_binary(context, url, machine_name):
 
 
 @when(
-    "I run ditto with the `{config_key}` config on the `{machine_name}` machine"  # noqa
+    "I run ditto for `{service}` on `{release}` on the `{machine_name}` machine"  # noqa
 )
-def run_ditto_with_config(context, config_key, machine_name):
+def run_ditto_for_service(context, service, release, machine_name):
     """
-    Run the ditto command with a specified config file.
-    Copies the config file to ditto-config.json in a working directory.
+    Run the ditto command with CLI parameters for a specific service and distribution.
+    Uses --repo-url, --dists, --components, --archs, and --download-path flags.
     """
-    # Get the config file path from context
-    if not hasattr(context, "ditto_config_files"):
-        raise ValueError("No ditto config files found in context")
+    if not hasattr(context, "service_mirror_cfg"):
+        raise ValueError("No service mirror config found in context")
 
-    if config_key not in context.ditto_config_files:
+    service_key = service.replace("-", "_")
+    if service_key not in context.service_mirror_cfg:
         raise ValueError(
-            "Config key '{}' not found. Available keys: {}".format(
-                config_key, list(context.ditto_config_files.keys())
-            )
+            "Service '{}' not found in service_mirror_cfg".format(service)
         )
 
-    source_config_path = context.ditto_config_files[config_key]
+    token = context.service_mirror_cfg[service_key]["credentials"]
+    service_type = service.split("-")[1]
 
-    # Copy the config file to ditto-config.json in the working directory
-    target_config_path = "ditto-config.json"
-    cp_cmd = "cp {} {}".format(source_config_path, target_config_path)
-    when_i_run_command(
-        context,
-        cp_cmd,
-        "with sudo",
-        machine_name=machine_name,
+    repo_url = "https://bearer:{}@esm.ubuntu.com/{}/ubuntu/".format(
+        token, service_type
     )
 
-    # Run ditto from the working directory
-    ditto_cmd = "ditto"
+    dists = [
+        "{}-{}-{}".format(release, service_type, dist_suffix)
+        for dist_suffix in ["updates", "security"]
+    ]
+    download_path = "/var/spool/ditto-repo/{}/ubuntu/".format(service_type)
+
+    if "path" not in context.service_mirror_cfg[service_key]:
+        context.service_mirror_cfg[service_key]["path"] = (
+            "/var/spool/ditto-repo/{}/".format(service_type)
+        )
+
+    ditto_cmd = (
+        "ditto "
+        "--repo-url={} "
+        "--dists={} "
+        "--components=main "
+        "--archs=amd64 "
+        "--languages=en "
+        "--download-path={} "
+        "--workers=5"
+    ).format(repo_url, ",".join(dists), download_path)
+
     when_i_run_command(
         context,
         ditto_cmd,

--- a/features/util.py
+++ b/features/util.py
@@ -156,6 +156,7 @@ def repo_state_hash(
         if os.path.isdir(fname):
             continue
         with open(fname) as f:
+            print(fname)
             new_file_content += f.read()
 
     output_to_hash = rev_out + diff_out + new_file_content.encode("utf-8")


### PR DESCRIPTION
## Why is this needed?
apt-mirror [appears to be in need of maintainership](https://github.com/apt-mirror/apt-mirror#new-maintainers-wanted). ditto-repo is maintained by the Landscape team and fills a similar role.

## Test Steps
Run the behave tests and make sure they pass.

```
tox -e behave -- features/airgapped.feature
```

Feel free to run a lot of other tests as well to ensure there's no regressions.