### PR TITLE
chore: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## Project overview
+
+`ubuntu-pro-client` (the `pro` command, package `ubuntu-advantage-tools`) is a Python client that attaches Ubuntu machines to Ubuntu Pro and manages its services (ESM, Livepatch, FIPS, etc.). The `main` branch supports very old Ubuntu releases (back to 16.04 Xenial), so avoid modern-only syntax and dependencies. Xenial runs on Python 3.5.
+
+- Target Python is the version shipped with supported Ubuntu releases; do not assume the latest Python features are available.
+- Only use dependencies already declared in `requirements*.txt` / `setup.py`. Do not add new runtime dependencies without strong justification.
+
+## Repository layout
+
+- `uaclient/` -- main Python source (CLI, API, entitlements, config, messages).
+- `uaclient/tests/` and `uaclient/**/tests/` -- unit tests (pytest).
+- `uaclient/messages/` -- user-facing strings (see string policy below).
+- `features/` -- behave integration tests (`.feature` + step `.py` files).
+- `apt-hook/`, `lib/`, `tools/`, `systemd/`, `update-motd.d/` -- supporting C++, shell, and helper code.
+- `dev-docs/` -- developer how-to guides; `docs/` -- user documentation.
+- `debian/` -- packaging, including `debian/po/` translations.
+
+## Environment setup
+
+The Python environment and dependencies should already be installed by `workshop`. Flag any missing dependencies or tooling to the user.
+
+## Common commands
+
+Run all lint + unit checks (matches CI defaults):
+
+```bash
+tox
+```
+
+Individual environments (see `tox.ini` for the full list):
+
+- `tox -e test` -- unit tests (pytest).
+- `tox -e test -- uaclient/tests/test_actions.py` -- a single test file.
+- `tox -e flake8` -- Python linter.
+- `tox -e mypy` -- type checker.
+- `tox -e black` / `tox -e isort` -- formatting checks.
+- `tox -e shellcheck` -- shell script linter.
+- `tox -e reformat-gherkin` -- `.feature` file formatting.
+- `tox -e behave` -- integration tests (slow; see below).
+
+## Code style
+
+- Format with `black` and sort imports with `isort`
+- Keep code compatible with Python 3.5 to keep support for Xenial
+- Use type annotations and keep `tox -e mypy` clean.
+- Match existing patterns in the module you are editing; prefer small, focused changes over broad refactors.
+
+## Testing instructions
+
+- Add or update unit tests for any code you change; put them beside the code in the matching `tests/` directory.
+- Tests use pytest with `mock`/`unittest.mock`. Tests are grouped in classes.
+- `autouse` fixtures in `conftest.py` prevent host side effects and assume the process runs as root -- rely on them rather than touching the real system.
+- Always run `tox -e test` (and the relevant lint envs) and make the suite green before declaring a change complete.
+
+### Integration (behave) tests
+
+Integration tests launch real LXD/cloud instances and are slow. Integration tests should only be run when they are specifically requested by the user.
+
+## User-facing strings policy
+
+Strings in `uaclient/messages/` are translated (see `debian/po/`). Changing an existing string requires justification in the PR (typo, factual error, or a product-driven wording change) and can affect translations. Prefer adding a new string over editing an existing one when the meaning changes. See [dev-docs/explanation/string_changes_policy.md](dev-docs/explanation/string_changes_policy.md).
+
+## Things to avoid
+
+- Do not add new runtime dependencies or drop support for old Ubuntu releases.
+- Do not edit `debian/changelog` version entries or packaging metadata unless the task is specifically a release/packaging change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,21 @@
 # AGENTS.md
 
+## Terminology
+
+The keywords MUST, MUST NOT, SHOULD, SHOULD NOT and MAY describe the strength and meaning of instructions in this file and other agent files in this repo.
+
+MUST -- This is a mandatory requirement. Follow it unless a higher-priority instruction from the user or execution environment directly conflicts with it.
+MUST NOT -- This action is prohibited.
+SHOULD -- This is the expected default. Deviate only when there is a clear, task-specific reason, and explain the deviation in the final response.
+SHOULD NOT -- Avoid this action unless there is a clear, task-specific reason to do otherwise.
+MAY -- This action is optional. Use judgment based on the task and surrounding code.
+
 ## Project overview
 
 `ubuntu-pro-client` is a Python client that attaches Ubuntu machines to Ubuntu Pro and manages its services (ESM, Livepatch, FIPS, etc.). The `main` branch supports very old Ubuntu releases (back to 16.04 Xenial), so avoid modern-only syntax and dependencies. Xenial runs on Python 3.5.
 
-- The target Python is the version shipped with supported Ubuntu releases (3.5); do not assume the latest Python features are available.
-- Only use dependencies already declared in `requirements*.txt` / `setup.py`. Do not add new runtime dependencies without strong justification.
+- The target Python is the version shipped with supported Ubuntu releases (3.5); you MUST NOT assume the latest Python features are available.
+- You MUST only use dependencies already declared in `requirements*.txt` / `setup.py`. You SHOULD NOT add new runtime dependencies unless there is strong justification.
 
 ## Repository layout
 
@@ -19,7 +29,7 @@
 
 ## Environment setup
 
