### PR TITLE
test(behave): add Resolute coverage for {azure,gcp,aws}.{generic,pro}

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -85,6 +85,7 @@ Feature: Pro is expected version
       | resolute | aws.generic    |
       | resolute | aws.pro        |
       | resolute | azure.generic  |
+      | resolute | azure.pro      |
       | resolute | gcp.generic    |
       | resolute | gcp.pro        |
 

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -83,8 +83,10 @@ Feature: Pro is expected version
       | resolute | lxd-container  |
       | resolute | lxd-vm         |
       | resolute | aws.generic    |
+      | resolute | aws.pro        |
       | resolute | azure.generic  |
       | resolute | gcp.generic    |
+      | resolute | gcp.pro        |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -82,6 +82,9 @@ Feature: Pro is expected version
       | questing | gcp.generic    |
       | resolute | lxd-container  |
       | resolute | lxd-vm         |
+      | resolute | aws.generic    |
+      | resolute | azure.generic  |
+      | resolute | gcp.generic    |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version

--- a/features/api/full_auto_attach.feature
+++ b/features/api/full_auto_attach.feature
@@ -20,19 +20,22 @@ Feature: Full Auto-Attach Endpoint
     And I verify that `livepatch` is disabled
 
     Examples:
-      | release | machine_type |
-      | xenial  | aws.pro      |
-      | xenial  | azure.pro    |
-      | xenial  | gcp.pro      |
-      | bionic  | aws.pro      |
-      | bionic  | azure.pro    |
-      | bionic  | gcp.pro      |
-      | focal   | aws.pro      |
-      | focal   | azure.pro    |
-      | focal   | gcp.pro      |
-      | jammy   | aws.pro      |
-      | jammy   | azure.pro    |
-      | jammy   | gcp.pro      |
-      | noble   | aws.pro      |
-      | noble   | azure.pro    |
-      | noble   | gcp.pro      |
+      | release  | machine_type |
+      | xenial   | aws.pro      |
+      | xenial   | azure.pro    |
+      | xenial   | gcp.pro      |
+      | bionic   | aws.pro      |
+      | bionic   | azure.pro    |
+      | bionic   | gcp.pro      |
+      | focal    | aws.pro      |
+      | focal    | azure.pro    |
+      | focal    | gcp.pro      |
+      | jammy    | aws.pro      |
+      | jammy    | azure.pro    |
+      | jammy    | gcp.pro      |
+      | noble    | aws.pro      |
+      | noble    | azure.pro    |
+      | noble    | gcp.pro      |
+      | resolute | aws.pro      |
+      | resolute | azure.pro    |
+      | resolute | gcp.pro      |

--- a/features/api/full_auto_attach.feature
+++ b/features/api/full_auto_attach.feature
@@ -37,5 +37,4 @@ Feature: Full Auto-Attach Endpoint
       | noble    | azure.pro    |
       | noble    | gcp.pro      |
       | resolute | aws.pro      |
-      | resolute | azure.pro    |
       | resolute | gcp.pro      |

--- a/features/api/full_auto_attach.feature
+++ b/features/api/full_auto_attach.feature
@@ -37,4 +37,5 @@ Feature: Full Auto-Attach Endpoint
       | noble    | azure.pro    |
       | noble    | gcp.pro      |
       | resolute | aws.pro      |
+      | resolute | azure.pro    |
       | resolute | gcp.pro      |

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -107,7 +107,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
     Then on `focal`, systemd status output says memory usage is less than `14` MB
     Then on `jammy`, systemd status output says memory usage is less than `15` MB
     Then on `noble`, systemd status output says memory usage is less than `17` MB
