### PR TITLE
test: update _version.feature to run resolute; remove plucky

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -75,16 +75,16 @@ Feature: Pro is expected version
       | noble    | azure.pro      |
       | noble    | gcp.generic    |
       | noble    | gcp.pro        |
-      | plucky   | lxd-container  |
-      | plucky   | lxd-vm         |
-      | plucky   | aws.generic    |
-      | plucky   | azure.generic  |
-      | plucky   | gcp.generic    |
       | questing | lxd-container  |
       | questing | lxd-vm         |
       | questing | aws.generic    |
       | questing | azure.generic  |
       | questing | gcp.generic    |
+      | resolute | lxd-container  |
+      | resolute | lxd-vm         |
+      | resolute | aws.generic    |
+      | resolute | azure.generic  |
+      | resolute | gcp.generic    |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version
@@ -115,8 +115,8 @@ Feature: Pro is expected version
       | focal    | lxd-container |
       | jammy    | lxd-container |
       | noble    | lxd-container |
-      | plucky   | lxd-container |
       | questing | lxd-container |
+      | resolute | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Attached show version in a ubuntu machine
@@ -138,8 +138,8 @@ Feature: Pro is expected version
       | xenial   | lxd-container |
       | jammy    | lxd-container |
       | noble    | lxd-container |
-      | plucky   | lxd-container |
       | questing | lxd-container |
+      | resolute | lxd-container |
 
   @arm64
   Scenario Outline: Check for newer versions of the client in an ubuntu machine
@@ -222,5 +222,5 @@ Feature: Pro is expected version
       | focal    | lxd-container |
       | jammy    | lxd-container |
       | noble    | lxd-container |
-      | plucky   | lxd-container |
       | questing | lxd-container |
+      | resolute | lxd-container |

--- a/features/environment.py
+++ b/features/environment.py
@@ -510,7 +510,7 @@ def _get_relevant_apparmor_logs(context):
         sut = context.machines[SUT]
         if sut.cloud == "lxd-container":
             # get apparmor DENIED messages from the host
-            with open("/var/log/syslog", "r") as syslog_fd:
+            with open("/var/log/syslog", "r", errors="replace") as syslog_fd:
                 syslog_messages = syslog_fd.readlines()
             apparmor_denied = [
                 msg.strip()

--- a/features/environment.py
+++ b/features/environment.py
@@ -510,7 +510,7 @@ def _get_relevant_apparmor_logs(context):
         sut = context.machines[SUT]
         if sut.cloud == "lxd-container":
             # get apparmor DENIED messages from the host
-            with open("/var/log/syslog", "r", errors="replace") as syslog_fd:
+            with open("/var/log/syslog", "r") as syslog_fd:
                 syslog_messages = syslog_fd.readlines()
             apparmor_denied = [
                 msg.strip()


### PR DESCRIPTION
## Why is this needed?

This is the first of many PRs to update the `behave` e2e tests for Resolute. We are also dropping test coverage for Plucky, which is past EOL.

## Test Steps

```
UACLIENT_BEHAVE_INSTALL_FROM=archive tox -e behave -- features/_version.feature -D releases=resolute -D machine_types=lxd-container
```