### PR TITLE
[Doc] Updating with generic steps taking recent LTS into account.

### DIFF
--- a/docs/howtoguides/create_a_fips_docker_image.rst
+++ b/docs/howtoguides/create_a_fips_docker_image.rst
@@ -71,23 +71,6 @@ First, let's create a directory for this tutorial and navigate there.
     mkdir pro_fips_tutorial
     cd pro_fips_tutorial
 
-.. Now we need to create our config file called ``pro-attach-config.yaml``:
-
-.. .. code-block:: bash
-
-..     touch pro-attach-config.yaml
-
-.. Edit the file, add the following contents, and save it:
-
-.. .. code-block:: yaml
-
-..     token: YOUR_TOKEN
-..     enable_services:
-..     - fips
-
-.. Replace ``YOUR_TOKEN`` with the Ubuntu Pro token we got from the Ubuntu Pro
-.. `dashboard <Pro_>`_ earlier.
-
 Create a Dockerfile
 ===================
 

--- a/docs/howtoguides/create_a_fips_docker_image.rst
+++ b/docs/howtoguides/create_a_fips_docker_image.rst
@@ -71,22 +71,22 @@ First, let's create a directory for this tutorial and navigate there.
     mkdir pro_fips_tutorial
     cd pro_fips_tutorial
 
-Now we need to create our config file called ``pro-attach-config.yaml``:
+.. Now we need to create our config file called ``pro-attach-config.yaml``:
 
-.. code-block:: bash
+.. .. code-block:: bash
 
-    touch pro-attach-config.yaml
+..     touch pro-attach-config.yaml
 
-Edit the file, add the following contents, and save it:
+.. Edit the file, add the following contents, and save it:
 
-.. code-block:: yaml
+.. .. code-block:: yaml
 
-    token: YOUR_TOKEN
-    enable_services:
-    - fips
+..     token: YOUR_TOKEN
+..     enable_services:
+..     - fips
 
-Replace ``YOUR_TOKEN`` with the Ubuntu Pro token we got from the Ubuntu Pro
-`dashboard <Pro_>`_ earlier.
+.. Replace ``YOUR_TOKEN`` with the Ubuntu Pro token we got from the Ubuntu Pro
+.. `dashboard <Pro_>`_ earlier.
 
 Create a Dockerfile
 ===================
@@ -103,24 +103,101 @@ and install the FIPS version of ``openssl``.
 
 Edit the file and add the following contents:
 
-.. code-block:: dockerfile
+.. tab-set::
 
-    FROM ubuntu:focal
+    .. tab-item:: Focal (20.04)
+        
+        .. code-block:: dockerfile
 