-    Then on `resolute`, systemd status output says memory usage is less than `17` MB
+    Then on `resolute`, systemd status output says memory usage is less than `20` MB
     When I run `journalctl -o cat -u ubuntu-advantage.service` with sudo
     Then stdout contains substring:
       """
@@ -198,12 +198,13 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
 
     Examples: version
-      | release | machine_type | pkg_name               |
-      | xenial  | gcp.generic  | ubuntu-advantage-tools |
-      | bionic  | gcp.generic  | ubuntu-advantage-tools |
-      | focal   | gcp.generic  | ubuntu-advantage-tools |
-      | jammy   | gcp.generic  | ubuntu-advantage-tools |
-      | noble   | gcp.generic  | ubuntu-pro-client      |
+      | release  | machine_type | pkg_name               |
+      | xenial   | gcp.generic  | ubuntu-advantage-tools |
+      | bionic   | gcp.generic  | ubuntu-advantage-tools |
+      | focal    | gcp.generic  | ubuntu-advantage-tools |
+      | jammy    | gcp.generic  | ubuntu-advantage-tools |
+      | noble    | gcp.generic  | ubuntu-pro-client      |
+      | resolute | gcp.generic  | ubuntu-pro-client      |
 
   @uses.config.contract_token
   Scenario Outline: daemon should run when appropriate on azure generic lts
@@ -265,12 +266,13 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       """
 
     Examples: version
-      | release | machine_type  |
-      | xenial  | azure.generic |
-      | bionic  | azure.generic |
-      | focal   | azure.generic |
-      | jammy   | azure.generic |
-      | noble   | azure.generic |
+      | release  | machine_type  |
+      | xenial   | azure.generic |
+      | bionic   | azure.generic |
+      | focal    | azure.generic |
+      | jammy    | azure.generic |
+      | noble    | azure.generic |
+      | resolute | azure.generic |
 
   @uses.config.contract_token
   Scenario Outline: daemon does not start on gcp,azure generic non lts
@@ -322,6 +324,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy    | aws.generic  |
       | noble    | aws.generic  |
       | questing | aws.generic  |
+      | resolute | aws.generic  |
 
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/detached_auto_attach.feature
+++ b/features/detached_auto_attach.feature
@@ -20,16 +20,19 @@ Feature: Attached cloud does not detach when auto-attaching after manually attac
     And I verify that `esm-infra` is enabled
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | aws.generic   |
-      | xenial  | azure.generic |
-      | xenial  | gcp.generic   |
-      | bionic  | aws.generic   |
-      | bionic  | azure.generic |
-      | bionic  | gcp.generic   |
-      | focal   | aws.generic   |
-      | focal   | azure.generic |
-      | focal   | gcp.generic   |
-      | noble   | aws.generic   |
-      | noble   | azure.generic |
-      | noble   | gcp.generic   |
+      | release  | machine_type  |
+      | xenial   | aws.generic   |
+      | xenial   | azure.generic |
+      | xenial   | gcp.generic   |
+      | bionic   | aws.generic   |
+      | bionic   | azure.generic |
+      | bionic   | gcp.generic   |
+      | focal    | aws.generic   |
+      | focal    | azure.generic |
+      | focal    | gcp.generic   |
+      | noble    | aws.generic   |
+      | noble    | azure.generic |
+      | noble    | gcp.generic   |
+      | resolute | aws.generic   |
+      | resolute | azure.generic |
+      | resolute | gcp.generic   |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -116,17 +116,19 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | azure.generic |
-      | xenial  | gcp.generic   |
-      | bionic  | azure.generic |
-      | bionic  | gcp.generic   |
-      | focal   | azure.generic |
-      | focal   | gcp.generic   |
-      | jammy   | azure.generic |
-      | jammy   | gcp.generic   |
-      | noble   | azure.generic |
-      | noble   | gcp.generic   |
+      | release  | machine_type  |
+      | xenial   | azure.generic |
+      | xenial   | gcp.generic   |
+      | bionic   | azure.generic |
+      | bionic   | gcp.generic   |
+      | focal    | azure.generic |
+      | focal    | gcp.generic   |
+      | jammy    | azure.generic |
+      | jammy    | gcp.generic   |
+      | noble    | azure.generic |
+      | noble    | gcp.generic   |
+      | resolute | azure.generic |
+      | resolute | gcp.generic   |
 
   Scenario Outline: auto-attach retries for a month and updates status
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -240,12 +242,13 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | aws.generic  |
-      | bionic  | aws.generic  |
-      | focal   | aws.generic  |
-      | jammy   | aws.generic  |
-      | noble   | aws.generic  |
+      | release  | machine_type |
+      | xenial   | aws.generic  |
+      | bionic   | aws.generic  |
+      | focal    | aws.generic  |
+      | jammy    | aws.generic  |
+      | noble    | aws.generic  |
+      | resolute | aws.generic  |
 
   Scenario Outline: auto-attach retries stop if manual auto-attach succeeds
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -397,12 +400,13 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | gcp.pro      |
-      | bionic  | gcp.pro      |
-      | focal   | gcp.pro      |
-      | jammy   | gcp.pro      |
-      | noble   | gcp.pro      |
+      | release  | machine_type |
+      | xenial   | gcp.pro      |
+      | bionic   | gcp.pro      |
+      | focal    | gcp.pro      |
+      | jammy    | gcp.pro      |
+      | noble    | gcp.pro      |
+      | resolute | gcp.pro      |
 
   Scenario Outline: auto-attach retries eventually succeed and clean up
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -502,4 +502,5 @@ Feature: auto-attach retries periodically on failures
       | noble    | azure.pro    |
       | noble    | gcp.pro      |
       | resolute | aws.pro      |
