### PR TITLE
launch xenial lxd vm without secureboot on newer lxd

### DIFF
--- a/dev-docs/tutorial/getting-started.md
+++ b/dev-docs/tutorial/getting-started.md
@@ -93,6 +93,13 @@ Install `lxd`:
 sudo snap install lxd
 ```
 
+> **Note**
+> We develop and test against LXD 6.x (the version available on recent Ubuntu
+> LTS releases such as Noble). Some behaviour the test suite relies on -- for
+> example the `boot.mode` instance option used for Xenial VMs -- requires a
+> recent LXD, so older LXD versions are not supported for running the
+> integration tests.
+
 Add yourself to the `lxd` group and use `newgrp` to apply the change without
 logging out and back in:
 
@@ -121,6 +128,12 @@ We need the boot parameters `systemd.unified_cgroup_hierarchy=0` and
 > Unfortunately, this means your host will miss out on the benefits and safety
 > features of cgroup v2, but it is necessary for developing and supporting
 > Ubuntu Pro Client for Xenial.
+
+We also test Xenial support using Xenial LXD virtual machines. Xenial VMs must
+be launched with secure boot disabled, so the test suite sets the
+`boot.mode: uefi-nosecureboot` instance option when creating them. This option
+is provided by LXD 6.x; it replaces the older `security.secureboot` key that
+newer LXD versions no longer accept for virtual machines.
 
 Use [this how-to guide](https://wiki.ubuntu.com/Kernel/KernelBootParameters) to
 edit your Linux kernel boot parameter. First make the change temporarily, and

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -704,42 +704,21 @@ class _LXD(Cloud):
         )
 
         if self.name == "lxd-virtual-machine" and series == "xenial":
-            # Livepatch won't apply patches on Xenial with secure boot enabled
-            config_dict = {"security.secureboot": False}
+            # Livepatch won't apply patches on Xenial with secure boot enabled.
+            # "boot.mode" is the config key used by LXD 6.x (the version we
+            # develop against on Noble); it replaces the older
+            # "security.secureboot" key.
+            config_dict = {"boot.mode": "uefi-nosecureboot"}
         else:
             config_dict = {}
 
-        try:
-            inst = self.api.launch(
-                name=instance_name,
-                image_id=image_name,
-                user_data=user_data,
-                ephemeral=ephemeral,
-                config_dict=config_dict,
-            )
-        except RuntimeError as e:
-            # Some LXD versions no longer support the "security.secureboot"
-            # config key for virtual-machines and reject it at instance
-            # creation time. It is only set to allow Livepatch on Xenial, so
-            # fall back to launching without it when it is not supported.
-            if "security.secureboot" in config_dict and (
-                "security.secureboot" in str(e)
-            ):
-                logging.warning(
-                    "LXD rejected 'security.secureboot'; retrying launch "
-                    "without it: %s",
-                    e,
-                )
-                config_dict.pop("security.secureboot")
-                inst = self.api.launch(
-                    name=instance_name,
-                    image_id=image_name,
-                    user_data=user_data,
-                    ephemeral=ephemeral,
-                    config_dict=config_dict,
-                )
-            else:
-                raise
+        inst = self.api.launch(
+            name=instance_name,
+            image_id=image_name,
+            user_data=user_data,
+            ephemeral=ephemeral,
+            config_dict=config_dict,
+        )
         return inst
 
     def get_instance_id(

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -704,10 +704,6 @@ class _LXD(Cloud):
         )
 
         if self.name == "lxd-virtual-machine" and series == "xenial":
-            # Livepatch won't apply patches on Xenial with secure boot enabled.
-            # "boot.mode" is the config key used by LXD 6.x (the version we
-            # develop against on Noble); it replaces the older
-            # "security.secureboot" key.
             config_dict = {"boot.mode": "uefi-nosecureboot"}
         else:
             config_dict = {}

--- a/features/cloud.py
+++ b/features/cloud.py
@@ -709,13 +709,37 @@ class _LXD(Cloud):
         else:
             config_dict = {}
 
-        inst = self.api.launch(
-            name=instance_name,
-            image_id=image_name,
-            user_data=user_data,
-            ephemeral=ephemeral,
-            config_dict=config_dict,
-        )
+        try:
+            inst = self.api.launch(
+                name=instance_name,
+                image_id=image_name,
+                user_data=user_data,
+                ephemeral=ephemeral,
+                config_dict=config_dict,
+            )
+        except RuntimeError as e:
+            # Some LXD versions no longer support the "security.secureboot"
+            # config key for virtual-machines and reject it at instance
+            # creation time. It is only set to allow Livepatch on Xenial, so
+            # fall back to launching without it when it is not supported.
+            if "security.secureboot" in config_dict and (
+                "security.secureboot" in str(e)
+            ):
+                logging.warning(
+                    "LXD rejected 'security.secureboot'; retrying launch "
+                    "without it: %s",
+                    e,
+                )
+                config_dict.pop("security.secureboot")
+                inst = self.api.launch(
+                    name=instance_name,
+                    image_id=image_name,
+                    user_data=user_data,
+                    ephemeral=ephemeral,
+                    config_dict=config_dict,
+                )
+            else:
+                raise
         return inst
 
     def get_instance_id(


### PR DESCRIPTION
## Why is this needed?
Launching a xenial lxd-vm on a Noble host fails at creation: `Failed creating instance record: "security.secureboot" is not supported for "virtual-machine"`
Recent LXD versions dropped the security.secureboot key for VMs. I've changed the code so that when LXD rejects secureboot, the launch now retries without it. Only xenial is affected, since it's the only series that sets the key.

## Test Steps
Prepare a host machine that is Noble (24.04) or more recent.
Run a feature test on Xenial using `lxd-vm`, and verify that the test no longer fails during token attachment.
```
UACLIENT_BEHAVE_CONTRACT_TOKEN=<your-token> \
tox -e behave -- features/cli/attach.feature -D releases=xenial -D machine_types=lxd-vm
```