### PR TITLE
ci: fix broken azure-mgmt versions against pycloudlib; use Standard_B2s_v2 images on Azure

### DIFF
--- a/features/cloud.py
+++ b/features/cloud.py
@@ -536,7 +536,7 @@ class Azure(Cloud):
         )
         inst = self.api.launch(
             image_id=image_name,
-            instance_type="Standard_B2s",
+            instance_type="Standard_B2s_v2",
             user_data=user_data,
             inbound_ports=inbound_ports,
         )

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,9 @@ deps =
     jsonschema
     jq
     pycloudlib>=1!10.18.0,<1!11
+    azure-mgmt-network<31
+    azure-mgmt-compute<31
+    azure-mgmt-resource<31
     PyHamcrest
     requests
     toml==0.10

--- a/tox.ini
+++ b/tox.ini
@@ -68,9 +68,8 @@ deps =
     jsonschema
     jq
     pycloudlib>=1!10.18.0,<1!11
-    azure-mgmt-network<31
-    azure-mgmt-compute<31
-    azure-mgmt-resource<31
+    azure-mgmt-network<31  # https://github.com/canonical/pycloudlib/issues/501
+    azure-mgmt-compute<38  # https://github.com/canonical/pycloudlib/issues/511
     PyHamcrest
     requests
     toml==0.10


### PR DESCRIPTION
## Why is this needed?

The newest version of the Azure network management library is not compatible with pycloudlib. I've reported upstream as well: https://github.com/canonical/pycloudlib/issues/511

I'm also lumping in a fix for another known issue with Azure compute management: https://github.com/canonical/pycloudlib/issues/501

Lastly, Azure (or at least Canonical's org) also doesn't stock `Standard_B2s` images AFAIK; they're all `Standard_B2s_v2`.

## Test Steps

You'll need Azure credentials to reproduce and verify that this fixes the problem. Run a test like so, with and without this fix:

```sh
export UACLIENT_BEHAVE_CONTRACT_TOKEN=<YOUR TOKEN>
UACLIENT_BEHAVE_INSTALL_FROM=local && tox -r -e behave -- features/cli/attach.feature -D releases=focal -D machine_types=azure.generic
```