+      | resolute | azure.pro    |
       | resolute | gcp.pro      |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -502,5 +502,4 @@ Feature: auto-attach retries periodically on failures
       | noble    | azure.pro    |
       | noble    | gcp.pro      |
       | resolute | aws.pro      |
-      | resolute | azure.pro    |
       | resolute | gcp.pro      |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -400,12 +400,13 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | gcp.pro      |
-      | bionic  | gcp.pro      |
-      | focal   | gcp.pro      |
-      | jammy   | gcp.pro      |
-      | noble   | gcp.pro      |
+      | release  | machine_type |
+      | xenial   | gcp.pro      |
+      | bionic   | gcp.pro      |
+      | focal    | gcp.pro      |
+      | jammy    | gcp.pro      |
+      | noble    | gcp.pro      |
+      | resolute | gcp.pro      |
 
   Scenario Outline: auto-attach retries eventually succeed and clean up
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -484,19 +485,22 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | aws.pro      |
-      | xenial  | azure.pro    |
-      | xenial  | gcp.pro      |
-      | bionic  | aws.pro      |
-      | bionic  | azure.pro    |
-      | bionic  | gcp.pro      |
-      | focal   | aws.pro      |
-      | focal   | azure.pro    |
-      | focal   | gcp.pro      |
-      | jammy   | aws.pro      |
-      | jammy   | azure.pro    |
-      | jammy   | gcp.pro      |
-      | noble   | aws.pro      |
-      | noble   | azure.pro    |
-      | noble   | gcp.pro      |
+      | release  | machine_type |
+      | xenial   | aws.pro      |
+      | xenial   | azure.pro    |
+      | xenial   | gcp.pro      |
+      | bionic   | aws.pro      |
+      | bionic   | azure.pro    |
+      | bionic   | gcp.pro      |
+      | focal    | aws.pro      |
+      | focal    | azure.pro    |
+      | focal    | gcp.pro      |
+      | jammy    | aws.pro      |
+      | jammy    | azure.pro    |
+      | jammy    | gcp.pro      |
+      | noble    | aws.pro      |
+      | noble    | azure.pro    |
+      | noble    | gcp.pro      |
+      | resolute | aws.pro      |
+      | resolute | azure.pro    |
+      | resolute | gcp.pro      |

