### PR TITLE
fix: add cap perfmon to cloud_id AppArmor profile #LP: 2153472

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -125,6 +125,11 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     include <abstractions/python>
 
     ptrace read peer=unconfined,
+    # LP: #2153472
+    # Include perfmon only for noble+; avoid changing releases that don't report the bug.
+{% if ubuntu_codename not in ["xenial", "bionic", "focal", "jammy"] %}
+    capability perfmon,
+{% endif %}
 
     /etc/cloud/** r,
     /etc/apt/** r,

--- a/sru/release-38/capability-perfmon-cloud-id.md
+++ b/sru/release-38/capability-perfmon-cloud-id.md
@@ -6,4 +6,27 @@ This bug is hard to reproduce locally since it only detectable on Azure VMs.
 
 This only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
 
-TODO: get confirmation from CPC team that bug is addressed. Use that as evidence; we'll have to trust them if we can't repro in our environments.
+The CPC team has confirmed that the addition of this capability fixes their issue and has provided reproduction steps:
+
+Reproduce using canonical:ubuntu-24_04-lts:server:latest image on Azure
+
+Confirm there no are no denials present initially:
+
+```sh
+journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'cloud_id'
+sudo apt update
+journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'cloud_id'
+```
+
+Attach to Pro:
+
+```sh
+sudo ua attach <token> --no-auto-enable
+```
+
+Confirm that denials appear after attaching:
+
+```sh
+sudo apt update
+journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'cloud_id'
+```

--- a/sru/release-38/capability-perfmon-cloud-id.md
+++ b/sru/release-38/capability-perfmon-cloud-id.md
@@ -1,14 +1,12 @@
 # Add capability `perfmon` to `cloud_id`
 
-This bug is hard to reproduce locally since it only detectable on Azure VMs.
+This bug is hard to reproduce locally since it only detectable on Azure VMs. This only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
 
-## Notes for SRU
+The CPC team has confirmed that the addition of this capability fixes their issue and has provided reproduction steps.
 
-This only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
+## Reproduction
 
-The CPC team has confirmed that the addition of this capability fixes their issue and has provided reproduction steps:
-
-Reproduce using canonical:ubuntu-24_04-lts:server:latest image on Azure
+Reproduce using canonical:ubuntu-24_04-lts:server:latest image on Azure.
 
 Confirm there no are no denials present initially:
 
@@ -30,3 +28,5 @@ Confirm that denials appear after attaching:
 sudo apt update
 journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'cloud_id'
 ```
+
+When using a build including this fix, there should be no denials after attaching.

--- a/sru/release-38/capability-perfmon-cloud-id.md
+++ b/sru/release-38/capability-perfmon-cloud-id.md
@@ -1,6 +1,6 @@
 # Add capability `perfmon` to `cloud_id`
 
-This bug is hard to reproduce locally since it only detectable on Azure VMs. This only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
+This bug is hard to reproduce locally since it is only detectable on Azure VMs. This fix only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
 
 The CPC team has confirmed that the addition of this capability fixes their issue and has provided reproduction steps.
 
@@ -8,7 +8,7 @@ The CPC team has confirmed that the addition of this capability fixes their issu
 
 Reproduce using canonical:ubuntu-24_04-lts:server:latest image on Azure.
 
-Confirm there no are no denials present initially:
+Confirm there are no denials present initially:
 
 ```sh
 journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'cloud_id'

--- a/sru/release-38/capability-perfmon-cloud-id.md
+++ b/sru/release-38/capability-perfmon-cloud-id.md
@@ -1,0 +1,9 @@
+# Add capability `perfmon` to `cloud_id`
+
+This bug is hard to reproduce locally since it only detectable on Azure VMs.
+
+## Notes for SRU
+
+This only adds a capability; releases that didn't need this capability won't be affected. Releases that didn't define this capability are explicitly excluded using the templating.
+
+TODO: get confirmation from CPC team that bug is addressed. Use that as evidence; we'll have to trust them if we can't repro in our environments.


### PR DESCRIPTION
## Why is this needed?

This fixes AppArmor denials seen in Azure VMs that attach to Pro on Noble.

## Test Steps

See SRU note. The CPC team has manually tested this fix and has confirmed that it addresses the bug.
