### PR TITLE
fix: xenial container network setup on recent-LTS hosts

### DIFF
--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -98,6 +98,23 @@ def given_a_machine(
     )
 
     if series == "xenial":
+        # On recent host kernels, the host AppArmor policy denies xenial's
+        # ISC dhclient from creating the raw AF_PACKET (LPF) socket it needs
+        # ("Open a socket for LPF: Permission denied"), so the container never
+        # gets an IPv4 DHCP lease and has no outbound network/DNS. Disable the
+        # in-container dhclient AppArmor profile and re-acquire the lease so
+        # the machine can reach the archive and contracts endpoints.
+        when_i_run_command(
+            context,
+            "bash -c '"
+            "ln -sf /etc/apparmor.d/sbin.dhclient /etc/apparmor.d/disable/ 2>/dev/null; "  # noqa: E501
+            "apparmor_parser -R /etc/apparmor.d/sbin.dhclient 2>/dev/null; "
+            "dhclient -v eth0'",
+            "with sudo",
+            verify_return=False,
+            machine_name=machine_name,
+        )
+
         # Upgrading open-iscsi to esm version on xenial restarts this service
         # This sometimes causes resource errors on github action runners
         when_i_run_command(

--- a/features/steps/machines.py
+++ b/features/steps/machines.py
@@ -98,22 +98,24 @@ def given_a_machine(
     )
 
     if series == "xenial":
-        # On recent host kernels, the host AppArmor policy denies xenial's
-        # ISC dhclient from creating the raw AF_PACKET (LPF) socket it needs
-        # ("Open a socket for LPF: Permission denied"), so the container never
-        # gets an IPv4 DHCP lease and has no outbound network/DNS. Disable the
-        # in-container dhclient AppArmor profile and re-acquire the lease so
-        # the machine can reach the archive and contracts endpoints.
-        when_i_run_command(
-            context,
-            "bash -c '"
-            "ln -sf /etc/apparmor.d/sbin.dhclient /etc/apparmor.d/disable/ 2>/dev/null; "  # noqa: E501
-            "apparmor_parser -R /etc/apparmor.d/sbin.dhclient 2>/dev/null; "
-            "dhclient -v eth0'",
-            "with sudo",
-            verify_return=False,
-            machine_name=machine_name,
-        )
+        if machine_type == "lxd-container":
+            # On recent host kernels (Noble+), the host AppArmor policy denies
+            # xenial's ISC dhclient the raw AF_PACKET (LPF) socket it needs
+            # ("Open a socket for LPF: Permission denied"), so the container
+            # never gets an IPv4 DHCP lease and has no outbound network/DNS.
+            # Disable the in-container dhclient AppArmor profile and re-acquire
+            # the lease so the machine can reach the archive and contracts
+            # endpoints.
+            when_i_run_command(
+                context,
+                "bash -c '"
+                "ln -sf /etc/apparmor.d/sbin.dhclient /etc/apparmor.d/disable/ 2>/dev/null; "  # noqa: E501
+                "apparmor_parser -R /etc/apparmor.d/sbin.dhclient 2>/dev/null; "
+                "timeout 60 dhclient -v eth0'",
+                "with sudo",
+                verify_return=False,
+                machine_name=machine_name,
+            )
 
         # Upgrading open-iscsi to esm version on xenial restarts this service
         # This sometimes causes resource errors on github action runners


### PR DESCRIPTION
## Why is this needed?
Launching a Xenial LXD container during behave tests on a recent-LTS host produces a broken container with no IPv4 address. The host AppArmor policy prevents Xenial's `dhclient` from completing DHCP, so the container never gets network.

This PR disables the in-container dhclient AppArmor profile and re-acquires the lease, restoring connectivity.

## Test Steps
Prepare a host machine that is Noble (24.04) or more recent.
Run a feature test on Xenial using `lxd-container`, and verify that the test no longer fails during token attachment.
```
UACLIENT_BEHAVE_CONTRACT_TOKEN=<your-token> \
tox -e behave -- features/cli/attach.feature -D releases=xenial -D machine_types=lxd-container
```