-The Python environment and dependencies should already be installed by `workshop`. Flag any missing dependencies or tooling to the user.
+The Python environment and dependencies SHOULD already be installed by `workshop`. You MUST flag any missing dependencies or tooling to the user.
 
 ## Common commands
 
@@ -40,27 +50,27 @@ See `tox.ini` for the full list.
 
 ## Code style
 
-- Format with `black` and sort imports with `isort`
-- Keep code compatible with Python 3.5 to keep support for Xenial
-- Use type annotations and keep `tox -e mypy` clean.
-- Match existing patterns in the module you are editing; prefer small, focused changes over broad refactors.
+- You MUST format with `black` and sort imports with `isort`.
+- You MUST keep code compatible with Python 3.5 to preserve Xenial support.
+- You SHOULD use type annotations and keep `tox -e mypy` clean.
+- You SHOULD match existing patterns in the module you are editing and prefer small, focused changes over broad refactors.
 
 ## Testing instructions
 
-- Add or update unit tests for any code you change; put them beside the code in the matching `tests/` directory.
-- Tests use pytest with `mock`/`unittest.mock`. Tests are grouped in classes.
-- `autouse` fixtures in `conftest.py` prevent host side effects and assume the process runs as root -- rely on them rather than touching the real system.
-- Always run `tox -e test` (and the relevant lint envs) and make the suite green before declaring a change complete.
+- You MUST add or update unit tests for any code you change, and place them in the matching `tests/` directory.
+- Tests MUST use pytest with `mock`/`unittest.mock`, and tests SHOULD be grouped in classes.
+- `autouse` fixtures in `conftest.py` prevent host side effects and assume the process runs as root; you MUST rely on them rather than touching the real system.
+- You MUST run `tox -e test` (and relevant lint envs) and ensure the suite is green before declaring a change complete.
 
 ### Integration (behave) tests
 
-Integration tests launch real LXD/cloud instances and are slow. Integration tests should only be run when they are specifically requested by the user.
+Integration tests launch real LXD/cloud instances and are slow. You SHOULD only run integration tests when specifically requested by the user.
 
 ## User-facing strings policy
 
-Strings in `uaclient/messages/` are translated (see `debian/po/`). Changing an existing string requires justification in the PR (typo, factual error, or a product-driven wording change) and can affect translations. Prefer adding a new string over editing an existing one when the meaning changes. See [dev-docs/explanation/string_changes_policy.md](dev-docs/explanation/string_changes_policy.md).
+Strings in `uaclient/messages/` are translated (see `debian/po/`). Changing an existing string MUST be justified in the PR (typo, factual error, or a product-driven wording change) and can affect translations. You SHOULD prefer adding a new string over editing an existing one when the meaning changes. See [dev-docs/explanation/string_changes_policy.md](dev-docs/explanation/string_changes_policy.md).
 
 ## Things to avoid
 
-- Do not add new runtime dependencies or drop support for old Ubuntu releases.
-- Do not edit `debian/changelog` version entries or packaging metadata unless the task is specifically a release/packaging change.
+- You MUST NOT add new runtime dependencies or drop support for old Ubuntu releases.
+- You MUST NOT edit `debian/changelog` version entries or packaging metadata unless the task is specifically a release/packaging change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Project overview
 
-`ubuntu-pro-client` (the `pro` command, package `ubuntu-advantage-tools`) is a Python client that attaches Ubuntu machines to Ubuntu Pro and manages its services (ESM, Livepatch, FIPS, etc.). The `main` branch supports very old Ubuntu releases (back to 16.04 Xenial), so avoid modern-only syntax and dependencies. Xenial runs on Python 3.5.
+`ubuntu-pro-client` is a Python client that attaches Ubuntu machines to Ubuntu Pro and manages its services (ESM, Livepatch, FIPS, etc.). The `main` branch supports very old Ubuntu releases (back to 16.04 Xenial), so avoid modern-only syntax and dependencies. Xenial runs on Python 3.5.
 
-- Target Python is the version shipped with supported Ubuntu releases; do not assume the latest Python features are available.
+- The target Python is the version shipped with supported Ubuntu releases (3.5); do not assume the latest Python features are available.
 - Only use dependencies already declared in `requirements*.txt` / `setup.py`. Do not add new runtime dependencies without strong justification.
 
 ## Repository layout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,9 @@ The Python environment and dependencies should already be installed by `workshop
 
 ## Common commands
 
-Run all lint + unit checks (matches CI defaults):
+Testing/linting is managed by `tox`.
 
-```bash
-tox
-```
-
-Individual environments (see `tox.ini` for the full list):
+Common environments:
 
 - `tox -e test` -- unit tests (pytest).
 - `tox -e test -- uaclient/tests/test_actions.py` -- a single test file.
@@ -39,6 +35,8 @@ Individual environments (see `tox.ini` for the full list):
 - `tox -e shellcheck` -- shell script linter.
 - `tox -e reformat-gherkin` -- `.feature` file formatting.
 - `tox -e behave` -- integration tests (slow; see below).
+
+See `tox.ini` for the full list.
 
 ## Code style
 


### PR DESCRIPTION
## Why is this needed?

`AGENTS.md` is the standard context for agent sessions. This PR introduces a minimal file including test commands, and an overview of the repo.

Treat this as an architectural change and review it as such; there isn't a concrete test to show that this is the "correct" agents file. Review that the content here is correct; I'm not too concerned about making the file complete yet; we can add as we go.