### PR TITLE
test: run features/api/security.feature on {noble,resolute}

### DIFF
--- a/features/api/security.feature
+++ b/features/api/security.feature
@@ -21,16 +21,7 @@ Feature: API security/security status tests
     Then I verify that `esm-infra` is enabled
     When I apt upgrade
     And I apt install `jq bzip2`
-    # Install the oscap version 1.3.7 which solved the epoch error message issue
-    And I apt install `cmake libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev libcap-dev libxml2-dev libldap2-dev libpcre3-dev swig libxml-parser-perl libxml-xpath-perl libperl-dev libbz2-dev g++ libapt-pkg-dev libyaml-dev libxmlsec1-dev libxmlsec1-openssl`
-    And I run `wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz` as non-root
-    And I run `tar xzf openscap-1.3.7.tar.gz` as non-root
-    And I run shell command `mkdir -p openscap-1.3.7/build` as non-root
-    And I run shell command `cd openscap-1.3.7/build/ && cmake ..` with sudo
-    And I run shell command `cd openscap-1.3.7/build/ && make` with sudo
-    And I run shell command `cd openscap-1.3.7/build/ && make install` with sudo
-    # Installs its shared libs in /usr/local/lib/
-    And I run `ldconfig` with sudo
+    And I install the oscap tool
     And I run shell command `pro api u.security.package_manifest.v1 | jq -r '.data.attributes.manifest_data' > manifest` as non-root
     And I run shell command `wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.<release>.usn.oval.xml.bz2` as non-root
     And I run `bunzip2 oci.com.ubuntu.<release>.usn.oval.xml.bz2` as non-root

--- a/features/api/security.feature
+++ b/features/api/security.feature
@@ -62,5 +62,3 @@ Feature: API security/security status tests
       | jammy    | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.7.3-4ubuntu1            | 555010000000 |
       | noble    | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.3-1.1ubuntu3          | 673320000000 |
       | resolute | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.12-2ubuntu1           | 828410000000 |
-
-# TODO(srunde3): refactor test to work with Noble+. libgnutls30 is not available there.

--- a/features/api/security.feature
+++ b/features/api/security.feature
@@ -55,11 +55,12 @@ Feature: API security/security status tests
       """
 
     Examples: ubuntu release
-      | release | machine_type  | package_name   | manifest_pattern     | forced_vulnerable_version | oval_def_id  |
-      | xenial  | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.4.10-4ubuntu1           | 39991000000  |
-      | bionic  | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.5.18-1ubuntu1           | 555010000000 |
-      | focal   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.6.13-2ubuntu1           | 555010000000 |
-      | jammy   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.7.3-4ubuntu1            | 555010000000 |
-      | noble   | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.3-1.1ubuntu3          | 673320000000 |
+      | release  | machine_type  | package_name   | manifest_pattern     | forced_vulnerable_version | oval_def_id  |
+      | xenial   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.4.10-4ubuntu1           | 39991000000  |
+      | bionic   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.5.18-1ubuntu1           | 555010000000 |
+      | focal    | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.6.13-2ubuntu1           | 555010000000 |
+      | jammy    | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.7.3-4ubuntu1            | 555010000000 |
+      | noble    | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.3-1.1ubuntu3          | 673320000000 |
+      | resolute | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.12-2ubuntu1           | 828410000000 |
 
 # TODO(srunde3): refactor test to work with Noble+. libgnutls30 is not available there.

--- a/features/api/security.feature
+++ b/features/api/security.feature
@@ -55,10 +55,11 @@ Feature: API security/security status tests
       """
 
     Examples: ubuntu release
-      | release | machine_type  | package_name | manifest_pattern  | forced_vulnerable_version | oval_def_id  |
-      | xenial  | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.4.10-4ubuntu1           | 39991000000  |
-      | bionic  | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.5.18-1ubuntu1           | 555010000000 |
-      | focal   | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.6.13-2ubuntu1           | 555010000000 |
-      | jammy   | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.7.3-4ubuntu1            | 555010000000 |
+      | release | machine_type  | package_name   | manifest_pattern     | forced_vulnerable_version | oval_def_id  |
+      | xenial  | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.4.10-4ubuntu1           | 39991000000  |
+      | bionic  | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.5.18-1ubuntu1           | 555010000000 |
+      | focal   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.6.13-2ubuntu1           | 555010000000 |
+      | jammy   | lxd-container | libgnutls30    | libgnutls30:amd64    | 3.7.3-4ubuntu1            | 555010000000 |
+      | noble   | lxd-container | libgnutls30t64 | libgnutls30t64:amd64 | 3.8.3-1.1ubuntu3          | 673320000000 |
 
 # TODO(srunde3): refactor test to work with Noble+. libgnutls30 is not available there.

