### PR TITLE
fix: include PID directory itself in apparmor profile

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -109,6 +109,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /dev/tty r,
 
     @{PROC}/ r,
+    @{PROC}/@{pid}/ r,
     @{PROC}/@{pid}/** r,
     @{PROC}/uptime r,
     @{PROC}/sys/kernel/** r,


### PR DESCRIPTION
## Why is this needed?

TODO: verify this with the AppArmor team.

## Test Steps

Repro:

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/api/full_token_attach.feature -D releases=resolute -D machine_types=lxd-container
```
