### PR TITLE
test(behave): cover resolute in detach, fix_plan, full_token_attach

### DIFF
--- a/features/api/detach.feature
+++ b/features/api/detach.feature
@@ -104,11 +104,11 @@ Feature: Detach API endpoint
       }
       """
 
-    # TODO: Add resolute once AppArmor ubuntu_pro_esm_cache//ps profile is fixed
     Examples: ubuntu release
-      | release | machine_type  |
-      | xenial  | lxd-container |
-      | bionic  | lxd-container |
-      | focal   | lxd-container |
-      | jammy   | lxd-container |
-      | noble   | lxd-container |
+      | release  | machine_type  |
+      | xenial   | lxd-container |
+      | bionic   | lxd-container |
+      | focal    | lxd-container |
+      | jammy    | lxd-container |
+      | noble    | lxd-container |
+      | resolute | lxd-container |

--- a/features/api/fix_plan.feature
+++ b/features/api/fix_plan.feature
@@ -3029,7 +3029,7 @@ Feature: Fix plan API endpoints
       }
       """
 
-    # TODO: Add resolute lxd-vm once AppArmor ubuntu_pro_esm_cache//ps profile is fixed
     Examples: ubuntu release details
       | release  | machine_type |
       | questing | lxd-vm       |
+      | resolute | lxd-vm       |

--- a/features/api/full_token_attach.feature
+++ b/features/api/full_token_attach.feature
@@ -135,7 +135,6 @@ Feature: Attach API endpoint
     And I verify that `esm-apps` is enabled
     And I verify that `esm-infra` is enabled
 
-    # TODO: Add resolute once AppArmor ubuntu_pro_esm_cache//ps profile is fixed
     Examples: ubuntu release
       | release  | machine_type  |
       | xenial   | lxd-container |
@@ -144,3 +143,4 @@ Feature: Attach API endpoint
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | resolute | lxd-container |


### PR DESCRIPTION
## Why is this needed?

Include tests that required changes to the `ps` AppArmor profile. Fix committed in https://github.com/canonical/ubuntu-pro-client/pull/3555.

## Test Steps

Verify the tests pass on Resolute:

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/api/full_token_attach.feature:146
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/api/detach.feature:115
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- features/api/detach.feature:3035
```
