### PR TITLE
ci: skip tests on stonking

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute']  # TODO test on stonking
     steps:
       - name: Prepare build tools
         env:

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -75,7 +75,7 @@ jobs:
       # as much information as possible from them.
       fail-fast: false
       matrix:
-        release: ['bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
+        release: ['bionic', 'focal', 'jammy', 'noble', 'resolute']
         platform: ['lxd-container']
         host_os: ['ubuntu-22.04']
         include:

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -15,6 +15,7 @@ defaults:
     shell: sh -ex {0}
 
 env:
+  # TODO: stonking current untested: https://warthogs.atlassian.net/browse/UPRO-1274
   DEVELOPMENT_RELEASE: 'stonking'
 
 jobs:
@@ -30,7 +31,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute']  # TODO test on stonking
+        # TODO test on stonking: https://warthogs.atlassian.net/browse/UPRO-1274
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute']
     steps:
       - name: Prepare build tools
         env:


### PR DESCRIPTION
## Why is this needed?

Builds are failing on stonking due to an "invalid release file": https://github.com/canonical/ubuntu-pro-client/actions/runs/29359576529/job/87175934107

Stonking only publishes SHA512 in the Release, and apparently `debootstrap` doesn't know how to read them. Perhaps Stonking will publish other hashes eventually, but until then, we won't run our tests on it.

For example, Resolute: https://archive.ubuntu.com/ubuntu/dists/resolute-proposed/Release
vs. Stonking: https://archive.ubuntu.com/ubuntu/dists/stonking-proposed/Release

If Stonking never plans to have other hashes, we'll need to reevaluate our build pipeline.

## Test Steps

Run the CI against this branch.
