### PR TITLE
test(behave): add coverage for Stonking

### DIFF
--- a/features/_version.feature
+++ b/features/_version.feature
@@ -76,15 +76,10 @@ Feature: Pro is expected version
       | noble    | gcp.generic    |
       | noble    | gcp.pro        |
       | questing | lxd-container  |
-      | stonking | lxd-container  |
       | questing | lxd-vm         |
-      | stonking | lxd-vm         |
       | questing | aws.generic    |
-      | stonking | aws.generic    |
       | questing | azure.generic  |
-      | stonking | azure.generic  |
       | questing | gcp.generic    |
-      | stonking | gcp.generic    |
       | resolute | lxd-container  |
       | resolute | lxd-vm         |
       | resolute | aws.generic    |
@@ -93,6 +88,11 @@ Feature: Pro is expected version
       | resolute | azure.pro      |
       | resolute | gcp.generic    |
       | resolute | gcp.pro        |
+      | stonking | lxd-container  |
+      | stonking | lxd-vm         |
+      | stonking | aws.generic    |
+      | stonking | azure.generic  |
+      | stonking | gcp.generic    |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version
@@ -124,8 +124,8 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Attached show version in a ubuntu machine
@@ -148,8 +148,8 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @arm64
   Scenario Outline: Check for newer versions of the client in an ubuntu machine
@@ -233,5 +233,5 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -90,9 +90,6 @@ Feature: Pro is expected version
       | resolute | gcp.pro        |
       | stonking | lxd-container  |
       | stonking | lxd-vm         |
-      | stonking | aws.generic    |
-      | stonking | azure.generic  |
-      | stonking | gcp.generic    |
 
   @uses.config.check_version @upgrade
   Scenario Outline: Check pro version

--- a/features/_version.feature
+++ b/features/_version.feature
@@ -76,10 +76,15 @@ Feature: Pro is expected version
       | noble    | gcp.generic    |
       | noble    | gcp.pro        |
       | questing | lxd-container  |
+      | stonking | lxd-container  |
       | questing | lxd-vm         |
+      | stonking | lxd-vm         |
       | questing | aws.generic    |
+      | stonking | aws.generic    |
       | questing | azure.generic  |
+      | stonking | azure.generic  |
       | questing | gcp.generic    |
+      | stonking | gcp.generic    |
       | resolute | lxd-container  |
       | resolute | lxd-vm         |
       | resolute | aws.generic    |
@@ -119,6 +124,7 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token
@@ -142,6 +148,7 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @arm64
@@ -226,4 +233,5 @@ Feature: Pro is expected version
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/api/api.feature
+++ b/features/api/api.feature
@@ -36,8 +36,8 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @arm64
   Scenario Outline: API invalid endpoint or args
@@ -88,8 +88,8 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @arm64
   Scenario Outline: Basic endpoints
@@ -183,8 +183,8 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: u.pro.status.is_attached.v1
@@ -297,5 +297,5 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/api/api.feature
+++ b/features/api/api.feature
@@ -36,6 +36,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @arm64
@@ -87,6 +88,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @arm64
@@ -181,6 +183,7 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token @arm64
@@ -294,4 +297,5 @@ Feature: Client behaviour for the API endpoints
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/api/enable.feature
+++ b/features/api/enable.feature
@@ -170,6 +170,7 @@ Feature: u.pro.services.enable
       | release  | machine_type  |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: u.pro.services.enable.v1 vm services

--- a/features/api/enable.feature
+++ b/features/api/enable.feature
@@ -170,8 +170,8 @@ Feature: u.pro.services.enable
       | release  | machine_type  |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: u.pro.services.enable.v1 vm services
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/api/fix_plan.feature
+++ b/features/api/fix_plan.feature
@@ -3033,3 +3033,4 @@ Feature: Fix plan API endpoints
       | release  | machine_type |
       | questing | lxd-vm       |
       | resolute | lxd-vm       |