--- a/features/api/security.feature
+++ b/features/api/security.feature
@@ -37,37 +37,37 @@ Feature: API security/security status tests
     And I run shell command `oscap oval eval --report report.html oci.com.ubuntu.<release>.usn.oval.xml` as non-root
     Then stdout matches regexp:
       """
-      oval:com.ubuntu.<release>:def:<CVE_ID>:\s+false
+      oval:com.ubuntu.<release>:def:<oval_def_id>:\s+false
       """
     # Trigger CVE https://ubuntu.com/security/CVE-2018-10846 with ID 39991000000 in OVAL data (<release> == Xenial $ Bionic)
     # Trigger CVE https://ubuntu.com/security/CVE-2022-2509 with ID 55501000000 in OVAL data (<release> > Xenial)
-    When I run shell command `sed -i -E 's/libgnutls30:amd64\s+.*/libgnutls30:amd64 <base_version>/' manifest` as non-root
+    When I run shell command `sed -i -E 's/<manifest_pattern>\s+.*/<manifest_pattern> <forced_vulnerable_version>/' manifest` as non-root
     And I run shell command `oscap oval eval --report report.html oci.com.ubuntu.<release>.usn.oval.xml` as non-root
     Then stdout matches regexp:
       """
-      oval:com.ubuntu.<release>:def:<CVE_ID>:\s+true
+      oval:com.ubuntu.<release>:def:<oval_def_id>:\s+true
       """
     # Update the manifest
     When I run shell command `pro api u.security.package_manifest.v1 | jq -r '.data.attributes.manifest_data' > manifest` as non-root
     And I run shell command `oscap oval eval --report report.html oci.com.ubuntu.<release>.usn.oval.xml` as non-root
     Then stdout matches regexp:
       """
-      oval:com.ubuntu.<release>:def:<CVE_ID>:\s+false
+      oval:com.ubuntu.<release>:def:<oval_def_id>:\s+false
       """
     # Downgrade the package
-    When I apt install `libgnutls30=<base_version>`
+    When I apt install `<package_name>=<forced_vulnerable_version>`
     And I run shell command `pro api u.security.package_manifest.v1 | jq -r '.data.attributes.manifest_data' > manifest` as non-root
     And I run shell command `oscap oval eval --report report.html oci.com.ubuntu.<release>.usn.oval.xml` as non-root
     Then stdout matches regexp:
       """
-      oval:com.ubuntu.<release>:def:<CVE_ID>:\s+true
+      oval:com.ubuntu.<release>:def:<oval_def_id>:\s+true
       """
 
     Examples: ubuntu release
-      | release | machine_type  | base_version    | CVE_ID      |
-      | xenial  | lxd-container | 3.4.10-4ubuntu1 | 39991000000 |
-      | bionic  | lxd-container | 3.5.18-1ubuntu1 | 55501000000 |
-      | focal   | lxd-container | 3.6.13-2ubuntu1 | 55501000000 |
-      | jammy   | lxd-container | 3.7.3-4ubuntu1  | 55501000000 |
+      | release | machine_type  | package_name | manifest_pattern  | forced_vulnerable_version | oval_def_id  |
+      | xenial  | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.4.10-4ubuntu1           | 39991000000  |
+      | bionic  | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.5.18-1ubuntu1           | 555010000000 |
+      | focal   | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.6.13-2ubuntu1           | 555010000000 |
+      | jammy   | lxd-container | libgnutls30  | libgnutls30:amd64 | 3.7.3-4ubuntu1            | 555010000000 |
 
 # TODO(srunde3): refactor test to work with Noble+. libgnutls30 is not available there.

--- a/features/environment.py
+++ b/features/environment.py
@@ -388,6 +388,8 @@ def before_feature(context: Context, feature: Feature):
 
 def before_scenario(context: Context, scenario: Scenario):
     context.stored_vars = {}
+    context.scenario_release = None
+    context.scenario_machine_type = None
 
     reason = _should_skip_config_tags(context, scenario.effective_tags)
     if reason:
@@ -416,6 +418,9 @@ def before_scenario(context: Context, scenario: Scenario):
         step_machine_type = given_a_series_machine_type_match.group(2)
         if step_machine_type != "<machine_type>":
             scenario_machine_type = step_machine_type
+
+    context.scenario_release = scenario_release
+    context.scenario_machine_type = scenario_machine_type
 
     releases = context.pro_config.releases
     if releases and scenario_release not in releases:

--- a/features/steps/security_tools.py
+++ b/features/steps/security_tools.py
@@ -41,7 +41,7 @@ def when_i_install_oscap_tool(context):
     Install the OpenSCAP scanner tool.
 
     On older releases, this is built from source to avoid problems that were fixed in
-    v1.3.7. This is not packaged until Noble.
+    v1.3.7. This version is not available in `apt` until Noble.
 
     On Noble+, install directly using `apt`.
 

