### PR TITLE
add placeholder files to fix RTD CI

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,3 +10,5 @@ build:
       # Docs are kept in separate docs and docs-devel branches.
       - exit 183
 
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,3 +12,4 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+  

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,9 @@
+# Placeholder Sphinx configuration for Read the Docs pull request build validation.
+#
+# The real documentation for this project lives in the docs branch.
+# Builds from main are skipped by .readthedocs.yaml with exit 183.
+# Do not add real project documentation configuration here.
+
+project = "Ubuntu Pro Client"
+extensions = []
+master_doc = "index"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,8 @@
+Placeholder documentation root
+==============================
+
+This is a placeholder Sphinx documentation root.
+
+The real documentation for this project lives in the ``docs`` branch.
+This file exists only so Read the Docs can validate pull request builds
+for branches that do not contain the real documentation source.


### PR DESCRIPTION
## Why is this needed?

Fixing the broken RTD CI, which now requires the Sphinx configuration file is specified. Since our docs are in a separate branch, I've added placeholder values just to meet the requirements for RTD.

In the future, the docs will ideally be moved to the `main` branch and these changes can be undone. The work in this PR is just to get the CI to pass so it stops being annoying