+      | stonking | lxd-vm       |

--- a/features/api/full_token_attach.feature
+++ b/features/api/full_token_attach.feature
@@ -144,4 +144,3 @@ Feature: Attach API endpoint
       | noble    | lxd-container |
       | questing | lxd-container |
       | resolute | lxd-container |
-      | stonking | lxd-container |

--- a/features/api/full_token_attach.feature
+++ b/features/api/full_token_attach.feature
@@ -144,3 +144,4 @@ Feature: Attach API endpoint
       | noble    | lxd-container |
       | questing | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/api/services_dependencies.feature
+++ b/features/api/services_dependencies.feature
@@ -388,5 +388,5 @@ Feature: u.pro.services.dependencies
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/api/services_dependencies.feature
+++ b/features/api/services_dependencies.feature
@@ -388,4 +388,5 @@ Feature: u.pro.services.dependencies
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/api/unattended_upgrades.feature
+++ b/features/api/unattended_upgrades.feature
@@ -254,4 +254,5 @@ Feature: api.u.unattended_upgrades.status.v1
       | jammy    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | noble    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | questing | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | stonking | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | resolute | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/api/unattended_upgrades.feature
+++ b/features/api/unattended_upgrades.feature
@@ -254,5 +254,5 @@ Feature: api.u.unattended_upgrades.status.v1
       | jammy    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | noble    | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | questing | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
-      | stonking | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
       | resolute | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |
+      | stonking | lxd-container | ,\n"Unattended-Upgrade::DevRelease": "auto"  |

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -131,9 +131,9 @@ Feature: APT Messages
 
     Examples: ubuntu release
       | release | machine_type  | ad_message                                                                                |
-      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
-      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
-      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\\/\\/ubuntu\\.com\\/pro                             |
+      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
+      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
+      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\/\/ubuntu\.com\/pro                                 |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-apps on upgrade

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -728,10 +728,10 @@ Feature: APT Messages
     Examples: ubuntu release
       | release  | machine_type  |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | questing | lxd-vm        |
-      | stonking | lxd-vm        |
       | resolute | lxd-container |
+      | stonking | lxd-container |
+      | stonking | lxd-vm        |
 
   # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
   # gains capability perfmon on resolute (needed by systemd-detect-virt at boot)
@@ -1586,8 +1586,8 @@ Feature: APT Messages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook do not advertises esm-apps on upgrade for interim releases

--- a/features/apt_messages.feature
+++ b/features/apt_messages.feature
@@ -131,9 +131,9 @@ Feature: APT Messages
 
     Examples: ubuntu release
       | release | machine_type  | ad_message                                                                                |
-      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
-      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\.04 at https:\/\/ubuntu\.com\/<version>-04      |
-      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\/\/ubuntu\.com\/pro                                 |
+      | xenial  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
+      | bionic  | lxd-container | Learn more about Ubuntu Pro for <version>\\.04 at https:\\/\\/ubuntu\\.com\\/<version>-04 |
+      | focal   | lxd-container | Learn more about Ubuntu Pro at https:\\/\\/ubuntu\\.com\\/pro                             |
 
   @uses.config.contract_token
   Scenario Outline: APT Hook advertises esm-apps on upgrade
@@ -728,7 +728,9 @@ Feature: APT Messages
     Examples: ubuntu release
       | release  | machine_type  |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | questing | lxd-vm        |
+      | stonking | lxd-vm        |
       | resolute | lxd-container |
 
   # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
@@ -1584,6 +1586,7 @@ Feature: APT Messages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token
@@ -1634,3 +1637,4 @@ Feature: APT Messages
     Examples: ubuntu release
       | release  | machine_type  |
       | questing | lxd-container |