--- a/features/steps/security_tools.py
+++ b/features/steps/security_tools.py
@@ -1,0 +1,92 @@
+from behave import when
+
+from features.steps.packages import when_i_apt_install
+from features.steps.shell import when_i_run_command, when_i_run_shell_command
+
+LEGACY_OSCAP_SOURCE_BUILDS = {"xenial", "bionic", "focal", "jammy"}
+
+OSCAP_137_BUILD_DEPS = " ".join(
+    [
+        "cmake",
+        "libdbus-1-dev",
+        "libdbus-glib-1-dev",
+        "libcurl4-openssl-dev",
+        "libgcrypt20-dev",
+        "libselinux1-dev",
+        "libxslt1-dev",
+        "libgconf2-dev",
+        "libacl1-dev",
+        "libblkid-dev",
+        "libcap-dev",
+        "libxml2-dev",
+        "libldap2-dev",
+        "libpcre3-dev",
+        "swig",
+        "libxml-parser-perl",
+        "libxml-xpath-perl",
+        "libperl-dev",
+        "libbz2-dev",
+        "g++",
+        "libapt-pkg-dev",
+        "libyaml-dev",
+        "libxmlsec1-dev",
+        "libxmlsec1-openssl",
+    ]
+)
+
+
+@when("I install the oscap tool")
+def when_i_install_oscap_tool(context):
+    """
+    Install the OpenSCAP scanner tool.
+
+    On older releases, this is built from source to avoid problems that were fixed in
+    v1.3.7. This is not packaged until Noble.
+
+    On Noble+, install directly using `apt`.
+
+    See https://github.com/OpenSCAP/openscap.
+    """
+
+    release = getattr(context, "scenario_release", None)
+
+    if release in LEGACY_OSCAP_SOURCE_BUILDS:
+        _install_oscap_from_source(context)
+    else:
+        # Newer releases should use distro-packaged OpenSCAP when available.
+        when_i_apt_install(context, "openscap-scanner")
+
+
+def _install_oscap_from_source(context):
+    when_i_apt_install(context, OSCAP_137_BUILD_DEPS)
+    when_i_run_command(
+        context,
+        "wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz",
+        "as non-root",
+    )
+    when_i_run_command(
+        context,
+        "tar xzf openscap-1.3.7.tar.gz",
+        "as non-root",
+    )
+    when_i_run_shell_command(
+        context,
+        "mkdir -p openscap-1.3.7/build",
+        "as non-root",
+    )
+    when_i_run_shell_command(
+        context,
+        "cd openscap-1.3.7/build/ && cmake ..",
+        "with sudo",
+    )
+    when_i_run_shell_command(
+        context,
+        "cd openscap-1.3.7/build/ && make",
+        "with sudo",
+    )
+    when_i_run_shell_command(
+        context,
+        "cd openscap-1.3.7/build/ && make install",
+        "with sudo",
+    )
+    when_i_run_command(context, "ldconfig", "with sudo")

--- a/features/steps/security_tools.py
+++ b/features/steps/security_tools.py
@@ -3,6 +3,8 @@ from behave import when
 from features.steps.packages import when_i_apt_install
 from features.steps.shell import when_i_run_command, when_i_run_shell_command
 
+OSCAP_RELEASE_URL = "https://github.com/OpenSCAP/openscap/releases/download/"
+OSCAP_137_RELEASE_TARBALL = "1.3.7/openscap-1.3.7.tar.gz"
 LEGACY_OSCAP_SOURCE_BUILDS = {"xenial", "bionic", "focal", "jammy"}
 
 OSCAP_137_BUILD_DEPS = " ".join(
@@ -40,8 +42,8 @@ def when_i_install_oscap_tool(context):
     """
     Install the OpenSCAP scanner tool.
 
-    On older releases, this is built from source to avoid problems that were fixed in
-    v1.3.7. This version is not available in `apt` until Noble.
+    On older releases, this is built from source to avoid problems that were
+    fixed in v1.3.7. This version is not available in `apt` until Noble.
 
     On Noble+, install directly using `apt`.
 
@@ -61,7 +63,7 @@ def _install_oscap_from_source(context):
     when_i_apt_install(context, OSCAP_137_BUILD_DEPS)
     when_i_run_command(
         context,
-        "wget https://github.com/OpenSCAP/openscap/releases/download/1.3.7/openscap-1.3.7.tar.gz",
+        f"wget {OSCAP_RELEASE_URL}{OSCAP_137_RELEASE_TARBALL}",
         "as non-root",
     )
     when_i_run_command(


### PR DESCRIPTION
## Why is this needed?

This ensures Noble and Resolute receive coverage for this security API.

The test parameters didn't have enough flexibility to run for Noble and Resolute, so I've refactored the test structure as well. We now have a helper that installs the OSCAP tooling.

## Test Steps

Export your contract token, then run:

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/api/security.feature -D releases=noble,resolute -D machine_types=lxd-container
```