### PR TITLE
fix: allow /usr/share/coreutils/locales/** in ubuntu_pro_esm_cache//cloud_id AppArmor profile

### DIFF
--- a/debian/apparmor/ubuntu_pro_esm_cache.jinja2
+++ b/debian/apparmor/ubuntu_pro_esm_cache.jinja2
@@ -149,6 +149,7 @@ profile ubuntu_pro_esm_cache flags=(attach_disconnected) {
     /{,usr/}bin/python3.{1,}[0-9] mrix,
     # LP: #2067319, #2123870
     /{bin/,usr/bin/,usr/bin/gnu,usr/lib/cargo/bin/coreutils/}uname mrix,
+    /usr/share/coreutils/locales/** r,
 
     /usr/share/dpkg/** r,
 

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -408,13 +408,10 @@ Feature: CLI attach command
     And I verify that `livepatch` status is `<livepatch_status>`
 
     Examples: ubuntu release
-      | release | machine_type | livepatch_status |
-      | xenial  | lxd-vm       | warning          |
-      | bionic  | lxd-vm       | enabled          |
-      | focal   | lxd-vm       | enabled          |
-      | jammy   | lxd-vm       | enabled          |
-      | noble   | lxd-vm       | enabled          |
-
-# TODO: Re-enable resolute once cloud_id AppArmor profile
-# allows coreutils locale reads in ubuntu_pro_esm_cache//cloud_id.
-# | resolute | lxd-vm      | enabled          |
+      | release  | machine_type | livepatch_status |
+      | xenial   | lxd-vm       | warning          |
+      | bionic   | lxd-vm       | enabled          |
+      | focal    | lxd-vm       | enabled          |
+      | jammy    | lxd-vm       | enabled          |
+      | noble    | lxd-vm       | enabled          |
+      | resolute | lxd-vm       | enabled          |

--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -256,16 +256,14 @@ Feature: CLI disable command
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | lxd-vm       |
-      | bionic  | lxd-vm       |
-      | focal   | lxd-vm       |
-      | jammy   | lxd-vm       |
-      | noble   | lxd-vm       |
+      | release  | machine_type |
+      | xenial   | lxd-vm       |
+      | bionic   | lxd-vm       |
+      | focal    | lxd-vm       |
+      | jammy    | lxd-vm       |
+      | noble    | lxd-vm       |
+      | resolute | lxd-vm       |
 
-  # TODO: Re-enable resolute once cloud_id AppArmor profile
-  # allows coreutils locale reads in ubuntu_pro_esm_cache//cloud_id.
-  # | resolute| lxd-vm       |
   @slow
   Scenario Outline: Disable and purge fips
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/environment.py
+++ b/features/environment.py
@@ -33,6 +33,17 @@ stderr:
 """
 
 
+# TODO(srunde3): remove once https://github.com/canonical/ubuntu-pro-client/pull/3540
+# lands upstream.
+# AppArmor checks are brittle against failures upstream; they detect a false positive
+# if there is a denial before the package-under-test has even installed.
+IGNORED_APPARMOR_DENIAL_PATTERNS = [
+    re.compile(
+        r'profile="ubuntu_pro_esm_cache_systemd_detect_virt".*capname="perfmon"'
+    ),
+]
+
+
 class UAClientBehaveConfig:
     """Store config options for Pro client behave test runs.
 
@@ -543,11 +554,26 @@ def _get_relevant_apparmor_logs(context):
 
             with open(syslog_dest, "r") as syslog_fd:
                 syslog_messages = syslog_fd.readlines()
-            apparmor_denied = [
-                msg.strip()
-                for msg in syslog_messages
-                if ("DENIED" in msg and "ubuntu_pro_" in msg)
-            ]
+            apparmor_denied = []
+            ignored_apparmor_denied = []
+            for msg in syslog_messages:
+                if "DENIED" not in msg or "ubuntu_pro_" not in msg:
+                    continue
+
+                if any(
+                    pattern.search(msg)
+                    for pattern in IGNORED_APPARMOR_DENIAL_PATTERNS
+                ):
+                    ignored_apparmor_denied.append(msg.strip())
+                    continue
+
+                apparmor_denied.append(msg.strip())
+
+            if ignored_apparmor_denied:
+                logging.warning("Ignored some known failures for AppArmor:")
+                logging.warning("--- BEGIN IGNORED APPARMOR FAILURES --- ")
+                logging.warning("\n".join(ignored_apparmor_denied))
+                logging.warning("--- END IGNORED APPARMOR FAILURES --- ")
             return apparmor_denied
     return None
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -33,13 +33,16 @@ stderr:
 """
 
 
-# TODO(srunde3): remove once https://github.com/canonical/ubuntu-pro-client/pull/3540
+# TODO(srunde3): remove once
+# https://github.com/canonical/ubuntu-pro-client/pull/3540
 # lands upstream.
-# AppArmor checks are brittle against failures upstream; they detect a false positive
+# AppArmor checks are brittle against failures upstream; they detect a false
+# positive
 # if there is a denial before the package-under-test has even installed.
 IGNORED_APPARMOR_DENIAL_PATTERNS = [
     re.compile(
-        r'profile="ubuntu_pro_esm_cache_systemd_detect_virt".*capname="perfmon"'
+        r'profile="ubuntu_pro_esm_cache_systemd_detect_virt"'
+        r'.*capname="perfmon"'
     ),
 ]
 


### PR DESCRIPTION
## Why is this needed?

This issue was introduced on Resolute.

This PR also introduces an "allowlist" for certain AppArmor denials. The test harness is sensitive to denials that have already made it into the upstream release; I'll fix this in a dedicated PR, but this workaround gets us unstuck quicker and keeps our pipeline clean.

## Test Steps

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/cli/attach.feature -D releases=resolute -D machine_types=lxd-container,lxd-vm
```