--- a/features/retry_auto_attach.feature
+++ b/features/retry_auto_attach.feature
@@ -400,13 +400,12 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release  | machine_type |
-      | xenial   | gcp.pro      |
-      | bionic   | gcp.pro      |
-      | focal    | gcp.pro      |
-      | jammy    | gcp.pro      |
-      | noble    | gcp.pro      |
-      | resolute | gcp.pro      |
+      | release | machine_type |
+      | xenial  | gcp.pro      |
+      | bionic  | gcp.pro      |
+      | focal   | gcp.pro      |
+      | jammy   | gcp.pro      |
+      | noble   | gcp.pro      |
 
   Scenario Outline: auto-attach retries eventually succeed and clean up
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -485,22 +484,19 @@ Feature: auto-attach retries periodically on failures
       """
 
     Examples: ubuntu release
-      | release  | machine_type |
-      | xenial   | aws.pro      |
-      | xenial   | azure.pro    |
-      | xenial   | gcp.pro      |
-      | bionic   | aws.pro      |
-      | bionic   | azure.pro    |
-      | bionic   | gcp.pro      |
-      | focal    | aws.pro      |
-      | focal    | azure.pro    |
-      | focal    | gcp.pro      |
-      | jammy    | aws.pro      |
-      | jammy    | azure.pro    |
-      | jammy    | gcp.pro      |
-      | noble    | aws.pro      |
-      | noble    | azure.pro    |
-      | noble    | gcp.pro      |
-      | resolute | aws.pro      |
-      | resolute | azure.pro    |
-      | resolute | gcp.pro      |
+      | release | machine_type |
+      | xenial  | aws.pro      |
+      | xenial  | azure.pro    |
+      | xenial  | gcp.pro      |
+      | bionic  | aws.pro      |
+      | bionic  | azure.pro    |
+      | bionic  | gcp.pro      |
+      | focal   | aws.pro      |
+      | focal   | azure.pro    |
+      | focal   | gcp.pro      |
+      | jammy   | aws.pro      |
+      | jammy   | azure.pro    |
+      | jammy   | gcp.pro      |
+      | noble   | aws.pro      |
+      | noble   | azure.pro    |
+      | noble   | gcp.pro      |

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -184,7 +184,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       | jammy    | gcp.pro      |
       | noble    | azure.pro    |
       | noble    | gcp.pro      |
-      | resolute | azure.pro    |
       | resolute | gcp.pro      |
 
   Scenario Outline: Auto-attach service works on Pro Machine on aws.pro
@@ -323,7 +322,6 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       | noble    | azure.pro    | ubuntu_pro       |
       | noble    | gcp.pro      | ubuntu_pro       |
       | resolute | aws.pro      | ubuntu_pro       |
-      | resolute | azure.pro    | ubuntu_pro       |
       | resolute | gcp.pro      | ubuntu_pro       |
 
   Scenario Outline: Unregistered Pro machine

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -322,6 +322,7 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       | noble    | azure.pro    | ubuntu_pro       |
       | noble    | gcp.pro      | ubuntu_pro       |
       | resolute | aws.pro      | ubuntu_pro       |
+      | resolute | azure.pro    | ubuntu_pro       |
       | resolute | gcp.pro      | ubuntu_pro       |
 
   Scenario Outline: Unregistered Pro machine

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -173,17 +173,19 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | azure.pro    |
-      | xenial  | gcp.pro      |
-      | bionic  | azure.pro    |
-      | bionic  | gcp.pro      |
-      | focal   | azure.pro    |
-      | focal   | gcp.pro      |
-      | jammy   | azure.pro    |
-      | jammy   | gcp.pro      |
-      | noble   | azure.pro    |
-      | noble   | gcp.pro      |
+      | release  | machine_type |
+      | xenial   | azure.pro    |
+      | xenial   | gcp.pro      |
+      | bionic   | azure.pro    |
+      | bionic   | gcp.pro      |
+      | focal    | azure.pro    |
+      | focal    | gcp.pro      |
+      | jammy    | azure.pro    |
+      | jammy    | gcp.pro      |
+      | noble    | azure.pro    |
+      | noble    | gcp.pro      |
+      | resolute | azure.pro    |
+      | resolute | gcp.pro      |
 
   Scenario Outline: Auto-attach service works on Pro Machine on aws.pro
     Given a `<release>` aws.pro machine with ubuntu-advantage-tools installed
@@ -303,23 +305,26 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       """
 
     Examples: ubuntu release