+      | stonking | lxd-container |

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -63,5 +63,5 @@ Feature: Pro autocomplete commands
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -63,4 +63,5 @@ Feature: Pro autocomplete commands
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cc_eal.feature
+++ b/features/cc_eal.feature
@@ -65,10 +65,10 @@ Feature: Enable cc-eal on Ubuntu
       """
 
     Examples: ubuntu release
-      | release  | machine_type  | version   | full_name        |
-      | focal    | lxd-container | 20.04 LTS | Focal Fossa      |
-      | jammy    | lxd-container | 22.04 LTS | Jammy Jellyfish  |
-      | noble    | lxd-container | 24.04 LTS | Noble Numbat     |
-      | questing | lxd-container | 25.10     | Questing Quokka  |
-      | stonking | lxd-container | 25.10     | Questing Quokka  |
-      | resolute | lxd-container | 26.04 LTS | Resolute Raccoon |
+      | release  | machine_type  | version   | full_name         |
+      | focal    | lxd-container | 20.04 LTS | Focal Fossa       |
+      | jammy    | lxd-container | 22.04 LTS | Jammy Jellyfish   |
+      | noble    | lxd-container | 24.04 LTS | Noble Numbat      |
+      | questing | lxd-container | 25.10     | Questing Quokka   |
+      | resolute | lxd-container | 26.04 LTS | Resolute Raccoon  |
+      | stonking | lxd-container | 26.10     | Stonking Stingray |

--- a/features/cc_eal.feature
+++ b/features/cc_eal.feature
@@ -70,4 +70,5 @@ Feature: Enable cc-eal on Ubuntu
       | jammy    | lxd-container | 22.04 LTS | Jammy Jellyfish  |
       | noble    | lxd-container | 24.04 LTS | Noble Numbat     |
       | questing | lxd-container | 25.10     | Questing Quokka  |
+      | stonking | lxd-container | 25.10     | Questing Quokka  |
       | resolute | lxd-container | 26.04 LTS | Resolute Raccoon |

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -36,6 +36,7 @@ Feature: CLI attach command
     Examples: ubuntu release
       | release  | machine_type  | landscape | status_string                                                           |
       | questing | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
+      | stonking | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
 
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -352,6 +353,7 @@ Feature: CLI attach command
       | noble    | lxd-container |
       | resolute | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token_staging_expired
   Scenario Outline: Attach command failure on expired token
@@ -399,6 +401,7 @@ Feature: CLI attach command
       | noble    | lxd-container |
       | resolute | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Attach operation on a lxd vm
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/attach.feature
+++ b/features/cli/attach.feature
@@ -36,7 +36,6 @@ Feature: CLI attach command
     Examples: ubuntu release
       | release  | machine_type  | landscape | status_string                                                           |
       | questing | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
-      | stonking | lxd-container | disabled  | landscape +yes +disabled +Management and administration tool for Ubuntu |
 
   Scenario Outline: Attach command with attach config
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/auto_attach.feature
+++ b/features/cli/auto_attach.feature
@@ -35,8 +35,8 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @arm64
   Scenario Outline: Unattached auto-attach does nothing in a ubuntu machine
@@ -69,5 +69,5 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/auto_attach.feature
+++ b/features/cli/auto_attach.feature
@@ -35,6 +35,7 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @arm64
@@ -68,4 +69,5 @@ Feature: CLI auto-attach command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -55,8 +55,8 @@ Feature: CLI collect-logs command
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | questing | lxd-container | with sudo   |
-      | stonking | lxd-container | with sudo   |
       | resolute | lxd-container | with sudo   |
+      | stonking | lxd-container | with sudo   |
 
   @uses.config.contract_token @arm64
   Scenario Outline: Run collect-logs on an attached machine

--- a/features/cli/collect_logs.feature
+++ b/features/cli/collect_logs.feature
@@ -55,6 +55,7 @@ Feature: CLI collect-logs command
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | questing | lxd-container | with sudo   |
+      | stonking | lxd-container | with sudo   |
       | resolute | lxd-container | with sudo   |
 
   @uses.config.contract_token @arm64

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -71,4 +71,5 @@ Feature: CLI config command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cli/config.feature
+++ b/features/cli/config.feature
@@ -71,5 +71,5 @@ Feature: CLI config command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/detach.feature
+++ b/features/cli/detach.feature
@@ -171,5 +171,5 @@ Feature: CLI detach command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/detach.feature
+++ b/features/cli/detach.feature
@@ -171,4 +171,5 @@ Feature: CLI detach command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -510,4 +510,5 @@ Feature: CLI disable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cli/disable.feature
+++ b/features/cli/disable.feature
@@ -510,5 +510,5 @@ Feature: CLI disable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -794,6 +794,7 @@ Feature: CLI enable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Running pro enable --auto

--- a/features/cli/enable.feature
+++ b/features/cli/enable.feature
@@ -794,8 +794,8 @@ Feature: CLI enable command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Running pro enable --auto
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -549,6 +549,7 @@ Feature: Pro Client help text
       | jammy    | lxd-container | options            |
       | noble    | lxd-container | options            |
       | questing | lxd-container | options            |
+      | stonking | lxd-container | options            |
       | resolute | lxd-container | options            |
 
   Scenario Outline: Help command on an attached machine
@@ -598,6 +599,7 @@ Feature: Pro Client help text
       | jammy    | lxd-container | enabled      |
       | noble    | lxd-container | enabled      |
       | questing | lxd-container | n/a          |
+      | stonking | lxd-container | n/a          |
       | resolute | lxd-container | enabled      |
 
   @arm64
@@ -648,4 +650,5 @@ Feature: Pro Client help text
       | jammy    | wsl           | yes             |
       | noble    | lxd-container | yes             |
       | questing | lxd-container | no              |
+      | stonking | lxd-container | no              |
       | resolute | lxd-container | yes             |

--- a/features/cli/help.feature
+++ b/features/cli/help.feature
@@ -85,7 +85,7 @@ Feature: Pro Client help text
       Use pro <command> --help for more information about a command.
       """
     When I run `pro collect-logs --help` as non-root
