### PR TITLE
fix: include jammy in distros that receive perfmon for esm-detect-virt AppArmor profile LP: #2156929

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -318,8 +318,9 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
 
     capability sys_ptrace,
     # LP: #2143251
-    # Include only for noble+; avoid changing releases that don't report the bug.
-{% if ubuntu_codename not in ["xenial", "bionic", "focal", "jammy"] %}
+    # LP: #2156929
+    # Include only for jammy+; avoid changing releases that don't report the bug.
+{% if ubuntu_codename not in ["xenial", "bionic", "focal"] %}
     capability perfmon,
 {% endif %}
 

--- a/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
+++ b/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
@@ -61,3 +61,7 @@ sudo apt update
 # Confirm still no logs
 journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'ubuntu_pro_esm_cache'
 ```
+
+## Amended to include jammy
+
+Amended to include jammy as well as of [LP #2156929](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2156929). This has the same reproduction steps and was confirmed to fix the issue on jammy by the CPC team.

--- a/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
+++ b/sru/release-38/ubuntu-pro-esm-cache-detect-virt-apparmor.md
@@ -64,4 +64,4 @@ journalctl --no-pager | grep 'apparmor="DENIED"' | grep 'ubuntu_pro_esm_cache'
 
 ## Amended to include jammy
 
-Amended to include jammy as well as of [LP #2156929](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2156929). This has the same reproduction steps and was confirmed to fix the issue on jammy by the CPC team.
+Amended to include jammy as of [LP #2156929](https://bugs.launchpad.net/ubuntu/+source/ubuntu-advantage-tools/+bug/2156929). This has the same reproduction steps and was confirmed by the CPC team to fix the issue on jammy.


### PR DESCRIPTION
## Why is this needed?

Relates to https://github.com/canonical/ubuntu-pro-client/pull/3540. This includes jammy in the released distros.

## Test Steps

The bug is difficult to reproduce locally. The CPC team has confirmed that this fix addresses the bug on jammy.

The CPC team has only reported this bug on `ppc64el` arch.