### PR TITLE
dev-docs: update LXD docs URLs

### DIFF
--- a/dev-docs/how-to/setup-workshop.md
+++ b/dev-docs/how-to/setup-workshop.md
@@ -6,7 +6,7 @@ sandboxed Ubuntu container with all required tooling pre-installed.
 
 ## Prerequisites
 
-Workshop uses [LXD](https://documentation.ubuntu.com/lxd/default/tutorial/first_steps/) to manage containers. Install it before proceeding:
+Workshop uses [LXD](https://canonical.com/lxd/docs/default/tutorial/first_steps/) to manage containers. Install it before proceeding:
 
 ```bash
 sudo snap install --channel 6/stable lxd

--- a/dev-docs/tutorial/getting-started.md
+++ b/dev-docs/tutorial/getting-started.md
@@ -156,7 +156,7 @@ lxc delete --force test-xenial
 > **Note**
 > Docker can interfere with LXD container networking. If you need Docker
 > installed alongside LXD, follow the guidance in
-> [the LXD documentation](https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker)
+> [the LXD documentation](https://canonical.com/lxd/docs/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker)
 > to ensure that Docker doesn't break LXD networking.
 
 ## Building Ubuntu Pro Client for testing


### PR DESCRIPTION
## Why is this needed?

LXD docs are now at https://canonical.com/lxd/docs/