-    Then if `<release>` not in `resolute` I will see the following on stdout:
+    Then if `<release>` not in `resolute or stonking` I will see the following on stdout:
       """
       usage: pro collect-logs [-h] [-o OUTPUT]
 
@@ -98,7 +98,7 @@ Feature: Pro Client help text
                               tarball where the logs will be stored. (Defaults to
                               ./pro_logs.tar.gz).
       """
-    And if `<release>` in `resolute` I will see the following on stdout:
+    And if `<release>` in `resolute or stonking` I will see the following on stdout:
       """
       usage: pro collect-logs [-h] [-o OUTPUT]
 
@@ -274,12 +274,12 @@ Feature: Pro Client help text
         --format {cli,json}  output in the specified format (default: cli)
       """
     When I run `pro security-status --help` as non-root
-    Then if `<release>` in `resolute` and stdout contains substring:
+    Then if `<release>` in `resolute or stonking` and stdout contains substring:
       """
       usage: pro security-status [-h] [--format {json,yaml,text}] [--thirdparty |
                                  --unavailable | --esm-infra | --esm-apps]
       """
-    And if `<release>` not in `resolute` and stdout contains substring:
+    And if `<release>` not in `resolute or stonking` and stdout contains substring:
       """
       usage: pro security-status [-h] [--format {json,yaml,text}]
                                  [--thirdparty | --unavailable | --esm-infra | --esm-apps]
@@ -549,8 +549,8 @@ Feature: Pro Client help text
       | jammy    | lxd-container | options            |
       | noble    | lxd-container | options            |
       | questing | lxd-container | options            |
-      | stonking | lxd-container | options            |
       | resolute | lxd-container | options            |
+      | stonking | lxd-container | options            |
 
   Scenario Outline: Help command on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -599,8 +599,8 @@ Feature: Pro Client help text
       | jammy    | lxd-container | enabled      |
       | noble    | lxd-container | enabled      |
       | questing | lxd-container | n/a          |
-      | stonking | lxd-container | n/a          |
       | resolute | lxd-container | enabled      |
+      | stonking | lxd-container | n/a          |
 
   @arm64
   Scenario Outline: Help command on an unattached machine
@@ -650,5 +650,5 @@ Feature: Pro Client help text
       | jammy    | wsl           | yes             |
       | noble    | lxd-container | yes             |
       | questing | lxd-container | no              |
-      | stonking | lxd-container | no              |
       | resolute | lxd-container | yes             |
+      | stonking | lxd-container | no              |

--- a/features/cli/refresh.feature
+++ b/features/cli/refresh.feature
@@ -46,6 +46,7 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
@@ -73,4 +74,5 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/cli/refresh.feature
+++ b/features/cli/refresh.feature
@@ -46,8 +46,8 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Unattached commands that requires enabled user in a ubuntu machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -74,5 +74,5 @@ Feature: CLI refresh command
       | jammy    | wsl           |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -1140,7 +1140,7 @@ Feature: CLI security-status command
           pro security-status --help
       for a list of available options\.
 
-      Main/Restricted packages receive updates until 1/2026\.
+      Main/Restricted packages receive updates until <support_until>\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -1151,7 +1151,7 @@ Feature: CLI security-status command
       \d+ packages installed:
        +\d+ packages from Ubuntu Main/Restricted repository
 
-      Main/Restricted packages receive updates until 1/2026\.
+      Main/Restricted packages receive updates until <support_until>\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -1182,7 +1182,7 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 1/2026\.
+      Main/Restricted packages receive updates until <support_until>\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
@@ -1204,15 +1204,15 @@ Feature: CLI security-status command
           sudo apt update
       to get the latest package information from apt\.
 
-      Main/Restricted packages receive updates until 1/2026\.
+      Main/Restricted packages receive updates until <support_until>\.
 
       Ubuntu Pro is not available for non-LTS releases\.
       """
 
     Examples: ubuntu release
