### PR TITLE
chore: fix mypy static analysis

### DIFF
--- a/uaclient/api/u/pro/security/cves/_common/v1.py
+++ b/uaclient/api/u/pro/security/cves/_common/v1.py
@@ -205,7 +205,7 @@ class VulnerabilitiesAlreadyFixed:
 
 
 class VulnerabilityParser(metaclass=abc.ABCMeta):
-    vulnerability_type = None  # type: str
+    vulnerability_type: str
 
     @abc.abstractmethod
     def get_package_vulnerabilities(

--- a/uaclient/api/u/pro/security/cves/_common/v1.py
+++ b/uaclient/api/u/pro/security/cves/_common/v1.py
@@ -205,10 +205,9 @@ class VulnerabilitiesAlreadyFixed:
 
 
 class VulnerabilityParser(metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def vulnerability_type(self) -> str:
-        pass
+
+    # subclasses must override this
+    vulnerability_type = ""  # type: str
 
     @abc.abstractmethod
     def get_package_vulnerabilities(

--- a/uaclient/api/u/pro/security/cves/_common/v1.py
+++ b/uaclient/api/u/pro/security/cves/_common/v1.py
@@ -205,7 +205,10 @@ class VulnerabilitiesAlreadyFixed:
 
 
 class VulnerabilityParser(metaclass=abc.ABCMeta):
-    vulnerability_type = None  # type: str  # type: ignore[assignment]
+    @property
+    @abc.abstractmethod
+    def vulnerability_type(self) -> str:
+        pass
 
     @abc.abstractmethod
     def get_package_vulnerabilities(

--- a/uaclient/api/u/pro/security/cves/_common/v1.py
+++ b/uaclient/api/u/pro/security/cves/_common/v1.py
@@ -205,7 +205,7 @@ class VulnerabilitiesAlreadyFixed:
 
 
 class VulnerabilityParser(metaclass=abc.ABCMeta):
-    vulnerability_type: str
+    vulnerability_type = None  # type: str  # type: ignore[assignment]
 
     @abc.abstractmethod
     def get_package_vulnerabilities(

--- a/uaclient/clouds/identity.py
+++ b/uaclient/clouds/identity.py
@@ -36,6 +36,8 @@ class NoCloudTypeReason(Enum):
 def cloud_type_to_contract_cloud_type(
     cloud_type: Optional[str],
 ) -> Optional[str]:
+    if cloud_type is None:
+        return None
     return CONTRACT_CLOUD_TYPE_ALIASES.get(cloud_type, cloud_type)
 
 

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import socket
 from collections import namedtuple
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import uaclient.files.machine_token as mtf
 from uaclient import (
@@ -868,8 +868,8 @@ def get_contract_information(cfg: UAConfig, token: str) -> Dict[str, Any]:
 
 
 def _get_override_weight(
-    override_selector: Mapping[str, str],
-    selector_values: Mapping[str, Optional[str]],
+    override_selector: Dict[str, str],
+    selector_values: Dict[str, Optional[str]],
 ) -> int:
     override_weight = 0
     for selector, value in override_selector.items():

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import socket
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import uaclient.files.machine_token as mtf
 from uaclient import (
@@ -868,7 +868,8 @@ def get_contract_information(cfg: UAConfig, token: str) -> Dict[str, Any]:
 
 
 def _get_override_weight(
-    override_selector: Dict[str, str], selector_values: Dict[str, str]
+    override_selector: Mapping[str, str],
+    selector_values: Mapping[str, Optional[str]],
 ) -> int:
     override_weight = 0
     for selector, value in override_selector.items():
@@ -882,7 +883,7 @@ def _get_override_weight(
 def _select_overrides(
     entitlement: Dict[str, Any],
     series_name: str,
-    cloud_type: str,
+    cloud_type: Optional[str],
     variant: Optional[str] = None,
 ) -> Dict[int, Dict[str, Any]]:
     overrides = {}
@@ -943,10 +944,7 @@ def apply_contract_overrides(
     )
     cloud_type, _ = get_cloud_type()
 
-    # TODO(srunde3): in practice this is always a string (`_select_overrides`
-    # expects a string), but signatures allow for `None`.
-    # Fix these code paths so that it is always a string.
-    cloud_type = cast(str, cloud_type_to_contract_cloud_type(cloud_type))
+    cloud_type = cloud_type_to_contract_cloud_type(cloud_type)
     orig_entitlement = orig_access.get("entitlement", {})
 
     overrides = _select_overrides(

--- a/uaclient/contract.py
+++ b/uaclient/contract.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import socket
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import uaclient.files.machine_token as mtf
 from uaclient import (
@@ -942,7 +942,11 @@ def apply_contract_overrides(
         system.get_release_info().series if series is None else series
     )
     cloud_type, _ = get_cloud_type()
-    cloud_type = cloud_type_to_contract_cloud_type(cloud_type)
+
+    # TODO(srunde3): in practice this is always a string (`_select_overrides`
+    # expects a string), but signatures allow for `None`.
+    # Fix these code paths so that it is always a string.
+    cloud_type = cast(str, cloud_type_to_contract_cloud_type(cloud_type))
     orig_entitlement = orig_access.get("entitlement", {})
 
     overrides = _select_overrides(

--- a/uaclient/data_types.py
+++ b/uaclient/data_types.py
@@ -11,8 +11,8 @@ LOG = logging.getLogger(util.replace_top_level_logger_name(__name__))
 
 class IncorrectTypeError(exceptions.UbuntuProError):
     _formatted_msg = messages.E_INCORRECT_TYPE_ERROR_MESSAGE
-    expected_type = None  # type: str
-    got_type = None  # type: str
+    expected_type = None  # type: Optional[str]
+    got_type = None  # type: Optional[str]
 
 
 class IncorrectListElementTypeError(IncorrectTypeError):
@@ -37,7 +37,7 @@ class IncorrectDictElementTypeError(IncorrectTypeError):
 
 class IncorrectFieldTypeError(IncorrectTypeError):
     _formatted_msg = messages.E_INCORRECT_FIELD_TYPE_ERROR_MESSAGE
-    key = None  # type: str
+    key = None  # type: Optional[str]
 
     def __init__(self, *, err: IncorrectTypeError, key: str):
         super().__init__(key=key, nested_msg=err.msg)

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -49,7 +49,7 @@ class EntitlementWithMessage:
 
 class UAEntitlement(metaclass=abc.ABCMeta):
     # Required: short name of the entitlement
-    name = None  # type: str
+    name: str
 
     # Whether the entitlement supports the --access-only flag
     supports_access_only = False

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -48,8 +48,8 @@ class EntitlementWithMessage:
 
 
 class UAEntitlement(metaclass=abc.ABCMeta):
-    # Required: short name of the entitlement
-    name = None  # type: str  # type: ignore[assignment]
+    # Required: short name of the entitlement; subclasses must override
+    name = ""  # type: str
 
     # Whether the entitlement supports the --access-only flag
     supports_access_only = False

--- a/uaclient/entitlements/base.py
+++ b/uaclient/entitlements/base.py
@@ -49,7 +49,7 @@ class EntitlementWithMessage:
 
 class UAEntitlement(metaclass=abc.ABCMeta):
     # Required: short name of the entitlement
-    name: str
+    name = None  # type: str  # type: ignore[assignment]
 
     # Whether the entitlement supports the --access-only flag
     supports_access_only = False

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 
 from uaclient import messages
 
@@ -56,7 +56,7 @@ class UbuntuProError(Exception):
                 **kwargs
             )  # type: messages.NamedMessage
         else:
-            self.named_msg = self._msg  # type: ignore[assignment]
+            self.named_msg = cast(messages.NamedMessage, self._msg)
 
         self.additional_info = kwargs
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -53,14 +53,15 @@ class UbuntuProError(Exception):
     def __init__(self, **kwargs) -> None:
         if self._formatted_msg is not None:
             self.named_msg = self._formatted_msg.format(**kwargs)
-        else:
-            if self._msg is None:
-                raise AttributeError(
-                    "{} must define either _msg or _formatted_msg".format(
-                        self.__class__.__name__
-                    )
-                )
+        elif self._msg is not None:
             self.named_msg = self._msg
+        else:
+            # This should not be reached in practice; subclasses should
+            # override either _msg or _formatted_msg. Provide a safe default
+            # just in case.
+            self.named_msg = messages.NamedMessage(
+                "ubuntu-pro-error", "an unexpected error occurred."
+            )
 
         self.additional_info = kwargs
 

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -45,8 +45,8 @@ class UbuntuProError(Exception):
     All possible exceptions from our API should extend this class.
     """
 
-    _msg = None  # type: messages.NamedMessage
-    _formatted_msg = None  # type: messages.FormattedNamedMessage
+    _msg = None  # type: Optional[messages.NamedMessage]
+    _formatted_msg = None  # type: Optional[messages.FormattedNamedMessage]
 
     exit_code = 1
 
@@ -56,7 +56,7 @@ class UbuntuProError(Exception):
                 **kwargs
             )  # type: messages.NamedMessage
         else:
-            self.named_msg = self._msg
+            self.named_msg = self._msg  # type: ignore[assignment]
 
         self.additional_info = kwargs
 
@@ -198,9 +198,9 @@ class ProxyAuthenticationFailed(UbuntuProError):
 
 class ExternalAPIError(UbuntuProError):
     _formatted_msg = messages.E_EXTERNAL_API_ERROR
-    code = None  # type: int
-    url = None  # type: str
-    body = None  # type: str
+    code = None  # type: Optional[int]
+    url = None  # type: Optional[str]
+    body = None  # type: Optional[str]
 
     def __str__(self):
         return "{}: [{}], {}".format(self.code, self.url, self.body)
@@ -449,7 +449,7 @@ class NonInteractiveKernelPurgeDisallowed(UbuntuProError):
 
 class InvalidProImage(UbuntuProError):
     _formatted_msg = messages.E_INVALID_PRO_IMAGE
-    error_msg = None  # type: str
+    error_msg = None  # type: Optional[str]
 
 
 class CloudMetadataError(UbuntuProError):
@@ -638,7 +638,7 @@ class LockHeldError(UbuntuProError):
     """
 
     _formatted_msg = messages.E_LOCK_HELD_ERROR
-    pid = None  # type: int
+    pid = None  # type: Optional[int]
 
 
 class NonRootUserError(UbuntuProError):

--- a/uaclient/exceptions.py
+++ b/uaclient/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, Tuple
 
 from uaclient import messages
 
@@ -52,11 +52,15 @@ class UbuntuProError(Exception):
 
     def __init__(self, **kwargs) -> None:
         if self._formatted_msg is not None:
-            self.named_msg = self._formatted_msg.format(
-                **kwargs
-            )  # type: messages.NamedMessage
+            self.named_msg = self._formatted_msg.format(**kwargs)
         else:
-            self.named_msg = cast(messages.NamedMessage, self._msg)
+            if self._msg is None:
+                raise AttributeError(
+                    "{} must define either _msg or _formatted_msg".format(
+                        self.__class__.__name__
+                    )
+                )
+            self.named_msg = self._msg
 
         self.additional_info = kwargs
 

--- a/uaclient/http/__init__.py
+++ b/uaclient/http/__init__.py
@@ -107,7 +107,7 @@ def validate_proxy(
         raise exceptions.ProxyNotWorkingError(proxy=proxy)
 
 
-_global_proxy_dict: Dict[str, str] = {}
+_global_proxy_dict = {}  # type: Dict[str, str]
 
 
 def configure_web_proxy(

--- a/uaclient/http/__init__.py
+++ b/uaclient/http/__init__.py
@@ -107,7 +107,7 @@ def validate_proxy(
         raise exceptions.ProxyNotWorkingError(proxy=proxy)
 
 
-_global_proxy_dict = {}
+_global_proxy_dict: Dict[str, str] = {}
 
 
 def configure_web_proxy(

--- a/uaclient/http/serviceclient.py
+++ b/uaclient/http/serviceclient.py
@@ -13,7 +13,7 @@ class UAServiceClient(metaclass=abc.ABCMeta):
     url_timeout = 30  # type: Optional[int]
     # Cached serviceclient_url_responses if provided in uaclient.conf
     # via features: {serviceclient_url_responses: /some/file.json}
-    _response_overlay = None  # type: Dict[str, Any]
+    _response_overlay = None  # type: Optional[Dict[str, Any]]
 
     @property
     @abc.abstractmethod

--- a/uaclient/tests/test_exceptions.py
+++ b/uaclient/tests/test_exceptions.py
@@ -1,0 +1,13 @@
+from uaclient import exceptions, messages
+
+
+class TestAnonymousUbuntuProError:
+    def test_from_named_msg(self):
+        named_msg = messages.NamedMessage("test-code", "test message")
+
+        exc = exceptions.AnonymousUbuntuProError(named_msg=named_msg)
+
+        assert exc.named_msg == named_msg
+        assert exc.msg == "test message"
+        assert exc.msg_code == "test-code"
+        assert str(exc) == "test message"

--- a/uaclient/tests/test_exceptions.py
+++ b/uaclient/tests/test_exceptions.py
@@ -1,6 +1,55 @@
 from uaclient import exceptions, messages
 
 
+class TestUbuntuProError:
+    def test_uses_msg_when_subclass_defines_msg(self):
+        class MsgOnlyError(exceptions.UbuntuProError):
+            _msg = messages.NamedMessage("msg-only", "msg only path")
+
+        exc = MsgOnlyError()
+
+        assert exc.msg == "msg only path"
+        assert exc.msg_code == "msg-only"
+        assert str(exc) == "msg only path"
+        assert exc.additional_info == {}
+
+    def test_uses_formatted_msg_when_subclass_defines_formatted_msg(self):
+        class FormattedOnlyError(exceptions.UbuntuProError):
+            _formatted_msg = messages.FormattedNamedMessage(
+                "formatted-only", "hello {name}"
+            )
+
+        exc = FormattedOnlyError(name="ubuntu")
+
+        assert exc.msg == "hello ubuntu"
+        assert exc.msg_code == "formatted-only"
+        assert str(exc) == "hello ubuntu"
+        assert exc.additional_info == {"name": "ubuntu"}
+        assert getattr(exc, "name") == "ubuntu"
+
+    def test_prefers_formatted_msg_when_both_are_defined(self):
+        class BothDefinedError(exceptions.UbuntuProError):
+            _msg = messages.NamedMessage("msg-branch", "from msg")
+            _formatted_msg = messages.FormattedNamedMessage(
+                "formatted-branch", "from formatted {value}"
+            )
+
+        exc = BothDefinedError(value="path")
+
+        assert exc.msg == "from formatted path"
+        assert exc.msg_code == "formatted-branch"
+
+    def test_uses_safe_fallback_when_neither_is_defined(self):
+        class NoMessageFieldsError(exceptions.UbuntuProError):
+            pass
+
+        exc = NoMessageFieldsError()
+
+        assert exc.msg == "an unexpected error occurred."
+        assert exc.msg_code == "ubuntu-pro-error"
+        assert str(exc) == "an unexpected error occurred."
+
+
 class TestAnonymousUbuntuProError:
     def test_from_named_msg(self):
         named_msg = messages.NamedMessage("test-code", "test message")


### PR DESCRIPTION
## Why is this needed?

CI is broken due to invalid mypy typing. Most of these are situations in which a base class intends for a subclass to define a field and uses `None` as a sentinel value. This makes the field optional, and it complicates the typing a bit.

Where possible I've just marked the types as optional. In some cases, all the subclasses properly override the attribute, so we can replace `None` with `""` to simplify typing.

I've added test coverage for `UbuntuProError` and have added a safe default in case `_msg` and `_formatted_msg` aren't defined; this simplifies the typing. I couldn't find any examples where these weren't overridden by a leaf class anyway. This change ensures that in the worst case, the user gets a slightly less helpful error message instead of a runtime error.

## Test Steps

See the CI for "Static Analysis"