-      | release | machine_type | cloud_init_key   |
-      | xenial  | aws.pro      | ubuntu_advantage |
-      | xenial  | azure.pro    | ubuntu_advantage |
-      | xenial  | gcp.pro      | ubuntu_advantage |
-      | bionic  | aws.pro      | ubuntu_advantage |
-      | bionic  | azure.pro    | ubuntu_advantage |
-      | bionic  | gcp.pro      | ubuntu_advantage |
+      | release  | machine_type | cloud_init_key   |
+      | xenial   | aws.pro      | ubuntu_advantage |
+      | xenial   | azure.pro    | ubuntu_advantage |
+      | xenial   | gcp.pro      | ubuntu_advantage |
+      | bionic   | aws.pro      | ubuntu_advantage |
+      | bionic   | azure.pro    | ubuntu_advantage |
+      | bionic   | gcp.pro      | ubuntu_advantage |
       # Keep ubuntu_advantage for focal/jammy to make sure it still works there
-      | focal   | aws.pro      | ubuntu_advantage |
-      | focal   | azure.pro    | ubuntu_advantage |
-      | focal   | gcp.pro      | ubuntu_advantage |
-      | jammy   | aws.pro      | ubuntu_advantage |
-      | jammy   | azure.pro    | ubuntu_advantage |
-      | jammy   | gcp.pro      | ubuntu_advantage |
-      | noble   | aws.pro      | ubuntu_pro       |
-      | noble   | azure.pro    | ubuntu_pro       |
-      | noble   | gcp.pro      | ubuntu_pro       |
+      | focal    | aws.pro      | ubuntu_advantage |
+      | focal    | azure.pro    | ubuntu_advantage |
+      | focal    | gcp.pro      | ubuntu_advantage |
+      | jammy    | aws.pro      | ubuntu_advantage |
+      | jammy    | azure.pro    | ubuntu_advantage |
+      | jammy    | gcp.pro      | ubuntu_advantage |
+      | noble    | aws.pro      | ubuntu_pro       |
+      | noble    | azure.pro    | ubuntu_pro       |
+      | noble    | gcp.pro      | ubuntu_pro       |
+      | resolute | aws.pro      | ubuntu_pro       |
+      | resolute | azure.pro    | ubuntu_pro       |
+      | resolute | gcp.pro      | ubuntu_pro       |
 
   Scenario Outline: Unregistered Pro machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -332,9 +332,10 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | aws.generic  |
-      | bionic  | aws.generic  |
-      | focal   | aws.generic  |
-      | jammy   | aws.generic  |
-      | noble   | aws.generic  |
+      | release  | machine_type |
+      | xenial   | aws.generic  |
+      | bionic   | aws.generic  |
+      | focal    | aws.generic  |
+      | jammy    | aws.generic  |
+      | noble    | aws.generic  |
+      | resolute | aws.generic  |

--- a/features/ubuntu_pro.feature
+++ b/features/ubuntu_pro.feature
@@ -245,12 +245,13 @@ Feature: Command behaviour when auto-attached in an ubuntu PRO image
       """
 
     Examples: ubuntu release
-      | release | machine_type |
-      | xenial  | aws.generic  |
-      | bionic  | aws.generic  |
-      | focal   | aws.generic  |
-      | jammy   | aws.generic  |
-      | noble   | aws.generic  |
+      | release  | machine_type |
+      | xenial   | aws.generic  |
+      | bionic   | aws.generic  |
+      | focal    | aws.generic  |
+      | jammy    | aws.generic  |
+      | noble    | aws.generic  |
+      | resolute | aws.generic  |
 
   Scenario Outline: Auto-attach no-op when cloud-init has ubuntu_advantage on userdata
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed adding this cloud-init user_data:

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ deps =
     behave
     jsonschema
     jq
-    pycloudlib>=1!11.0.0
+    pycloudlib>=1!11.1.2,<1!12
     PyHamcrest
     requests
     toml==0.10


### PR DESCRIPTION
## Why is this needed?

Adds test coverage for Resolute images on clouds.

Note that passing on `azure.pro` required a change upstream in `pycloudlib` https://github.com/canonical/pycloudlib/pull/521 and depends on https://github.com/canonical/ubuntu-pro-client/pull/3589

## Test Steps

Export your token, then:

```sh
tox -e behave -- -D releases=resolute -D machine_types=aws.generic,gcp.generic,azure.generic
```

```sh
tox -e behave -- -D releases=resolute -D machine_types=aws.pro,gcp.pro,azure.pro
```