### PR TITLE
fix: include PID directory read perm in AppArmor profiles

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -109,6 +109,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /dev/tty r,
 
     @{PROC}/ r,
+    @{PROC}/@{pid}/ r,
     @{PROC}/@{pid}/** r,
     @{PROC}/uptime r,
     @{PROC}/sys/kernel/** r,


### PR DESCRIPTION
## Why is this needed?

This allows pro client to list items in the `proc/<pid>` directory, not just read files under that dir.

Confirmed with the AppArmor team that both rules are necessary for full read access to the process's PID dir.

## Test Steps

This is visible in at least the following scenario, "Attach command with attach config". Add a line for Resolute if not already present on this branch and run it with and without this fix to see the difference:

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/cli/attach.feature:125 -D releases=resolute -D machine_types=lxd-container
```

There should be no AppArmor DENIED logs with this fix.