-    RUN --mount=type=secret,id=pro-attach-config \
-        apt-get update \
-        && apt-get install --no-install-recommends -y ubuntu-pro-client ca-certificates \
-        && pro attach --attach-config /run/secrets/pro-attach-config \
-        && apt-get upgrade -y \
-        && apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server \
-        && pro detach --assume-yes \
-        && apt-get purge --auto-remove -y ubuntu-pro-client ca-certificates \
-        && rm -rf /var/lib/apt/lists/*
+            FROM ubuntu:focal
 
-.. hint::
+            ENV DEBIAN_FRONTEND=noninteractive
+            ENV OPENSSL_FORCE_FIPS_MODE=0
 
-    For more details on how this works, see our how-to guide on enabling
-    :ref:`Ubuntu Pro Services in a Dockerfile <enable_in_dockerfile>`.
+            # Mount the token file and attach explicitly
+            RUN --mount=type=secret,id=pro-token \
+                apt-get update -y && \
+                apt-get install -y ubuntu-pro-client ca-certificates && \
+                pro attach $(cat /run/secrets/pro-token) --no-auto-enable && \
+                pro enable fips-updates --assume-yes && \
+                apt-get update -y && \
+                apt-get install -y openssl libssl1.1 libssl1.1-hmac libgcrypt20 libgcrypt20-hmac strongswan strongswan-hmac openssh-client openssh-server && \
+                pro detach --assume-yes || true && \
+                apt-get purge -y ubuntu-pro-client && \
+                apt-get autoremove -y && \
+                rm -rf /var/lib/apt/lists/*
+
+            ENV OPENSSL_FORCE_FIPS_MODE=1
+
+            CMD ["/bin/bash"]
+
+    .. tab-item:: Jammy (22.04)
+
+        .. code-block:: dockerfile
+
+            FROM ubuntu:jammy
+
+            ENV DEBIAN_FRONTEND=noninteractive
+            ENV OPENSSL_FORCE_FIPS_MODE=0
+
+            # Mount the token file and attach explicitly
+            RUN --mount=type=secret,id=pro-token \
+                apt-get update -y && \
+                apt-get install -y ubuntu-pro-client ca-certificates && \
+                pro attach $(cat /run/secrets/pro-token) --no-auto-enable && \
+                pro enable fips-updates --assume-yes && \
+                apt-get update -y && \
+                apt-get install -y openssl openssl-fips-module-3 libgcrypt20 strongswan openssh-client libgnutls30 && \
+                pro detach --assume-yes || true && \
+                apt-get purge -y ubuntu-pro-client && \
+                apt-get autoremove -y && \
+                rm -rf /var/lib/apt/lists/*
+
+            ENV OPENSSL_FORCE_FIPS_MODE=1
+
+            CMD ["/bin/bash"]
+
+    .. tab-item:: Noble (24.04)
+
+        .. code-block:: dockerfile
+
+            FROM ubuntu:noble
+
+            ENV DEBIAN_FRONTEND=noninteractive
+            ENV OPENSSL_FORCE_FIPS_MODE=0
+
+            # Mount the token file and attach explicitly
+            RUN --mount=type=secret,id=pro-token \
+                apt-get update -y && \
+                apt-get install -y ubuntu-pro-client ca-certificates && \
+                pro attach $(cat /run/secrets/pro-token) --no-auto-enable && \
+                pro enable fips-updates --assume-yes && \
+                apt-get update -y && \
+                apt-get install -y openssl openssl-fips-module-3 libgcrypt20 strongswan openssh-client libgnutls30t64 && \
+                pro detach --assume-yes || true && \
+                apt-get purge -y ubuntu-pro-client && \
+                apt-get autoremove -y && \
+                rm -rf /var/lib/apt/lists/*
+
+            ENV OPENSSL_FORCE_FIPS_MODE=1
+
+            CMD ["/bin/bash"]
+
+
+Create a short-lived token and store it in a file:
+======================================================
+.. code-block:: bash
+
+    sudo pro api u.pro.attach.guest.get_guest_token.v1 | jq -r '.data.attributes.guest_token' > pro-token.txt
+
+.. note::
+
+    The token is short-lived and will expire after a few minutes. If you are
+    unable to build the Docker image in that time, you will need to create a
+    new token.
+
+Alternatively, we can use the permanent Ubuntu Pro token in the 
+``pro-token.txt`` file if the host is not attached to Pro. This is however not recommended.
 
 Build the Docker image
 ======================
@@ -129,11 +206,17 @@ Now let's build the docker image by running the following command:
 
 .. code-block:: bash
 
-    DOCKER_BUILDKIT=1 docker build . --secret id=pro-attach-config,src=pro-attach-config.yaml -t ubuntu-focal-fips
+    DOCKER_BUILDKIT=1 docker build . --secret id=pro-token,src=pro-token.txt -t <image-name>
 
-This will pass the ``pro-attach-config.yaml`` file we created earlier as a
+This will pass the ``pro-token.txt`` file we created earlier as a
 `BuildKit Secret`_ so that the finished Docker image will not contain your
 Ubuntu Pro token.
+
+Optionally, delete the ``pro-token.txt`` file after the build is complete:
+
+.. code-block:: bash
+
+    rm pro-token.txt
 
 Test the Docker image
 =====================
@@ -148,7 +231,8 @@ container. First, let us run:
 
 .. code-block:: bash
 
-    docker run -it ubuntu-focal-fips dpkg-query --show openssl
+    docker image list
+    docker run -it --rm <image-name> dpkg-query --show openssl
 
 This should show something like: ``openssl	1.1.1f-1ubuntu2.fips.2.8`` (notice
 "fips" in the version name).
@@ -158,7 +242,7 @@ to ``https://ubuntu.com``:
 
 .. code-block:: bash
 
-    docker run -it ubuntu-focal-fips sh -c "echo | openssl s_client -connect ubuntu.com:443"
+    docker run -it --rm <image-name> sh -c "echo | openssl s_client -connect ubuntu.com:443"
 
 This should print information about the certificates of ubuntu.com and the
 algorithms used during the TLS handshake.


### PR DESCRIPTION
## Why is this needed?
<!-- This information should be captured in your commit messages, so any description here can be very brief -->
The documentation was very specific to building images in Focal. Some of those stages in the Dockerfile work on Jammy but not on Noble. 

This PR will make the steps more generic taking recent LTS into account. Some of the changes from the original Dockerfile:
 - Retain ca-certificates in the image because its a crucial package. 
 - Avoid using Ubuntu Pro tokens, instead default approach is by using short-lived tokens --> more secure.
 - A simple txt file without keys instead of yaml format to mount secret. 
 - Service enablement happens within the Dockerfile instead via yaml seed since the name are different for different series. This reduces unnecessary steps.
 - Focal uses `fips-updates` instead of `fips` to get latest available packages. I think that very crucial for images and places where security is involved. 
 
<!-- By default, we rebase PRs and will ask for a clean well-organized commit history in the PR before rebasing. If your PR is small enough and you prefer, you can write a suggested commit message here and request a squashed PR. -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if this is a bug fix) this change on a live deployed system, including any necessary configuration files, user-data, setup, and teardown. Scripts used may be attached directly to this PR. -->

<!-- Example:
```
env SHELL_BEFORE=1 ./tools/test-in-lxd.sh xenial
# Set up test scenario before upgrade
exit # new version gets installed after exit and lxc shell is re-started
sudo pro new-sub-command --new-flag
# Assert something
```
-->

The test steps are exactly how its in the docs. 
For quick testing, create 3 VMs (focal,jammy,noble), enable FIPS and  follow the exact steps mentioned in the docs. 

Issue ref: #3474 