### PR TITLE
ci: use mmdebstrap and unshare instead of debootstrap and schroot; run on stonking

### DIFF
--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -44,6 +44,7 @@ jobs:
           $unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
           $unshare_mmdebstrap_extra_args = [
               '*' => ['--components=main,universe'],
+              'xenial' => ['--variant=apt'],
               'stonking' => [
                   '--include=ca-certificates',
                   '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -35,7 +35,9 @@ jobs:
           DEBEMAIL: nobody@nowhere.invalid
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install -t noble-backports 'sbuild (>= 0.88.3ubuntu2~bpo24.04.1)' mmdebstrap uidmap git-buildpackage
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install -t noble-backports sbuild mmdebstrap uidmap git-buildpackage
+          sbuild_version="$(dpkg-query -W -f='${Version}' sbuild)"
+          dpkg --compare-versions "$sbuild_version" ge '0.88.3ubuntu2~bpo24.04.1'
           mkdir -p ~/.config/sbuild
           cat << 'EOF' > ~/.config/sbuild/config.pl
           $chroot_mode = 'unshare';

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -35,16 +35,16 @@ jobs:
           DEBEMAIL: nobody@nowhere.invalid
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install -t noble-backports sbuild mmdebstrap uidmap git-buildpackage
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install -t noble-backports sbuild schroot ubuntu-dev-tools debootstrap mmdebstrap uidmap git-buildpackage
           sbuild_version="$(dpkg-query -W -f='${Version}' sbuild)"
           dpkg --compare-versions "$sbuild_version" ge '0.88.3ubuntu2~bpo24.04.1'
+          sudo sbuild-adduser $USER
           mkdir -p ~/.config/sbuild
           cat << 'EOF' > ~/.config/sbuild/config.pl
           $chroot_mode = 'unshare';
           $unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
           $unshare_mmdebstrap_extra_args = [
               '*' => ['--components=main,universe'],
-              'xenial' => ['--variant=apt'],
               'stonking' => [
                   '--include=ca-certificates',
                   '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',
@@ -62,7 +62,12 @@ jobs:
         run: |
           gbp dch --ignore-branch --snapshot --distribution=${{ matrix.release }}
           dch --local=~${{ matrix.release }} ""
-          sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
+          if [ "${{ matrix.release }}" = "xenial" ]; then
+            sg sbuild -c "mk-sbuild --skip-proposed xenial"
+            sg sbuild -c "sbuild --chroot-mode=schroot --dist=xenial --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'"
+          else
+            sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
+          fi
           mv ../*.deb '${{ runner.temp }}'  # Workaround for Debbug: #990734, drop in Jammy
       - name: Archive debs as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -14,10 +14,6 @@ defaults:
   run:
     shell: sh -ex {0}
 
-env:
-  # TODO: stonking current untested: https://warthogs.atlassian.net/browse/UPRO-1274
-  DEVELOPMENT_RELEASE: 'stonking'
-
 jobs:
   check-secrets:
     name: Check secrets
@@ -28,11 +24,10 @@ jobs:
     name: Packaging
     needs: check-secrets
     if: ${{ needs.check-secrets.outputs.has-secrets == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        # TODO test on stonking: https://warthogs.atlassian.net/browse/UPRO-1274
-        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute']
+        release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
     steps:
       - name: Prepare build tools
         env:
@@ -40,9 +35,21 @@ jobs:
           DEBEMAIL: nobody@nowhere.invalid
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install --no-install-recommends sbuild schroot ubuntu-dev-tools debootstrap git-buildpackage
-          sudo sbuild-adduser $USER
-          cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install -t noble-backports 'sbuild (>= 0.88.3ubuntu2~bpo24.04.1)' mmdebstrap uidmap git-buildpackage
+          mkdir -p ~/.config/sbuild
+          cat << 'EOF' > ~/.config/sbuild/config.pl
+          $chroot_mode = 'unshare';
+          $unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
+          $unshare_mmdebstrap_extra_args = [
+              '*' => ['--components=main,universe'],
+              'stonking' => [
+                  '--include=ca-certificates',
+                  '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',
+                  '--aptopt=APT::Default-Release "stonking";',
+              ],
+          ];
+          1;
+          EOF
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Build package
@@ -52,13 +59,7 @@ jobs:
         run: |
           gbp dch --ignore-branch --snapshot --distribution=${{ matrix.release }}
           dch --local=~${{ matrix.release }} ""
-          if [ "${{ matrix.release }}" = "${{ env.DEVELOPMENT_RELEASE }}" ]; then
-            SKIP_PROPOSED=""
-          else
-            SKIP_PROPOSED="--skip-proposed"
-          fi
-          sg sbuild -c "mk-sbuild $SKIP_PROPOSED ${{ matrix.release }}"
-          sg sbuild -c "sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'"
+          sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
           mv ../*.deb '${{ runner.temp }}'  # Workaround for Debbug: #990734, drop in Jammy
       - name: Archive debs as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -68,7 +68,6 @@ jobs:
           else
             sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
           fi
-          mv ../*.deb '${{ runner.temp }}'  # Workaround for Debbug: #990734, drop in Jammy
       - name: Archive debs as artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -48,6 +48,8 @@ jobs:
         run: |
           gbp dch --ignore-branch --snapshot --distribution=${{ matrix.release }}
           dch --local=~${{ matrix.release }} ""
+          # Xenial's systemd post-installation fails during mmdebstrap bootstrap.
+          # Build with a schroot instead.
           if [ "${{ matrix.release }}" = "xenial" ]; then
             sg sbuild -c "mk-sbuild --skip-proposed xenial"
             sg sbuild -c "sbuild --chroot-mode=schroot --dist=xenial --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'"

--- a/.github/workflows/ci-integration.yaml
+++ b/.github/workflows/ci-integration.yaml
@@ -29,6 +29,8 @@ jobs:
       matrix:
         release: ['xenial', 'bionic', 'focal', 'jammy', 'noble', 'resolute', 'stonking']
     steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
       - name: Prepare build tools
         env:
           DEBFULLNAME: GitHub CI Auto Builder
@@ -39,22 +41,6 @@ jobs:
           sbuild_version="$(dpkg-query -W -f='${Version}' sbuild)"
           dpkg --compare-versions "$sbuild_version" ge '0.88.3ubuntu2~bpo24.04.1'
           sudo sbuild-adduser $USER
-          mkdir -p ~/.config/sbuild
-          cat << 'EOF' > ~/.config/sbuild/config.pl
-          $chroot_mode = 'unshare';
-          $unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
-          $unshare_mmdebstrap_extra_args = [
-              '*' => ['--components=main,universe'],
-              'stonking' => [
-                  '--include=ca-certificates',
-                  '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',
-                  '--aptopt=APT::Default-Release "stonking";',
-              ],
-          ];
-          1;
-          EOF
-      - name: Git checkout
-        uses: actions/checkout@v3
       - name: Build package
         env:
           DEBFULLNAME: GitHub CI Auto Builder
@@ -66,7 +52,7 @@ jobs:
             sg sbuild -c "mk-sbuild --skip-proposed xenial"
             sg sbuild -c "sbuild --chroot-mode=schroot --dist=xenial --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'"
           else
-            sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
+            SBUILD_CONFIG="$PWD/tools/sbuild-config.pl" sbuild --dist='${{ matrix.release }}' --resolve-alternatives --no-clean-source --nolog --verbose --no-run-lintian --build-dir='${{ runner.temp }}'
           fi
       - name: Archive debs as artifacts
         uses: actions/upload-artifact@v4

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,7 @@ in this directory will be shipped as part of the packaging
 - check-versions-are-consistent.py: Helper script to verify changelog and package version matches.
 - README.md: This file.
 - refresh-keyrings.sh: Refresh the keyring files for services, stored in the repo
+- sbuild-config.pl: Shared sbuild configuration for package builds; load with `SBUILD_CONFIG=tools/sbuild-config.pl sbuild ...`.
 - setup_sbuild.sh: Downloads and prepares chroots used in the build (and test) process.
 - test-in-lxd.sh: Build the package and then install it on an LXD instance for testing
 - test-in-multipass.sh: Build the package and then install it on a multipass instance for testing

--- a/tools/sbuild-config.pl
+++ b/tools/sbuild-config.pl
@@ -1,0 +1,11 @@
+$chroot_mode = 'unshare';
+$unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
+$unshare_mmdebstrap_extra_args = [
+    '*' => ['--components=main,universe'],
+    'stonking' => [
+        '--include=ca-certificates',
+        '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',
+        '--aptopt=APT::Default-Release "stonking";',
+    ],
+];
+1;

--- a/tools/sbuild-config.pl
+++ b/tools/sbuild-config.pl
@@ -2,6 +2,10 @@ $chroot_mode = 'unshare';
 $unshare_tmpdir_template = '/var/tmp/tmp.sbuild.XXXXXXXXXX';
 $unshare_mmdebstrap_extra_args = [
     '*' => ['--components=main,universe'],
+    # The development release needs dependencies from its proposed pocket.
+    # Stonking is the current development release; update this block when it
+    # changes. Keep the release as APT's default so proposed is used only when
+    # required by the package dependency resolver.
     'stonking' => [
         '--include=ca-certificates',
         '--setup-hook=echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu stonking-proposed main universe" > "$1"/etc/apt/sources.list.d/proposed.list',


### PR DESCRIPTION
## Why is this needed?

Stonking only includes SHA512 package hashes. `debootstrap` cannot parse them, although it will gain that capability once the fix is backported: https://bugs.launchpad.net/ubuntu/+source/debootstrap/+bug/2160111

Instead, we can use `mmdebstrap` and `unshare` as the backend for `sbuild`. This has the added advantage of not needing root.

## Test Steps

This should run automatically in CI. Confirm that the build passes for Stonking.