-      | release  | machine_type  |
-      | questing | lxd-container |
-      | stonking | lxd-container |
+      | release  | machine_type  | support_until |
+      | questing | lxd-container | 1/2026        |
+      | stonking | lxd-container | 7/2027        |
 
   Scenario Outline: Pass custom APT configuration to the Client for updates information
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/security_status.feature
+++ b/features/cli/security_status.feature
@@ -1212,6 +1212,7 @@ Feature: CLI security-status command
     Examples: ubuntu release
       | release  | machine_type  |
       | questing | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Pass custom APT configuration to the Client for updates information
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -76,8 +76,8 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: Non-root status can see in-progress operations
@@ -695,8 +695,8 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @arm64
   Scenario Outline: Unattached status in a ubuntu machine
@@ -1638,8 +1638,8 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Warn users not to redirect/pipe human readable output
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -1734,5 +1734,5 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/cli/status.feature
+++ b/features/cli/status.feature
@@ -76,6 +76,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token @arm64
@@ -694,6 +695,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @arm64
@@ -1636,6 +1638,7 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Warn users not to redirect/pipe human readable output
@@ -1731,4 +1734,5 @@ Feature: CLI status command
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -16,6 +16,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token @arm64
@@ -295,7 +296,9 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
     Examples: version
       | release  | machine_type  |
       | questing | azure.generic |
+      | stonking | azure.generic |
       | questing | gcp.generic   |
+      | stonking | gcp.generic   |
 
   @uses.config.contract_token
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
@@ -325,6 +328,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | noble    | aws.generic  |
       | questing | aws.generic  |
       | resolute | aws.generic  |
+      | stonking | aws.generic  |
 
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -296,9 +296,7 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
     Examples: version
       | release  | machine_type  |
       | questing | azure.generic |
-      | stonking | azure.generic |
       | questing | gcp.generic   |
