### PR TITLE
ci: run resolute and stonking in behave test workflow

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -14,6 +14,9 @@ defaults:
   run:
     shell: sh -ex {0}
 
+env:
+  DEVELOPMENT_RELEASE: 'stonking'
+
 jobs:
   check-secrets:
     name: Check secrets
@@ -27,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
     steps:
       - name: Prepare build tools
         env:
@@ -47,7 +50,7 @@ jobs:
         run: |
           gbp dch --ignore-branch --snapshot --distribution=${{ matrix.release }}
           dch --local=~${{ matrix.release }} ""
-          if [ \"${{ matrix.release }}\" = \"noble\" ]; then  # TODO update this for the new devel after noble is released
+          if [ "${{ matrix.release }}" = "${{ env.DEVELOPMENT_RELEASE }}" ]; then
             SKIP_PROPOSED=""
           else
             SKIP_PROPOSED="--skip-proposed"
@@ -70,7 +73,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy', 'noble']
+        release: ['bionic', 'focal', 'jammy', 'noble', 'resolute']
         platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -73,7 +73,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy', 'noble', 'resolute']
+        release: ['bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
         platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:


### PR DESCRIPTION
## Why is this needed?

This ensures that as tests are added, they are gated in CI.

Tests for Resolute are being added; there may not be any ready to run when this PR goes through. There also aren't any tests for Stonking yet.

This PR also makes a small refactor to indicate that we `--skip-proposed` for the development release, not arbitrary releases. This should make it more clear when something needs to be updated.

## Test Steps

None - see changes working CI. Should see "passed" for resolute and stonking since we don't have any tests.