### PR TITLE
fix: CVE-2026-9494

### DIFF
--- a/uaclient/apt.py
+++ b/uaclient/apt.py
@@ -136,18 +136,31 @@ def assert_valid_apt_credentials(repo_url, username, password):
     @raises: UbuntuProError for invalid credentials, timeout or unexpected
         errors.
     """
-    protocol, repo_path = repo_url.split("://")
     if not os.path.exists("/usr/lib/apt/apt-helper"):
         return
+    protocol, repo_path = repo_url.split("://")
+    apt_auth_file = get_apt_auth_file_from_apt_config()
+    auth_path = apt_auth_file + "-validation"
+    if not repo_path.endswith("/"):
+        repo_path_slash = repo_path + "/"
+    else:
+        repo_path_slash = repo_path
+    auth_line = (
+        "machine {repo_path} login {username}"
+        " password {password}\n".format(
+            repo_path=repo_path_slash,
+            username=username,
+            password=password,
+        )
+    )
     try:
+        system.write_file(auth_path, auth_line, mode=0o600)
         with tempfile.TemporaryDirectory() as tmpd:
             system.subp(
                 [
                     "/usr/lib/apt/apt-helper",
                     "download-file",
-                    "{}://{}:{}@{}/pool/".format(
-                        protocol, username, password, repo_path
-                    ),
+                    "{}://{}/pool/".format(protocol, repo_path),
                     os.path.join(tmpd, "apt-helper-output"),
                 ],
                 timeout=APT_HELPER_TIMEOUT,
@@ -166,6 +179,8 @@ def assert_valid_apt_credentials(repo_url, username, password):
         raise exceptions.APTCommandTimeout(
             seconds=APT_HELPER_TIMEOUT, repo=repo_path
         )
+    finally:
+        system.ensure_file_absent(auth_path)
 
 
 def _parse_apt_update_for_invalid_apt_config(

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -175,6 +175,12 @@ class TestRemoveAptListFiles:
 
 
 class TestValidAptCredentials:
+    """Tests for assert_valid_apt_credentials.
+
+    Includes regression tests for CVE-2026-9494 (credential leakage
+    via /proc/<pid>/cmdline).
+    """
+
     @mock.patch("uaclient.system.subp")
     @mock.patch("os.path.exists", return_value=False)
     def test_passes_when_missing_apt_helper(self, m_exists, m_subp):

--- a/uaclient/tests/test_apt.py
+++ b/uaclient/tests/test_apt.py
@@ -188,9 +188,21 @@ class TestValidAptCredentials:
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
+    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.system.write_file")
+    @mock.patch(
+        "uaclient.apt.get_apt_auth_file_from_apt_config",
+        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
+    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_passes_on_valid_creds(
-        self, m_exists, m_subp, m_temporary_directory
+        self,
+        m_exists,
+        m_get_apt_auth,
+        m_write_file,
+        m_ensure_file_absent,
+        m_subp,
+        m_temporary_directory,
     ):
         """Succeed when apt-helper succeeds in authenticating to repo."""
         m_temporary_directory.return_value.__enter__.return_value = (
@@ -212,13 +224,21 @@ class TestValidAptCredentials:
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
-                "http://user:pwd@fakerepo/pool/",
+                "http://fakerepo/pool/",
                 expected_path,
             ],
             timeout=60,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
+        # Verify credentials are written to auth file, not in argv
+        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        m_write_file.assert_called_once_with(
+            auth_path,
+            "machine fakerepo/ login user password pwd\n",
+            mode=0o600,
+        )
+        m_ensure_file_absent.assert_called_once_with(auth_path)
 
     @pytest.mark.parametrize(
         "exit_code,stderr,error_msg",
@@ -252,10 +272,19 @@ class TestValidAptCredentials:
     )
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
+    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.system.write_file")
+    @mock.patch(
+        "uaclient.apt.get_apt_auth_file_from_apt_config",
+        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
+    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_process_execution_errors(
         self,
         m_exists,
+        m_get_apt_auth,
+        m_write_file,
+        m_ensure_file_absent,
         m_subp,
         m_temporary_directory,
         exit_code,
@@ -289,19 +318,34 @@ class TestValidAptCredentials:
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
-                "http://user:pwd@fakerepo/pool/",
+                "http://fakerepo/pool/",
                 expected_path,
             ],
             timeout=60,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
+        # Verify auth file is always cleaned up even on error
+        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        m_ensure_file_absent.assert_called_once_with(auth_path)
 
     @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
     @mock.patch("uaclient.system.subp")
+    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.system.write_file")
+    @mock.patch(
+        "uaclient.apt.get_apt_auth_file_from_apt_config",
+        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
+    )
     @mock.patch("uaclient.apt.os.path.exists", return_value=True)
     def test_errors_on_apt_helper_process_timeout(
-        self, m_exists, m_subp, m_temporary_directory
+        self,
+        m_exists,
+        m_get_apt_auth,
+        m_write_file,
+        m_ensure_file_absent,
+        m_subp,
+        m_temporary_directory,
     ):
         """Raise the appropriate user facing error from apt-helper timeout."""
         m_temporary_directory.return_value.__enter__.return_value = (
@@ -332,13 +376,73 @@ class TestValidAptCredentials:
             [
                 "/usr/lib/apt/apt-helper",
                 "download-file",
-                "http://user:pwd@fakerepo/pool/",
+                "http://fakerepo/pool/",
                 expected_path,
             ],
             timeout=APT_HELPER_TIMEOUT,
             retry_sleeps=APT_RETRIES,
         )
         assert [apt_helper_call] == m_subp.call_args_list
+        # Verify auth file is always cleaned up even on timeout
+        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        m_ensure_file_absent.assert_called_once_with(auth_path)
+
+    @mock.patch("uaclient.apt.tempfile.TemporaryDirectory")
+    @mock.patch("uaclient.system.subp")
+    @mock.patch("uaclient.system.ensure_file_absent")
+    @mock.patch("uaclient.system.write_file")
+    @mock.patch(
+        "uaclient.apt.get_apt_auth_file_from_apt_config",
+        return_value="/etc/apt/auth.conf.d/90ubuntu-advantage",
+    )
+    @mock.patch("uaclient.apt.os.path.exists", return_value=True)
+    def test_credentials_not_in_subprocess_argv(
+        self,
+        m_exists,
+        m_get_apt_auth,
+        m_write_file,
+        m_ensure_file_absent,
+        m_subp,
+        m_temporary_directory,
+    ):
+        """Credentials must not appear in apt-helper argv (CVE fix).
+
+        Verify that the bearer token / password is never passed as part
+        of the subprocess command line, preventing leakage via
+        /proc/<pid>/cmdline.
+        """
+        m_temporary_directory.return_value.__enter__.return_value = (
+            "/does/not/exist"
+        )
+        m_subp.return_value = "Get:1 https://esm.ubuntu.com\nFetched 285 B", ""
+        secret_token = "super-secret-bearer-token-value"
+
+        assert_valid_apt_credentials(
+            repo_url="https://esm.ubuntu.com/infra/ubuntu",
+            username="bearer",
+            password=secret_token,
+        )
+
+        # Assert the secret never appears in any argument to subp
+        subp_call_args = m_subp.call_args[0][0]  # first positional: argv list
+        for arg in subp_call_args:
+            assert secret_token not in arg, (
+                "Credential leaked into subprocess argv: %s" % arg
+            )
+            assert "bearer" not in arg or arg == "/usr/lib/apt/apt-helper", (
+                "Username leaked into subprocess argv: %s" % arg
+            )
+
+        # Assert credentials are instead written to the auth file
+        auth_path = "/etc/apt/auth.conf.d/90ubuntu-advantage-validation"
+        m_write_file.assert_called_once_with(
+            auth_path,
+            "machine esm.ubuntu.com/infra/ubuntu/ login bearer"
+            " password super-secret-bearer-token-value\n",
+            mode=0o600,
+        )
+        # Assert auth file is cleaned up
+        m_ensure_file_absent.assert_called_once_with(auth_path)
 
 
 class TestAddAuthAptRepo:


### PR DESCRIPTION
## Why is this needed?
Fixes CVE-2026-9494 by removing credentials out of argv into apt's own auth.conf.d facility.

## Test Steps
Run unit test
```
tox -e test -- uaclient/tests/test_apt.py
```