-      | stonking | gcp.generic   |
 
   @uses.config.contract_token
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
@@ -328,7 +326,6 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | noble    | aws.generic  |
       | questing | aws.generic  |
       | resolute | aws.generic  |
-      | stonking | aws.generic  |
 
   Scenario Outline: daemon does not start when not on gcpgeneric or azuregeneric
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/daemon.feature
+++ b/features/daemon.feature
@@ -16,8 +16,8 @@ Feature: Pro Upgrade Daemon only runs in environments where necessary
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token @arm64
   Scenario Outline: cloud-id-shim should run in postinst and on boot

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -29,8 +29,8 @@ Feature: Ua fix command behaviour
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Fix command on an unattached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/fix.feature
+++ b/features/fix.feature
@@ -29,6 +29,7 @@ Feature: Ua fix command behaviour
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Fix command on an unattached machine

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -65,6 +65,7 @@ Feature: Pro supports multiple languages
     Examples: ubuntu release
       | release  | machine_type  |
       | questing | lxd-container |
+      | stonking | lxd-container |
 
   # Note: Translations do work on xenial, but our test environment triggers a bug in python that
   # causes it to think we're in an ascii-only environment
@@ -229,6 +230,7 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   @uses.config.contract_token
@@ -288,4 +290,5 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/i18n.feature
+++ b/features/i18n.feature
@@ -230,8 +230,8 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   @uses.config.contract_token
   Scenario Outline: Pro client's commands run successfully in a non-utf8 locale
@@ -290,5 +290,5 @@ Feature: Pro supports multiple languages
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -13,8 +13,8 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu-advantage-tools |
       | noble    | lxd-container | ubuntu-pro-client      |
       | questing | lxd-container | ubuntu-pro-client      |
-      | stonking | lxd-container | ubuntu-pro-client      |
       | resolute | lxd-container | ubuntu-pro-client      |
+      | stonking | lxd-container | ubuntu-pro-client      |
 
   @uses.config.contract_token
   Scenario Outline: Purge package after attaching it to a machine
@@ -159,8 +159,8 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu_advantage |
       | noble    | lxd-container | ubuntu_pro       |
       | questing | lxd-container | ubuntu_pro       |
-      | stonking | lxd-container | ubuntu_pro       |
       | resolute | lxd-container | ubuntu_pro       |
+      | stonking | lxd-container | ubuntu_pro       |
 
   @uses.config.contract_token
   Scenario Outline: Create public machine token on postinst

--- a/features/install_uninstall.feature
+++ b/features/install_uninstall.feature
@@ -13,6 +13,7 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu-advantage-tools |
       | noble    | lxd-container | ubuntu-pro-client      |
       | questing | lxd-container | ubuntu-pro-client      |
+      | stonking | lxd-container | ubuntu-pro-client      |
       | resolute | lxd-container | ubuntu-pro-client      |
 
   @uses.config.contract_token
@@ -158,6 +159,7 @@ Feature: Pro Install and Uninstall related tests
       | jammy    | lxd-container | ubuntu_advantage |
       | noble    | lxd-container | ubuntu_pro       |
       | questing | lxd-container | ubuntu_pro       |
+      | stonking | lxd-container | ubuntu_pro       |
       | resolute | lxd-container | ubuntu_pro       |
 
   @uses.config.contract_token

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -194,9 +194,9 @@ Feature: Livepatch
       """
 
     Examples: ubuntu release
-      | release  | machine_type | pretty_name             |
-      | questing | lxd-vm       | 25.10 (Questing Quokka) |
-      | stonking | lxd-vm       | 25.10 (Questing Quokka) |
+      | release  | machine_type | pretty_name               |
+      | questing | lxd-vm       | 25.10 (Questing Quokka)   |
+      | stonking | lxd-vm       | 26.10 (Stonking Stingray) |
 
   Scenario Outline: Livepatch is supported on interim HWE kernel
     # This test is intended to ensure that an interim HWE kernel has the correct support status

--- a/features/livepatch.feature
+++ b/features/livepatch.feature
@@ -196,6 +196,7 @@ Feature: Livepatch
     Examples: ubuntu release
       | release  | machine_type | pretty_name             |
       | questing | lxd-vm       | 25.10 (Questing Quokka) |
+      | stonking | lxd-vm       | 25.10 (Questing Quokka) |
 
   Scenario Outline: Livepatch is supported on interim HWE kernel
     # This test is intended to ensure that an interim HWE kernel has the correct support status

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -27,6 +27,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | questing | lxd-container | with sudo   |
+      | stonking | lxd-container | with sudo   |
       | resolute | lxd-container | with sudo   |
 
   Scenario Outline: Non-root user and root user log files are different
@@ -61,6 +62,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Non-root user log files included in collect logs
@@ -89,6 +91,7 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: logrotate configuration works
@@ -139,4 +142,5 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |

--- a/features/logs.feature
+++ b/features/logs.feature
@@ -27,8 +27,8 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container | as non-root |
       | noble    | lxd-container | with sudo   |
       | questing | lxd-container | with sudo   |
-      | stonking | lxd-container | with sudo   |
       | resolute | lxd-container | with sudo   |
+      | stonking | lxd-container | with sudo   |
 
   Scenario Outline: Non-root user and root user log files are different
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -62,8 +62,8 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Non-root user log files included in collect logs
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -91,8 +91,8 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: logrotate configuration works
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -142,5 +142,5 @@ Feature: Logs in Json Array Formatter
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -18,6 +18,7 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Run timer script on an attached machine
@@ -96,6 +97,7 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
+      | stonking | lxd-container |
       | resolute | lxd-container |
 
   Scenario Outline: Run timer script to validate machine activity endpoint

--- a/features/timer.feature
+++ b/features/timer.feature
@@ -18,8 +18,8 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Run timer script on an attached machine
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed
@@ -97,8 +97,8 @@ Feature: Timer for regular background jobs while attached
       | jammy    | lxd-container |
       | noble    | lxd-container |
       | questing | lxd-container |
-      | stonking | lxd-container |
       | resolute | lxd-container |
+      | stonking | lxd-container |
 
   Scenario Outline: Run timer script to validate machine activity endpoint
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade.feature
+++ b/features/ubuntu_upgrade.feature
@@ -57,6 +57,7 @@ Feature: Upgrade between releases when uaclient is attached
   # TODO: re-enable once AppArmor profile ubuntu_pro_esm_cache_systemd_detect_virt
   # gains capability perfmon in the resolute archive (archive package installed post-upgrade)
   # | questing | lxd-container | resolute     | normal |               | esm-infra | n/a             | esm-apps | n/a             | true           |
+  # | stonking | lxd-container | resolute     | normal |               | esm-infra | n/a             | esm-apps | n/a             | true           |
   @slow @upgrade
   Scenario Outline: Attached FIPS upgrade across LTS releases
     Given a `<release>` `<machine_type>` machine with ubuntu-advantage-tools installed

--- a/features/ubuntu_upgrade_unattached.feature
+++ b/features/ubuntu_upgrade_unattached.feature
@@ -70,3 +70,4 @@ Feature: Upgrade between releases when uaclient is unattached
       | noble   | lxd-container | resolute     | normal | --devel-release | n/a            |
 
 # | questing | lxd-container | resolute     | normal |               | n/a            |
+# | stonking | lxd-container | resolute     | normal |               | n/a            |


### PR DESCRIPTION
## Why is this needed?

Stonking has limited features (not even Landscape) at the moment, so this just adds basic coverage for anything that will pass without available services.

## Test Steps

Export your token, then run:

```sh
UACLIENT_BEHAVE_INSTALL_FROM=local tox -e behave -- -D releases=stonking
```